### PR TITLE
docs: add UX gap items to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,10 @@
 - Need a way to amend pending message (including deleting it) by pressing 'up'
 - Improve stats table (could render using markdown renderer?)
 - Show session name as well as agent name
+- Session browser — navigate and restore previous conversations (not just recent history on startup)
+- Persistent model switching — persist `/model` selection across restarts per agent
+- Completion notification — terminal bell (or optional system notification) when a long response finishes while the window is unfocused
+- Skill discovery — `/skills search <term>` to browse and install skills from the ClawHub registry without leaving the TUI
 
 ## Bugs
 


### PR DESCRIPTION
Adds four feature suggestions to the roadmap based on a competitive analysis of the OpenClaw TUI space.

## Changes

- **Session browser** — navigate and restore previous conversations, not just the recent history loaded on startup
- **Persistent model switching** — persist `/model` selection per agent across restarts (currently resets each session)
- **Completion notification** — terminal bell or optional system notification when a long response finishes while the window is unfocused
- **Skill discovery** — `/skills search <term>` to browse and install skills from the ClawHub registry without leaving the TUI

These were identified as gaps relative to adjacent tools (cc-switch's session browser, general terminal UX expectations) where repclaw has room to differentiate further as the canonical terminal-first OpenClaw client.