### PR TITLE
fix: prevent /skills output from being sent to the model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,4 +22,4 @@
 - ~~shift+enter for new line doesn't work~~ (shift+enter or alt+enter)
 - Long user messages seem to be truncated
 - Timestamps appearing at the start of user messages in message history
-- When triggering the `/skills` command don't send the output as a user message to the model
+- ~~When triggering the `/skills` command don't send the output as a user message to the model~~

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -21,21 +21,20 @@ const inputHeight = 3
 
 // chatModel is the chat view.
 type chatModel struct {
-	viewport         viewport.Model
-	textarea         textarea.Model
-	messages         []chatMessage
-	client           *client.Client
-	sessionKey       string
-	agentName        string
-	sending          bool
-	pendingMessages  []string
-	width            int
-	height           int
-	renderer         *glamour.TermRenderer
-	stats            *sessionStats
-	modelID          string
-	skills           []agentSkill
-	skillCatalogSent bool
+	viewport        viewport.Model
+	textarea        textarea.Model
+	messages        []chatMessage
+	client          *client.Client
+	sessionKey      string
+	agentName       string
+	sending         bool
+	pendingMessages []string
+	width           int
+	height          int
+	renderer        *glamour.TermRenderer
+	stats           *sessionStats
+	modelID         string
+	skills          []agentSkill
 }
 
 func newChatModel(c *client.Client, sessionKey, agentName, modelID string) chatModel {
@@ -239,7 +238,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			m.messages = append(m.messages, chatMessage{role: "user", content: text})
 			m.sending = true
 			m.updateViewport()
-			cmds = append(cmds, m.sendMessage(m.withSkillCatalog(text)))
+			cmds = append(cmds, m.sendMessage(text))
 			return m, tea.Batch(cmds...)
 		}
 
@@ -310,17 +309,6 @@ func (m *chatModel) sendMessage(text string) tea.Cmd {
 		_, err := m.client.ChatSend(context.Background(), sessionKey, text, idemKey)
 		return chatSentMsg{err: err}
 	}
-}
-
-// withSkillCatalog prepends the skill catalog to the message text on the first
-// send. The catalog uses "System:" prefixed lines which stripSystemLines removes
-// from display in history.
-func (m *chatModel) withSkillCatalog(text string) string {
-	if m.skillCatalogSent || len(m.skills) == 0 {
-		return text
-	}
-	m.skillCatalogSent = true
-	return skillCatalogBlock(m.skills) + "\n" + text
 }
 
 // drainQueue sends the next queued message if any are pending.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -78,6 +78,9 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		m.updateViewport()
 		return true, nil
 	case "/skills":
+		// Local-only: the skill listing is rendered in the TUI and must never
+		// be sent to the gateway as a user message. Always role="system" and
+		// return a nil cmd so no network call is scheduled.
 		if len(m.skills) == 0 {
 			m.messages = append(m.messages, chatMessage{role: "system", content: "No agent skills found.\nPlace skills in <cwd>/.agents/skills/<name>/SKILL.md or ~/.agents/skills/<name>/SKILL.md"})
 		} else {

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -126,19 +126,3 @@ func prefixAllLines(text string) string {
 	}
 	return strings.Join(lines, "\n")
 }
-
-// skillCatalogBlock returns a System: prefixed block listing available skills.
-// This is prepended to the first user message so the agent knows what's available.
-// Every line is prefixed with "System:" so that stripSystemLines removes the
-// entire block from display after a history refresh.
-func skillCatalogBlock(skills []agentSkill) string {
-	if len(skills) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("Available agent skills (activate with /skill-name):\n")
-	for _, s := range skills {
-		b.WriteString(fmt.Sprintf("  - %s: %s\n", s.Name, s.Description))
-	}
-	return prefixAllLines(b.String())
-}

--- a/internal/tui/skills_test.go
+++ b/internal/tui/skills_test.go
@@ -48,29 +48,6 @@ func TestParseSkillFile_UnclosedFrontmatter(t *testing.T) {
 	}
 }
 
-func TestSkillCatalogBlock(t *testing.T) {
-	skills := []agentSkill{
-		{Name: "review", Description: "Code review"},
-		{Name: "test", Description: "Write tests"},
-	}
-	block := skillCatalogBlock(skills)
-	if block == "" {
-		t.Fatal("expected non-empty catalog block")
-	}
-	if !contains(block, "review") || !contains(block, "test") {
-		t.Error("catalog block should contain skill names")
-	}
-	if !contains(block, "System:") {
-		t.Error("catalog block should have System: prefix")
-	}
-}
-
-func TestSkillCatalogBlock_Empty(t *testing.T) {
-	if block := skillCatalogBlock(nil); block != "" {
-		t.Errorf("expected empty block for no skills, got %q", block)
-	}
-}
-
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }
@@ -158,39 +135,6 @@ func TestSkillActivation(t *testing.T) {
 	}
 }
 
-func TestWithSkillCatalog(t *testing.T) {
-	m := newSlashTestModel()
-	m.skills = []agentSkill{
-		{Name: "review", Description: "Code review"},
-	}
-
-	// First call should prepend catalog.
-	result := m.withSkillCatalog("hello")
-	if !contains(result, "System:") {
-		t.Error("first message should contain skill catalog")
-	}
-	if !contains(result, "hello") {
-		t.Error("first message should contain original text")
-	}
-
-	// Second call should not prepend.
-	result2 := m.withSkillCatalog("world")
-	if contains(result2, "System:") {
-		t.Error("second message should not contain skill catalog")
-	}
-	if result2 != "world" {
-		t.Errorf("second message = %q, want %q", result2, "world")
-	}
-}
-
-func TestWithSkillCatalog_NoSkills(t *testing.T) {
-	m := newSlashTestModel()
-	result := m.withSkillCatalog("hello")
-	if result != "hello" {
-		t.Errorf("expected unmodified text with no skills, got %q", result)
-	}
-}
-
 func TestSkillsDiscoveredMsg_AddsMessage(t *testing.T) {
 	m := newSlashTestModel()
 	initialCount := len(m.messages)
@@ -238,13 +182,21 @@ func TestSkillsListCommand(t *testing.T) {
 	if !handled {
 		t.Fatal("expected /skills to be handled")
 	}
+	// /skills output is local-only — it must never return a cmd that would
+	// send it to the gateway.
 	if cmd != nil {
-		t.Error("expected nil cmd from /skills")
+		t.Error("expected nil cmd from /skills (output must stay local)")
+	}
+	if m.sending {
+		t.Error("/skills must not flip sending=true (no network activity)")
 	}
 	if len(m.messages) != initialCount+1 {
 		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
 	}
 	msg := m.messages[len(m.messages)-1]
+	if msg.role != "system" {
+		t.Errorf("skills list role = %q, want system (user role would send to model)", msg.role)
+	}
 	if !contains(msg.content, "/review") || !contains(msg.content, "/test") {
 		t.Errorf("skills list should contain skill names, got %q", msg.content)
 	}
@@ -254,11 +206,17 @@ func TestSkillsListCommand_Empty(t *testing.T) {
 	m := newSlashTestModel()
 	initialCount := len(m.messages)
 
-	handled, _ := m.handleSlashCommand("/skills")
+	handled, cmd := m.handleSlashCommand("/skills")
 	if !handled {
 		t.Fatal("expected /skills to be handled")
 	}
+	if cmd != nil {
+		t.Error("expected nil cmd from /skills (output must stay local)")
+	}
 	msg := m.messages[len(m.messages)-1]
+	if msg.role != "system" {
+		t.Errorf("empty-skills message role = %q, want system", msg.role)
+	}
 	if !contains(msg.content, "No agent skills found") {
 		t.Errorf("expected empty skills message, got %q", msg.content)
 	}


### PR DESCRIPTION
Fixes a bug where invoking \`/skills\` would send its output as a user message to the agent, triggering an unwanted model turn.

## Summary

- Remove \`withSkillCatalog\` wrapper from the message send path — skill context was being injected into user messages, causing the skills listing to be forwarded to the model
- Remove the now-unused \`skillCatalogSent\` tracking field from \`chatModel\`
- Mark the roadmap item as resolved