### PR TITLE
feat: recall and edit queued messages with up-arrow

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -201,6 +201,20 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				}
 			}
 			return m, nil
+		case "up":
+			// Recall the most recent queued message into the input for editing
+			// or deletion. Only when the input is empty, so multi-line cursor
+			// movement is preserved.
+			if m.textarea.Value() == "" && len(m.pendingMessages) > 0 {
+				last := len(m.pendingMessages) - 1
+				text := m.pendingMessages[last]
+				m.pendingMessages = m.pendingMessages[:last]
+				m.textarea.Reset()
+				m.textarea.SetValue(text)
+				m.textarea.CursorEnd()
+				m.updateViewport()
+				return m, nil
+			}
 		case "enter":
 			text := strings.TrimSpace(m.textarea.Value())
 			if text == "" {
@@ -441,7 +455,7 @@ func (m chatModel) View() string {
 		} else {
 			helpText := " enter: send | shift/alt+enter: newline | /help: commands"
 			if n := len(m.pendingMessages); n > 0 {
-				helpText += fmt.Sprintf(" | %d queued", n)
+				helpText += fmt.Sprintf(" | %d queued (up: edit last)", n)
 			}
 			help = helpStyle.Render(helpText)
 		}

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -42,5 +43,59 @@ func TestNewChatModel_InsertNewlineBinding(t *testing.T) {
 	shiftEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}
 	if !key.Matches(shiftEnter, m.textarea.KeyMap.InsertNewline) {
 		t.Errorf("shift+enter should match InsertNewline, got string=%q", shiftEnter.String())
+	}
+}
+
+func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.pendingMessages = []string{"first", "second", "third"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if got, want := m.textarea.Value(), "third"; got != want {
+		t.Errorf("textarea value: got %q, want %q", got, want)
+	}
+	if got, want := len(m.pendingMessages), 2; got != want {
+		t.Fatalf("pendingMessages length: got %d, want %d", got, want)
+	}
+	if m.pendingMessages[0] != "first" || m.pendingMessages[1] != "second" {
+		t.Errorf("remaining pending: got %v, want [first second]", m.pendingMessages)
+	}
+}
+
+func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if got := m.textarea.Value(); got != "" {
+		t.Errorf("textarea should remain empty, got %q", got)
+	}
+}
+
+func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.textarea.SetValue("in progress")
+	m.pendingMessages = []string{"queued"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if got, want := m.textarea.Value(), "in progress"; got != want {
+		t.Errorf("textarea value: got %q, want %q", got, want)
+	}
+	if len(m.pendingMessages) != 1 || m.pendingMessages[0] != "queued" {
+		t.Errorf("pendingMessages should be untouched, got %v", m.pendingMessages)
 	}
 }

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/key"
@@ -97,5 +98,114 @@ func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
 	}
 	if len(m.pendingMessages) != 1 || m.pendingMessages[0] != "queued" {
 		t.Errorf("pendingMessages should be untouched, got %v", m.pendingMessages)
+	}
+}
+
+func TestUpKey_RecallingOnlyMessageEmptiesQueue(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.pendingMessages = []string{"solo"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if got, want := m.textarea.Value(), "solo"; got != want {
+		t.Errorf("textarea value: got %q, want %q", got, want)
+	}
+	if len(m.pendingMessages) != 0 {
+		t.Errorf("pendingMessages should be empty, got %v", m.pendingMessages)
+	}
+}
+
+func TestUpKey_SuccessiveRecallsPopInLIFOOrder(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.pendingMessages = []string{"a", "b", "c"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "c"; got != want {
+		t.Fatalf("first recall: got %q, want %q", got, want)
+	}
+
+	// Clearing the textarea lets the next up press recall again.
+	m.textarea.Reset()
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "b"; got != want {
+		t.Fatalf("second recall: got %q, want %q", got, want)
+	}
+
+	m.textarea.Reset()
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "a"; got != want {
+		t.Fatalf("third recall: got %q, want %q", got, want)
+	}
+
+	if len(m.pendingMessages) != 0 {
+		t.Errorf("expected empty queue after three recalls, got %v", m.pendingMessages)
+	}
+}
+
+func TestUpKey_RecallThenClearDiscardsMessage(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.pendingMessages = []string{"keep", "discard"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	// User decides to delete the recalled message by clearing the input and
+	// not pressing enter. The queued message should stay gone.
+	m.textarea.Reset()
+
+	if len(m.pendingMessages) != 1 || m.pendingMessages[0] != "keep" {
+		t.Errorf("pendingMessages: got %v, want [keep]", m.pendingMessages)
+	}
+}
+
+func TestUpKey_RecallEditAndRequeueWhileSending(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.sending = true
+	m.pendingMessages = []string{"original"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "original"; got != want {
+		t.Fatalf("recall: got %q, want %q", got, want)
+	}
+
+	// Edit the recalled text and press enter while the agent is still
+	// responding — it should re-queue with the new contents.
+	m.textarea.SetValue("edited")
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	m, _ = m.Update(enter)
+
+	if len(m.pendingMessages) != 1 || m.pendingMessages[0] != "edited" {
+		t.Errorf("pendingMessages: got %v, want [edited]", m.pendingMessages)
+	}
+	if got := m.textarea.Value(); got != "" {
+		t.Errorf("textarea should be reset after enter, got %q", got)
+	}
+}
+
+func TestView_HelpShowsUpHintWhenQueued(t *testing.T) {
+	m := newChatModel(nil, "main", "test", "")
+	m.viewport = viewport.New()
+	m.setSize(80, 30)
+	m.pendingMessages = []string{"one", "two"}
+
+	view := m.View()
+	if !strings.Contains(view, "2 queued (up: edit last)") {
+		t.Errorf("expected help text to advertise up-arrow recall, got:\n%s", view)
 	}
 }


### PR DESCRIPTION
Adds up-arrow support to pop the most recent queued message back into the input for editing or deletion.

## Summary

- Pressing \`↑\` when the input is empty and messages are queued recalls the last pending message into the textarea, removing it from the queue
- Cursor is placed at the end of the recalled text so editing can begin immediately
- Help bar updates to hint \`(up: edit last)\` when messages are queued
- Only triggers when the input is empty, preserving normal cursor-up behaviour in multi-line input