### PR TITLE
feat: animate streaming response placeholder with braille spinner

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@
 - Need a way to amend pending message (including deleting it) by pressing 'up'
 - Improve stats table (could render using markdown renderer?)
 - Show session name as well as agent name
-- Replace static `_` placeholder when awaiting final response message with simple character animation
+- ~~Replace static `_` placeholder when awaiting final response message with simple character animation~~
 - Session browser — navigate and restore previous conversations (not just recent history on startup)
 - Persistent model switching — persist `/model` selection across restarts per agent
 - Completion notification — terminal bell (or optional system notification) when a long response finishes while the window is unfocused

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -19,6 +19,12 @@ import (
 
 const inputHeight = 3
 
+// spinnerFrames cycles the streaming-response placeholder through a braille
+// spinner. Each frame is a single display cell so line wrapping is unaffected.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+const spinnerInterval = 120 * time.Millisecond
+
 // chatModel is the chat view.
 type chatModel struct {
 	viewport         viewport.Model
@@ -36,6 +42,33 @@ type chatModel struct {
 	modelID          string
 	skills           []agentSkill
 	skillCatalogSent bool
+	spinnerFrame     int
+	spinnerTicking   bool
+}
+
+func spinnerTickCmd() tea.Cmd {
+	return tea.Tick(spinnerInterval, func(time.Time) tea.Msg {
+		return spinnerTickMsg{}
+	})
+}
+
+// hasStreamingMessage reports whether any assistant message is still streaming.
+func (m *chatModel) hasStreamingMessage() bool {
+	for i := range m.messages {
+		if m.messages[i].streaming {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureSpinnerTicking starts the spinner animation if one is not already scheduled.
+func (m *chatModel) ensureSpinnerTicking() tea.Cmd {
+	if m.spinnerTicking {
+		return nil
+	}
+	m.spinnerTicking = true
+	return spinnerTickCmd()
 }
 
 func newChatModel(c *client.Client, sessionKey, agentName, modelID string) chatModel {
@@ -275,6 +308,15 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		ev := protocol.Event(msg)
 		cmd := m.handleEvent(ev)
 		return m, cmd
+
+	case spinnerTickMsg:
+		if !m.hasStreamingMessage() {
+			m.spinnerTicking = false
+			return m, nil
+		}
+		m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
+		m.updateViewport()
+		return m, spinnerTickCmd()
 	}
 
 	// Update sub-components.

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -164,6 +164,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			streaming: true,
 		})
 		m.updateViewport()
+		return m.ensureSpinnerTicking()
 
 	case "final":
 		logEvent("  FINAL msgContent=%s", string(chatEv.Message))

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -92,3 +92,6 @@ type sessionCreatedMsg struct {
 type skillsDiscoveredMsg struct {
 	skills []agentSkill
 }
+
+// spinnerTickMsg advances the streaming-response placeholder animation.
+type spinnerTickMsg struct{}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -40,7 +40,7 @@ func (m *chatModel) updateViewport() {
 			} else if msg.streaming {
 				body := wordWrap(msg.content, wrapWidth)
 				b.WriteString(indentMultiline(body, prefixIndent))
-				b.WriteString(cursorStyle.Render("_"))
+				b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
 			} else if msg.rendered {
 				// Glamour-rendered content is already wrapped and contains ANSI codes.
 				b.WriteString(indentMultiline(msg.content, prefixIndent))

--- a/internal/tui/spinner_test.go
+++ b/internal/tui/spinner_test.go
@@ -1,0 +1,203 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestHasStreamingMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []chatMessage
+		want     bool
+	}{
+		{"empty", nil, false},
+		{"no streaming", []chatMessage{
+			{role: "user", content: "hi"},
+			{role: "assistant", content: "done", streaming: false},
+		}, false},
+		{"streaming assistant", []chatMessage{
+			{role: "user", content: "hi"},
+			{role: "assistant", content: "…", streaming: true},
+		}, true},
+		{"streaming in middle", []chatMessage{
+			{role: "assistant", content: "a", streaming: true},
+			{role: "assistant", content: "b", streaming: false},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestChatModel()
+			m.messages = tt.messages
+			if got := m.hasStreamingMessage(); got != tt.want {
+				t.Errorf("hasStreamingMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureSpinnerTicking_StartsOnFirstCall(t *testing.T) {
+	m := newTestChatModel()
+
+	cmd := m.ensureSpinnerTicking()
+
+	if cmd == nil {
+		t.Fatal("expected non-nil tick cmd on first call")
+	}
+	if !m.spinnerTicking {
+		t.Error("expected spinnerTicking = true after first call")
+	}
+}
+
+func TestEnsureSpinnerTicking_NoOpWhenAlreadyTicking(t *testing.T) {
+	m := newTestChatModel()
+	m.spinnerTicking = true
+
+	cmd := m.ensureSpinnerTicking()
+
+	if cmd != nil {
+		t.Error("expected nil cmd when a tick is already scheduled")
+	}
+	if !m.spinnerTicking {
+		t.Error("spinnerTicking should remain true")
+	}
+}
+
+func TestHandleEvent_DeltaStartsSpinner(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{{role: "user", content: "hello"}}
+
+	cmd := m.handleEvent(makeChatEvent("delta", "run1", 1, json.RawMessage(`"First"`)))
+
+	if cmd == nil {
+		t.Fatal("expected spinner tick cmd when new streaming assistant message is created")
+	}
+	if !m.spinnerTicking {
+		t.Error("expected spinnerTicking = true after first delta")
+	}
+}
+
+func TestHandleEvent_DeltaDoesNotRestartSpinnerForExistingStream(t *testing.T) {
+	m := newTestChatModel()
+	m.spinnerTicking = true
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "par", streaming: true},
+	}
+
+	cmd := m.handleEvent(makeChatEvent("delta", "run1", 2, json.RawMessage(`"partial"`)))
+
+	if cmd != nil {
+		t.Error("expected nil cmd for subsequent delta on an existing streaming message")
+	}
+	if !m.spinnerTicking {
+		t.Error("spinnerTicking should remain true while the existing tick chain runs")
+	}
+}
+
+func TestUpdate_SpinnerTickAdvancesFrameWhileStreaming(t *testing.T) {
+	m := *newTestChatModel()
+	m.spinnerTicking = true
+	m.messages = []chatMessage{
+		{role: "assistant", content: "working", streaming: true},
+	}
+	startFrame := m.spinnerFrame
+
+	updated, cmd := m.Update(spinnerTickMsg{})
+
+	if cmd == nil {
+		t.Error("expected next tick cmd while streaming")
+	}
+	if updated.spinnerFrame != (startFrame+1)%len(spinnerFrames) {
+		t.Errorf("spinnerFrame = %d, want %d", updated.spinnerFrame, (startFrame+1)%len(spinnerFrames))
+	}
+	if !updated.spinnerTicking {
+		t.Error("spinnerTicking should remain true while streaming")
+	}
+}
+
+func TestUpdate_SpinnerTickWrapsAroundFrameIndex(t *testing.T) {
+	m := *newTestChatModel()
+	m.spinnerTicking = true
+	m.spinnerFrame = len(spinnerFrames) - 1
+	m.messages = []chatMessage{
+		{role: "assistant", content: "x", streaming: true},
+	}
+
+	updated, _ := m.Update(spinnerTickMsg{})
+
+	if updated.spinnerFrame != 0 {
+		t.Errorf("expected frame to wrap to 0, got %d", updated.spinnerFrame)
+	}
+}
+
+func TestUpdate_SpinnerTickStopsWhenNoStreamingMessage(t *testing.T) {
+	m := *newTestChatModel()
+	m.spinnerTicking = true
+	m.messages = []chatMessage{
+		{role: "user", content: "hi"},
+		{role: "assistant", content: "done", streaming: false},
+	}
+
+	updated, cmd := m.Update(spinnerTickMsg{})
+
+	if cmd != nil {
+		t.Error("expected nil cmd once no message is streaming")
+	}
+	if updated.spinnerTicking {
+		t.Error("expected spinnerTicking = false after tick sees no streaming messages")
+	}
+}
+
+func TestUpdateViewport_RendersCurrentSpinnerFrame(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(40)
+	vp.SetHeight(10)
+	m := &chatModel{
+		viewport:  vp,
+		width:     40,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "assistant", content: "hi", streaming: true},
+		},
+		spinnerFrame: 3,
+	}
+
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+
+	want := spinnerFrames[3]
+	if !strings.Contains(view, want) {
+		t.Errorf("expected viewport to contain frame %q, view was:\n%s", want, view)
+	}
+	// Sanity: the old static underscore placeholder should be gone.
+	if strings.Contains(view, "hi_") {
+		t.Errorf("viewport should no longer render the legacy underscore placeholder:\n%s", view)
+	}
+}
+
+func TestUpdateViewport_SpinnerNotRenderedForFinalisedMessage(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(40)
+	vp.SetHeight(10)
+	m := &chatModel{
+		viewport:  vp,
+		width:     40,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "assistant", content: "hi", streaming: false},
+		},
+		spinnerFrame: 3,
+	}
+
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+
+	if strings.Contains(view, spinnerFrames[3]) {
+		t.Errorf("spinner should not appear on finalised message, view was:\n%s", view)
+	}
+}


### PR DESCRIPTION
Replaces the static \`_\` placeholder shown during a streaming response with a braille spinner that ticks at 120ms intervals.

## Summary

- Add \`spinnerFrames\` (braille dot sequence) and \`spinnerInterval\` (120ms) constants
- Spinner starts when a streaming assistant message appears and stops when it finalises
- Each frame is a single display cell, so line wrapping and layout are unaffected
- \`ensureSpinnerTicking\` guards against scheduling duplicate tick commands
- Mark the roadmap item as resolved