### PR TITLE
feat: add /agents as alias for /back to return to agent picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Type these in the chat input. Tab autocompletes partial commands.
 | `/model <name>` | Switch model (fuzzy match) |
 | `/stats` | Show token usage and cost breakdown |
 | `/clear` | Clear chat display |
-| `/agents`, `/back` | Return to agent picker |
+| `/agents` | Return to agent picker |
 | `/quit` | Quit repclaw |
 
 ## Remote commands

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Type these in the chat input. Tab autocompletes partial commands.
 | `/model <name>` | Switch model (fuzzy match) |
 | `/stats` | Show token usage and cost breakdown |
 | `/clear` | Clear chat display |
-| `/back` | Return to agent list |
+| `/agents`, `/back` | Return to agent picker |
 | `/quit` | Quit repclaw |
 
 ## Remote commands

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -10,7 +10,7 @@ import (
 )
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/back", "/clear", "/exit", "/help", "/model", "/quit", "/skills", "/stats"}
+var slashCommands = []string{"/agents", "/back", "/clear", "/exit", "/help", "/model", "/quit", "/skills", "/stats"}
 
 // completeSlashCommand returns the first matching slash command for the given
 // prefix, or "" if no match. Includes skill names as slash commands.
@@ -51,14 +51,14 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	switch command {
 	case "/quit", "/exit":
 		return true, tea.Quit
-	case "/back":
+	case "/back", "/agents":
 		return true, func() tea.Msg { return goBackMsg{} }
 	case "/clear":
 		m.messages = nil
 		m.updateViewport()
 		return true, nil
 	case "/help":
-		helpText := "/quit, /exit — quit repclaw\n/back — return to agent list\n/clear — clear chat display\n/model — list available models\n/model <name> — switch model\n/stats — show session statistics\n/skills — list available agent skills\n/help — show this help\n\n!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit repclaw\n/agents, /back — return to agent picker\n/clear — clear chat display\n/model — list available models\n/model <name> — switch model\n/stats — show session statistics\n/skills — list available agent skills\n/help — show this help\n\n!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -10,7 +10,7 @@ import (
 )
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/agents", "/back", "/clear", "/exit", "/help", "/model", "/quit", "/skills", "/stats"}
+var slashCommands = []string{"/agents", "/clear", "/exit", "/help", "/model", "/quit", "/skills", "/stats"}
 
 // completeSlashCommand returns the first matching slash command for the given
 // prefix, or "" if no match. Includes skill names as slash commands.
@@ -51,14 +51,14 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	switch command {
 	case "/quit", "/exit":
 		return true, tea.Quit
-	case "/back", "/agents":
+	case "/agents":
 		return true, func() tea.Msg { return goBackMsg{} }
 	case "/clear":
 		m.messages = nil
 		m.updateViewport()
 		return true, nil
 	case "/help":
-		helpText := "/quit, /exit — quit repclaw\n/agents, /back — return to agent picker\n/clear — clear chat display\n/model — list available models\n/model <name> — switch model\n/stats — show session statistics\n/skills — list available agent skills\n/help — show this help\n\n!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit repclaw\n/agents — return to agent picker\n/clear — clear chat display\n/model — list available models\n/model <name> — switch model\n/stats — show session statistics\n/skills — list available agent skills\n/help — show this help\n\n!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/viewport"
@@ -100,8 +101,166 @@ func TestSlashCommand_Help(t *testing.T) {
 	if len(m.messages) != initialCount+1 {
 		t.Errorf("expected %d messages after /help, got %d", initialCount+1, len(m.messages))
 	}
-	if m.messages[len(m.messages)-1].role != "system" {
-		t.Errorf("help message role = %q, want system", m.messages[len(m.messages)-1].role)
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" {
+		t.Errorf("help message role = %q, want system", last.role)
+	}
+
+	// Every advertised command should appear in the help text.
+	for _, want := range []string{"/quit", "/exit", "/agents", "/back", "/clear", "/model", "/stats", "/skills", "/help"} {
+		if !strings.Contains(last.content, want) {
+			t.Errorf("/help text missing %q\ngot: %s", want, last.content)
+		}
+	}
+}
+
+func TestSlashCommand_Help_MentionsSkillsWhenLoaded(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{{Name: "greet", Description: "say hi", Body: "hello"}}
+
+	m.handleSlashCommand("/help")
+	last := m.messages[len(m.messages)-1]
+	if !strings.Contains(last.content, "1 agent skill") {
+		t.Errorf("expected help to mention skill count, got: %s", last.content)
+	}
+}
+
+func TestSlashCommand_Stats_NotLoaded(t *testing.T) {
+	m := newSlashTestModel()
+	initialCount := len(m.messages)
+
+	handled, cmd := m.handleSlashCommand("/stats")
+	if !handled {
+		t.Fatal("expected /stats to be handled")
+	}
+	if cmd == nil {
+		t.Error("expected a loadStats cmd when stats are nil")
+	}
+	if len(m.messages) != initialCount+1 {
+		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || !strings.Contains(last.content, "not yet loaded") {
+		t.Errorf("unexpected system message: %+v", last)
+	}
+}
+
+func TestSlashCommand_Stats_Loaded(t *testing.T) {
+	m := newSlashTestModel()
+	m.stats = &sessionStats{
+		inputTokens:       100,
+		outputTokens:      200,
+		totalCost:         0.42,
+		totalMessages:     3,
+		userMessages:      2,
+		assistantMessages: 1,
+	}
+
+	handled, cmd := m.handleSlashCommand("/stats")
+	if !handled {
+		t.Fatal("expected /stats to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd when stats already loaded")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" {
+		t.Errorf("expected system role, got %q", last.role)
+	}
+	if !strings.Contains(last.content, "Input") || !strings.Contains(last.content, "Total") {
+		t.Errorf("expected stats table in message, got: %s", last.content)
+	}
+}
+
+func TestSlashCommand_Skills_Empty(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/skills")
+	if !handled {
+		t.Fatal("expected /skills to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from /skills")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || !strings.Contains(last.content, "No agent skills found") {
+		t.Errorf("expected empty-skills message, got: %+v", last)
+	}
+}
+
+func TestSlashCommand_Skills_Populated(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{
+		{Name: "greet", Description: "say hi", Body: "hello"},
+		{Name: "summarise", Description: "condense text", Body: "summary"},
+	}
+	handled, _ := m.handleSlashCommand("/skills")
+	if !handled {
+		t.Fatal("expected /skills to be handled")
+	}
+	last := m.messages[len(m.messages)-1]
+	for _, want := range []string{"/greet", "say hi", "/summarise", "condense text"} {
+		if !strings.Contains(last.content, want) {
+			t.Errorf("expected %q in skills listing\ngot: %s", want, last.content)
+		}
+	}
+}
+
+func TestSlashCommand_Model_ListReturnsCmd(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/model")
+	if !handled {
+		t.Fatal("expected /model to be handled")
+	}
+	if cmd == nil {
+		t.Error("expected /model to return a list cmd")
+	}
+}
+
+func TestSlashCommand_Model_SwitchReturnsCmd(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/model sonnet")
+	if !handled {
+		t.Fatal("expected /model <name> to be handled")
+	}
+	if cmd == nil {
+		t.Error("expected /model <name> to return a switch cmd")
+	}
+}
+
+func TestSlashCommand_SkillActivation(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{{Name: "greet", Description: "say hi", Body: "Greet the user warmly."}}
+	initialCount := len(m.messages)
+
+	handled, cmd := m.handleSlashCommand("/greet")
+	if !handled {
+		t.Fatal("expected /greet to be handled as skill activation")
+	}
+	if cmd == nil {
+		t.Error("expected sendMessage cmd from skill activation")
+	}
+	if !m.sending {
+		t.Error("expected m.sending to be true after skill activation")
+	}
+	if len(m.messages) != initialCount+1 {
+		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "user" || last.content != "/greet" {
+		t.Errorf("expected user message %q, got role=%q content=%q", "/greet", last.role, last.content)
+	}
+}
+
+func TestSlashCommand_SkillActivation_CaseInsensitive(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{{Name: "Greet", Description: "say hi", Body: "hi"}}
+
+	handled, cmd := m.handleSlashCommand("/GREET")
+	if !handled {
+		t.Fatal("expected skill activation to be case-insensitive")
+	}
+	if cmd == nil {
+		t.Error("expected a sendMessage cmd")
 	}
 }
 
@@ -186,6 +345,8 @@ func TestSlashCommandHint(t *testing.T) {
 		{"/he", "lp"},
 		{"/help", ""},
 		{"/q", "uit"},
+		{"/a", "gents"},
+		{"/agents", ""},
 		{"/z", ""},
 		{"hello", ""},
 		{"/help foo", ""},
@@ -198,5 +359,25 @@ func TestSlashCommandHint(t *testing.T) {
 				t.Errorf("slashCommandHint(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCompleteSlashCommand_IncludesSkills(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{
+		{Name: "greet", Description: "say hi"},
+		{Name: "summarise", Description: "condense"},
+	}
+
+	// Built-in commands still take priority when they match.
+	if got := m.completeSlashCommand("/s"); got != "/skills" {
+		t.Errorf("completeSlashCommand(%q) = %q, want %q", "/s", got, "/skills")
+	}
+	// Skill name is reachable when no built-in prefix matches.
+	if got := m.completeSlashCommand("/gr"); got != "/greet" {
+		t.Errorf("completeSlashCommand(%q) = %q, want %q", "/gr", got, "/greet")
+	}
+	if got := m.completeSlashCommand("/sum"); got != "/summarise" {
+		t.Errorf("completeSlashCommand(%q) = %q, want %q", "/sum", got, "/summarise")
 	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -57,6 +57,21 @@ func TestSlashCommand_Back(t *testing.T) {
 	}
 }
 
+func TestSlashCommand_Agents(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/agents")
+	if !handled {
+		t.Fatal("expected /agents to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected a goBackMsg cmd")
+	}
+	msg := cmd()
+	if _, ok := msg.(goBackMsg); !ok {
+		t.Errorf("expected goBackMsg, got %T", msg)
+	}
+}
+
 func TestSlashCommand_Clear(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/clear")
@@ -145,8 +160,10 @@ func TestCompleteSlashCommand(t *testing.T) {
 		{"/b", "/back"},
 		{"/c", "/clear"},
 		{"/e", "/exit"},
+		{"/a", "/agents"},
+		{"/agents", "/agents"},
 		{"/z", ""},
-		{"/", "/back"},
+		{"/", "/agents"},
 		{"/H", "/help"},
 	}
 	for _, tt := range tests {

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -43,21 +43,6 @@ func TestSlashCommand_Exit(t *testing.T) {
 	}
 }
 
-func TestSlashCommand_Back(t *testing.T) {
-	m := newSlashTestModel()
-	handled, cmd := m.handleSlashCommand("/back")
-	if !handled {
-		t.Fatal("expected /back to be handled")
-	}
-	if cmd == nil {
-		t.Fatal("expected a goBackMsg cmd")
-	}
-	msg := cmd()
-	if _, ok := msg.(goBackMsg); !ok {
-		t.Errorf("expected goBackMsg, got %T", msg)
-	}
-}
-
 func TestSlashCommand_Agents(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/agents")
@@ -107,7 +92,7 @@ func TestSlashCommand_Help(t *testing.T) {
 	}
 
 	// Every advertised command should appear in the help text.
-	for _, want := range []string{"/quit", "/exit", "/agents", "/back", "/clear", "/model", "/stats", "/skills", "/help"} {
+	for _, want := range []string{"/quit", "/exit", "/agents", "/clear", "/model", "/stats", "/skills", "/help"} {
 		if !strings.Contains(last.content, want) {
 			t.Errorf("/help text missing %q\ngot: %s", want, last.content)
 		}
@@ -316,11 +301,11 @@ func TestCompleteSlashCommand(t *testing.T) {
 		{"/he", "/help"},
 		{"/help", "/help"},
 		{"/q", "/quit"},
-		{"/b", "/back"},
 		{"/c", "/clear"},
 		{"/e", "/exit"},
 		{"/a", "/agents"},
 		{"/agents", "/agents"},
+		{"/b", ""},
 		{"/z", ""},
 		{"/", "/agents"},
 		{"/H", "/help"},

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -229,7 +229,7 @@ func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
 		m.loading = true
 		return m, m.loadAgents()
 
-	case tea.KeyMsg:
+	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 	}
 
@@ -242,7 +242,7 @@ func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
 	return m, cmd
 }
 
-func (m selectModel) handleKey(msg tea.KeyMsg) (selectModel, tea.Cmd) {
+func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 	if m.subState == subStateCreate {
 		return m.handleCreateKey(msg)
 	}
@@ -275,7 +275,7 @@ func (m selectModel) handleKey(msg tea.KeyMsg) (selectModel, tea.Cmd) {
 	return m, cmd
 }
 
-func (m selectModel) handleCreateKey(msg tea.KeyMsg) (selectModel, tea.Cmd) {
+func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		m.subState = subStateList


### PR DESCRIPTION
Adds \`/agents\` as a more discoverable alias for the existing \`/back\` command.

## Summary

- \`/agents\` and \`/back\` both navigate back to the agent picker; \`/back\` is kept for backwards compatibility
- \`/agents\` added to the slash command autocomplete list and \`/help\` output
- README command table updated to show both names