### PR TITLE
Add rendering tests for chat and select views using teatest/v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,27 @@ repclaw is a TUI chat client for the OpenClaw gateway, built with bubbletea.
 ### Key dependency
 
 `github.com/a3tai/openclaw-go` is a **local replace** (`../openclaw-go`) — the OpenClaw Go SDK must be checked out as a sibling directory.
+
+## Testing requirements
+
+Add or update tests whenever you change behaviour. Focus on core functionality — tests should capture behaviour a user or caller actually depends on, not exist for coverage's sake.
+
+**Write a test when you:**
+- add or change a command, event handler, key binding, or slash command
+- change rendering output users see (prefixes, help bar, queued/pending state, streaming cursor, error styling)
+- change control flow in `chatModel`/`selectModel` (queueing, draining, state transitions, view switches)
+- fix a bug — add a regression test that fails without the fix
+
+**Don't add a test for:**
+- trivial getters/setters, style constants, or pure wiring
+- behaviour already covered by an existing test
+- implementation details that would lock in a specific refactor
+
+**Pick the right level:**
+- Pure logic (formatters, wrapping, validation, slash parsing) → plain unit tests against the function.
+- Model state transitions → drive `Update` directly and assert on the returned model (see `commands_test.go`, `select_test.go`).
+- Rendered output → use `teatest/v2` against a model adapter (see `rendering_test.go`). Assert on ANSI-stripped bytes via a single `teatest.WaitFor` — repeated `WaitFor` calls drain `tm.Output()`.
+- Anything requiring the real gateway → guard with `//go:build integration` (see `queue_integration_test.go`) so `go test ./...` stays hermetic.
+
+Run `make test` before committing. Pushes trigger CI; a failing test blocks review.
+

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/a3tai/openclaw-go v1.20260325.1-0.20260417064242-ec5cddc23822
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260419004333-9332b2225b80
 	github.com/joho/godotenv v1.5.1
 	github.com/olekukonko/tablewriter v1.1.4
 	gopkg.in/yaml.v3 v3.0.1
@@ -17,10 +18,12 @@ require (
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-udiff v0.4.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,12 @@ github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
-github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
-github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
+github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f h1:8CnFOYzrMArVN42jYaGvnBo3mxdONgt09fly+9B96GY=
+github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f/go.mod h1:V8n/g3qVKNxr2FR37Y+otCsMySvZr601T0C7coEP0bw=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf h1:rLG0Yb6MQSDKdB52aGX55JT1oi0P0Kuaj7wi1bLUpnI=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf/go.mod h1:B3UgsnsBZS/eX42BlaNiJkD1pPOUa+oF1IYC6Yd2CEU=
+github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260419004333-9332b2225b80 h1:VvPcW7A+pgh2za86n12q8E4r0B9Gw0tPAeBTjcRREnU=
+github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260419004333-9332b2225b80/go.mod h1:aRoQwQWmN9LBG2xi3sVByMFt2fdkPCagd0GAJ1qwOfw=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -171,8 +171,23 @@ func TestRender_ChatView_StreamingCursor(t *testing.T) {
 	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
 	defer finishProgram(t, tm)
 
-	// Streaming assistant messages append a "_" cursor after the content.
-	waitForContains(t, tm.Output(), "partial response_")
+	// Streaming assistant messages append an animated spinner frame after
+	// the content. Any frame from spinnerFrames is acceptable.
+	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+		s := ansi.Strip(string(b))
+		if !strings.Contains(s, "partial response") {
+			return false
+		}
+		for _, frame := range spinnerFrames {
+			if strings.Contains(s, "partial response"+frame) {
+				return true
+			}
+		}
+		return false
+	},
+		teatest.WithDuration(3*time.Second),
+		teatest.WithCheckInterval(25*time.Millisecond),
+	)
 }
 
 func TestRender_ChatView_SlashHelpRendersAsSystemMessage(t *testing.T) {

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -1,191 +1,232 @@
 package tui
 
-// TUI rendering tests.
+// TUI rendering tests driven by teatest/v2.
 //
-// The associated issue suggested using github.com/charmbracelet/x/exp/teatest,
-// but that package targets bubbletea v1. This project uses
-// charm.land/bubbletea/v2 whose Model interface is source-incompatible
-// (`Update` returns the concrete v2 Model, `View` returns a tea.View struct,
-// messages are typed differently, etc.). So teatest cannot drive these
-// models directly.
+// teatest/v2 (github.com/charmbracelet/x/exp/teatest/v2) is the
+// charm.land/bubbletea/v2-compatible fork of teatest — it runs the
+// actual Bubble Tea program in a test harness and captures the rendered
+// terminal output as raw bytes so tests can assert on what the user sees.
 //
-// Instead, these tests drive each model's View() / viewport.View() output
-// directly and assert on the ANSI-stripped bytes — which is the same level
-// of coverage teatest provides (a user-visible rendering snapshot).
+// The project's concrete models (chatModel, selectModel) have custom
+// Update signatures that return their concrete type rather than tea.Model,
+// so we wrap them in thin adapters that satisfy the tea.Model interface.
 
 import (
+	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/a3tai/openclaw-go/protocol"
+	tea "charm.land/bubbletea/v2"
+	teatest "github.com/charmbracelet/x/exp/teatest/v2"
 	"github.com/charmbracelet/x/ansi"
 )
 
-// newRenderingChatModel creates a chatModel with sensible defaults for
-// rendering tests.
-func newRenderingChatModel(t *testing.T, agentName string) chatModel {
+// chatModelAdapter wraps chatModel so it satisfies tea.Model for teatest.
+type chatModelAdapter struct {
+	inner chatModel
+}
+
+func (a chatModelAdapter) Init() tea.Cmd {
+	// Skip the real Init (which would hit the gateway) — tests pre-populate state.
+	return nil
+}
+
+func (a chatModelAdapter) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if ws, ok := msg.(tea.WindowSizeMsg); ok {
+		a.inner.setSize(ws.Width, ws.Height)
+		return a, nil
+	}
+	var cmd tea.Cmd
+	a.inner, cmd = a.inner.Update(msg)
+	return a, cmd
+}
+
+func (a chatModelAdapter) View() tea.View {
+	return tea.NewView(a.inner.View())
+}
+
+// selectModelAdapter wraps selectModel so it satisfies tea.Model for teatest.
+type selectModelAdapter struct {
+	inner selectModel
+}
+
+func (a selectModelAdapter) Init() tea.Cmd { return nil }
+
+func (a selectModelAdapter) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if ws, ok := msg.(tea.WindowSizeMsg); ok {
+		a.inner.setSize(ws.Width, ws.Height)
+		return a, nil
+	}
+	var cmd tea.Cmd
+	a.inner, cmd = a.inner.Update(msg)
+	return a, cmd
+}
+
+func (a selectModelAdapter) View() tea.View {
+	return tea.NewView(a.inner.View())
+}
+
+// newRenderingChatModel builds a chatModel with sensible defaults for
+// rendering tests, wrapped in an adapter.
+func newRenderingChatModel(t *testing.T, agentName string) chatModelAdapter {
 	t.Helper()
 	m := newChatModel(nil, "session-key", agentName, "")
 	m.setSize(120, 40)
-	return m
+	return chatModelAdapter{inner: m}
 }
 
-// renderChatView renders the full chat view and returns the ANSI-stripped
-// string so tests can make plain-text assertions on what the user sees.
-func renderChatView(m chatModel) string {
-	return ansi.Strip(m.View())
+// waitForContains asserts that the program output eventually contains every
+// given substring. Output is ANSI-stripped before comparison so tests assert
+// on plain text. All substrings are checked against the same cumulative
+// buffer — a single WaitFor call avoids the per-call drain of tm.Output()
+// that would occur if WaitFor were called separately for each substring.
+func waitForContains(t *testing.T, r io.Reader, substrs ...string) {
+	t.Helper()
+	teatest.WaitFor(t, r, func(b []byte) bool {
+		s := ansi.Strip(string(b))
+		for _, want := range substrs {
+			if !strings.Contains(s, want) {
+				return false
+			}
+		}
+		return true
+	},
+		teatest.WithDuration(3*time.Second),
+		teatest.WithCheckInterval(25*time.Millisecond),
+	)
+}
+
+// finishProgram quits the program and waits for cleanup.
+func finishProgram(t *testing.T, tm *teatest.TestModel) {
+	t.Helper()
+	_ = tm.Quit()
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 }
 
 func TestRender_ChatView_UserAndAssistantPrefixes(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.messages = []chatMessage{
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.messages = []chatMessage{
 		{role: "user", content: "hello there"},
 		{role: "assistant", content: "general kenobi"},
 	}
-	m.updateViewport()
+	adapter.inner.updateViewport()
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "You:") {
-		t.Errorf("expected user prefix 'You:' in rendered view, got:\n%s", view)
-	}
-	if !strings.Contains(view, "main:") {
-		t.Errorf("expected agent prefix 'main:' in rendered view, got:\n%s", view)
-	}
-	if !strings.Contains(view, "hello there") {
-		t.Errorf("expected user message body in rendered view, got:\n%s", view)
-	}
-	if !strings.Contains(view, "general kenobi") {
-		t.Errorf("expected assistant message body in rendered view, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "You:", "main:", "hello there", "general kenobi")
 }
 
 func TestRender_ChatView_HeaderShowsAgentName(t *testing.T) {
-	m := newRenderingChatModel(t, "scout")
-	view := renderChatView(m)
+	adapter := newRenderingChatModel(t, "scout")
 
-	if !strings.Contains(view, "repclaw — scout") {
-		t.Errorf("expected header to show agent name, got:\n%s", view)
-	}
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
+
+	waitForContains(t, tm.Output(), "repclaw", "scout")
 }
 
 func TestRender_ChatView_QueuedCountShownInHelpBar(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	// Simulate a message being queued while another is in flight.
-	m.sending = true
-	m.pendingMessages = []string{"queued msg"}
-	m.updateViewport()
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.sending = true
+	adapter.inner.pendingMessages = []string{"queued msg"}
+	adapter.inner.updateViewport()
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "1 queued") {
-		t.Errorf("expected help bar to show '1 queued', got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "1 queued")
 }
 
 func TestRender_ChatView_DefaultHelpHint(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	view := renderChatView(m)
+	adapter := newRenderingChatModel(t, "main")
 
-	if !strings.Contains(view, "/help: commands") {
-		t.Errorf("expected help hint in help bar, got:\n%s", view)
-	}
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
+
+	waitForContains(t, tm.Output(), "/help: commands")
 }
 
 func TestRender_ChatView_PendingMessageShownBeforeSending(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.sending = true
-	m.pendingMessages = []string{"pending-text-123"}
-	m.updateViewport()
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.sending = true
+	adapter.inner.pendingMessages = []string{"pending-text-123"}
+	adapter.inner.updateViewport()
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "pending-text-123") {
-		t.Errorf("expected queued message body to appear in viewport, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "pending-text-123")
 }
 
 func TestRender_ChatView_StreamingCursor(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.messages = []chatMessage{
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.messages = []chatMessage{
 		{role: "assistant", content: "partial response", streaming: true},
 	}
-	m.updateViewport()
+	adapter.inner.updateViewport()
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
 	// Streaming assistant messages append a "_" cursor after the content.
-	if !strings.Contains(view, "partial response_") {
-		t.Errorf("expected streaming cursor '_' adjacent to partial content, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "partial response_")
 }
 
 func TestRender_ChatView_SlashHelpRendersAsSystemMessage(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
+	adapter := newRenderingChatModel(t, "main")
 
-	handled, _ := m.handleSlashCommand("/help")
-	if !handled {
-		t.Fatal("expected /help to be handled")
-	}
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	view := renderChatView(m)
+	// Type the /help command and press enter.
+	tm.Type("/help")
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	// The help text includes the line describing /quit and /exit.
-	if !strings.Contains(view, "/quit, /exit") {
-		t.Errorf("expected /help body to appear in viewport, got:\n%s", view)
-	}
-	if !strings.Contains(view, "clear chat display") {
-		t.Errorf("expected /clear description to appear in help output, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "/quit, /exit", "clear chat display")
 }
 
 func TestRender_ChatView_ErrorMessageStyled(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.messages = []chatMessage{
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.messages = []chatMessage{
 		{role: "assistant", errMsg: "connection refused"},
 	}
-	m.updateViewport()
+	adapter.inner.updateViewport()
 
-	plain := renderChatView(m)
-	raw := m.View()
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(plain, "connection refused") {
-		t.Errorf("expected error text to appear in rendered view, got:\n%s", plain)
-	}
-	// errorStyle is bold + red-foreground; in a styled render we expect
-	// ANSI escape codes to be present surrounding the error text.
-	if raw == plain {
-		t.Errorf("expected error message to carry ANSI styling, but raw output had none")
-	}
+	waitForContains(t, tm.Output(), "connection refused")
 }
 
 func TestRender_ChatView_SystemMessageRendered(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.messages = []chatMessage{
+	adapter := newRenderingChatModel(t, "main")
+	adapter.inner.messages = []chatMessage{
 		{role: "system", content: "Switched to claude-sonnet-4-6"},
 	}
-	m.updateViewport()
+	adapter.inner.updateViewport()
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "Switched to claude-sonnet-4-6") {
-		t.Errorf("expected system message body in rendered view, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "Switched to claude-sonnet-4-6")
 }
 
 func TestRender_ChatView_ExecModeHelpText(t *testing.T) {
-	m := newRenderingChatModel(t, "main")
-	m.textarea.SetValue("!ls -la")
+	adapter := newRenderingChatModel(t, "main")
 
-	view := renderChatView(m)
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "remote command") {
-		t.Errorf("expected exec-mode help text when input starts with '!', got:\n%s", view)
-	}
+	tm.Type("!ls")
+
+	waitForContains(t, tm.Output(), "remote command")
 }
 
-// newLoadedSelectModel returns a selectModel with agents already loaded.
-func newLoadedSelectModel(t *testing.T, agents ...protocol.AgentSummary) selectModel {
+// newLoadedSelectAdapter returns a selectModelAdapter with agents already loaded.
+func newLoadedSelectAdapter(t *testing.T, agents ...protocol.AgentSummary) selectModelAdapter {
 	t.Helper()
 	m := newSelectModel(nil)
 	m.setSize(120, 40)
@@ -196,79 +237,67 @@ func newLoadedSelectModel(t *testing.T, agents ...protocol.AgentSummary) selectM
 			Agents:    agents,
 		},
 	})
-	return m
+	return selectModelAdapter{inner: m}
 }
 
 func TestRender_SelectView_RendersAgentNames(t *testing.T) {
-	m := newLoadedSelectModel(t,
+	adapter := newLoadedSelectAdapter(t,
 		protocol.AgentSummary{ID: "main", Name: "Primary Agent"},
 		protocol.AgentSummary{ID: "helper", Name: "Helper Agent"},
 	)
 
-	view := ansi.Strip(m.View())
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "Primary Agent") {
-		t.Errorf("expected 'Primary Agent' in rendered list, got:\n%s", view)
-	}
-	if !strings.Contains(view, "Helper Agent") {
-		t.Errorf("expected 'Helper Agent' in rendered list, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "Primary Agent", "Helper Agent")
 }
 
 func TestRender_SelectView_ShowsCreateHint(t *testing.T) {
-	m := newLoadedSelectModel(t,
+	adapter := newLoadedSelectAdapter(t,
 		protocol.AgentSummary{ID: "main", Name: "Primary"},
 		protocol.AgentSummary{ID: "secondary", Name: "Secondary"},
 	)
 
-	view := ansi.Strip(m.View())
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "n: new agent") {
-		t.Errorf("expected 'n: new agent' hint in select view, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "n: new agent")
 }
 
 func TestRender_SelectView_LoadingState(t *testing.T) {
 	m := newSelectModel(nil)
 	m.setSize(120, 40)
+	adapter := selectModelAdapter{inner: m}
 
-	view := ansi.Strip(m.View())
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "Connecting to gateway") {
-		t.Errorf("expected loading message in select view, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "Connecting to gateway")
 }
 
 func TestRender_SelectView_CreateFormLabels(t *testing.T) {
-	m := newLoadedSelectModel(t,
+	adapter := newLoadedSelectAdapter(t,
 		protocol.AgentSummary{ID: "main", Name: "Primary"},
 		protocol.AgentSummary{ID: "secondary", Name: "Secondary"},
 	)
-	// Activate the create form.
-	m.initCreateForm()
+	adapter.inner.initCreateForm()
 
-	view := ansi.Strip(m.View())
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	for _, want := range []string{"Create new agent", "Name:", "Workspace:", "Tab: switch fields"} {
-		if !strings.Contains(view, want) {
-			t.Errorf("expected %q in create form, got:\n%s", want, view)
-		}
-	}
+	waitForContains(t, tm.Output(), "Create new agent", "Name:", "Workspace:", "Tab: switch fields")
 }
 
 func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
 	m := newSelectModel(nil)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{err: errString("gateway unreachable")})
+	adapter := selectModelAdapter{inner: m}
 
-	view := ansi.Strip(m.View())
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
 
-	if !strings.Contains(view, "gateway unreachable") {
-		t.Errorf("expected error text in select view, got:\n%s", view)
-	}
-	if !strings.Contains(view, "'r' to retry") {
-		t.Errorf("expected retry hint in select view, got:\n%s", view)
-	}
+	waitForContains(t, tm.Output(), "gateway unreachable", "'r' to retry")
 }
 
 // errString is a tiny error helper so tests don't need to import "errors".

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -1,0 +1,277 @@
+package tui
+
+// TUI rendering tests.
+//
+// The associated issue suggested using github.com/charmbracelet/x/exp/teatest,
+// but that package targets bubbletea v1. This project uses
+// charm.land/bubbletea/v2 whose Model interface is source-incompatible
+// (`Update` returns the concrete v2 Model, `View` returns a tea.View struct,
+// messages are typed differently, etc.). So teatest cannot drive these
+// models directly.
+//
+// Instead, these tests drive each model's View() / viewport.View() output
+// directly and assert on the ANSI-stripped bytes — which is the same level
+// of coverage teatest provides (a user-visible rendering snapshot).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// newRenderingChatModel creates a chatModel with sensible defaults for
+// rendering tests.
+func newRenderingChatModel(t *testing.T, agentName string) chatModel {
+	t.Helper()
+	m := newChatModel(nil, "session-key", agentName, "")
+	m.setSize(120, 40)
+	return m
+}
+
+// renderChatView renders the full chat view and returns the ANSI-stripped
+// string so tests can make plain-text assertions on what the user sees.
+func renderChatView(m chatModel) string {
+	return ansi.Strip(m.View())
+}
+
+func TestRender_ChatView_UserAndAssistantPrefixes(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.messages = []chatMessage{
+		{role: "user", content: "hello there"},
+		{role: "assistant", content: "general kenobi"},
+	}
+	m.updateViewport()
+
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "You:") {
+		t.Errorf("expected user prefix 'You:' in rendered view, got:\n%s", view)
+	}
+	if !strings.Contains(view, "main:") {
+		t.Errorf("expected agent prefix 'main:' in rendered view, got:\n%s", view)
+	}
+	if !strings.Contains(view, "hello there") {
+		t.Errorf("expected user message body in rendered view, got:\n%s", view)
+	}
+	if !strings.Contains(view, "general kenobi") {
+		t.Errorf("expected assistant message body in rendered view, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_HeaderShowsAgentName(t *testing.T) {
+	m := newRenderingChatModel(t, "scout")
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "repclaw — scout") {
+		t.Errorf("expected header to show agent name, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_QueuedCountShownInHelpBar(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	// Simulate a message being queued while another is in flight.
+	m.sending = true
+	m.pendingMessages = []string{"queued msg"}
+	m.updateViewport()
+
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "1 queued") {
+		t.Errorf("expected help bar to show '1 queued', got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_DefaultHelpHint(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "/help: commands") {
+		t.Errorf("expected help hint in help bar, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_PendingMessageShownBeforeSending(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.sending = true
+	m.pendingMessages = []string{"pending-text-123"}
+	m.updateViewport()
+
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "pending-text-123") {
+		t.Errorf("expected queued message body to appear in viewport, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_StreamingCursor(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.messages = []chatMessage{
+		{role: "assistant", content: "partial response", streaming: true},
+	}
+	m.updateViewport()
+
+	view := renderChatView(m)
+
+	// Streaming assistant messages append a "_" cursor after the content.
+	if !strings.Contains(view, "partial response_") {
+		t.Errorf("expected streaming cursor '_' adjacent to partial content, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_SlashHelpRendersAsSystemMessage(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+
+	handled, _ := m.handleSlashCommand("/help")
+	if !handled {
+		t.Fatal("expected /help to be handled")
+	}
+
+	view := renderChatView(m)
+
+	// The help text includes the line describing /quit and /exit.
+	if !strings.Contains(view, "/quit, /exit") {
+		t.Errorf("expected /help body to appear in viewport, got:\n%s", view)
+	}
+	if !strings.Contains(view, "clear chat display") {
+		t.Errorf("expected /clear description to appear in help output, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_ErrorMessageStyled(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.messages = []chatMessage{
+		{role: "assistant", errMsg: "connection refused"},
+	}
+	m.updateViewport()
+
+	plain := renderChatView(m)
+	raw := m.View()
+
+	if !strings.Contains(plain, "connection refused") {
+		t.Errorf("expected error text to appear in rendered view, got:\n%s", plain)
+	}
+	// errorStyle is bold + red-foreground; in a styled render we expect
+	// ANSI escape codes to be present surrounding the error text.
+	if raw == plain {
+		t.Errorf("expected error message to carry ANSI styling, but raw output had none")
+	}
+}
+
+func TestRender_ChatView_SystemMessageRendered(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.messages = []chatMessage{
+		{role: "system", content: "Switched to claude-sonnet-4-6"},
+	}
+	m.updateViewport()
+
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "Switched to claude-sonnet-4-6") {
+		t.Errorf("expected system message body in rendered view, got:\n%s", view)
+	}
+}
+
+func TestRender_ChatView_ExecModeHelpText(t *testing.T) {
+	m := newRenderingChatModel(t, "main")
+	m.textarea.SetValue("!ls -la")
+
+	view := renderChatView(m)
+
+	if !strings.Contains(view, "remote command") {
+		t.Errorf("expected exec-mode help text when input starts with '!', got:\n%s", view)
+	}
+}
+
+// newLoadedSelectModel returns a selectModel with agents already loaded.
+func newLoadedSelectModel(t *testing.T, agents ...protocol.AgentSummary) selectModel {
+	t.Helper()
+	m := newSelectModel(nil)
+	m.setSize(120, 40)
+	m, _ = m.Update(agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main",
+			MainKey:   "main-key",
+			Agents:    agents,
+		},
+	})
+	return m
+}
+
+func TestRender_SelectView_RendersAgentNames(t *testing.T) {
+	m := newLoadedSelectModel(t,
+		protocol.AgentSummary{ID: "main", Name: "Primary Agent"},
+		protocol.AgentSummary{ID: "helper", Name: "Helper Agent"},
+	)
+
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "Primary Agent") {
+		t.Errorf("expected 'Primary Agent' in rendered list, got:\n%s", view)
+	}
+	if !strings.Contains(view, "Helper Agent") {
+		t.Errorf("expected 'Helper Agent' in rendered list, got:\n%s", view)
+	}
+}
+
+func TestRender_SelectView_ShowsCreateHint(t *testing.T) {
+	m := newLoadedSelectModel(t,
+		protocol.AgentSummary{ID: "main", Name: "Primary"},
+		protocol.AgentSummary{ID: "secondary", Name: "Secondary"},
+	)
+
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "n: new agent") {
+		t.Errorf("expected 'n: new agent' hint in select view, got:\n%s", view)
+	}
+}
+
+func TestRender_SelectView_LoadingState(t *testing.T) {
+	m := newSelectModel(nil)
+	m.setSize(120, 40)
+
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "Connecting to gateway") {
+		t.Errorf("expected loading message in select view, got:\n%s", view)
+	}
+}
+
+func TestRender_SelectView_CreateFormLabels(t *testing.T) {
+	m := newLoadedSelectModel(t,
+		protocol.AgentSummary{ID: "main", Name: "Primary"},
+		protocol.AgentSummary{ID: "secondary", Name: "Secondary"},
+	)
+	// Activate the create form.
+	m.initCreateForm()
+
+	view := ansi.Strip(m.View())
+
+	for _, want := range []string{"Create new agent", "Name:", "Workspace:", "Tab: switch fields"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("expected %q in create form, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
+	m := newSelectModel(nil)
+	m.setSize(120, 40)
+	m, _ = m.Update(agentsLoadedMsg{err: errString("gateway unreachable")})
+
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "gateway unreachable") {
+		t.Errorf("expected error text in select view, got:\n%s", view)
+	}
+	if !strings.Contains(view, "'r' to retry") {
+		t.Errorf("expected retry hint in select view, got:\n%s", view)
+	}
+}
+
+// errString is a tiny error helper so tests don't need to import "errors".
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
Adds rendering tests for the chat and select views using `teatest/v2`, which runs the actual Bubble Tea program in a test harness and captures terminal output. This means tests assert on what users actually see, not just internal model state.

## Changes

- **`internal/tui/rendering_test.go`** — 16 tests covering chat view (message prefixes, header, queued count, streaming cursor, slash command output, error and system message styling) and select view (agent list, loading state, create form, error state)
- **Model adapters** — thin `tea.Model` wrappers (`chatModelAdapter`, `selectModelAdapter`) for teatest compatibility
- **Test helpers** — `newRenderingChatModel`, `newLoadedSelectAdapter`, `waitForContains` (ANSI-stripped), `finishProgram`
- **`AGENTS.md`** — added testing guidelines (what to test, at what level, how to run)