### PR TITLE
feat: add /status command for gateway health view

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Type these in the chat input. Tab autocompletes partial commands.
 | `/sessions` | Browse and restore previous sessions |
 | `/skills` | List available agent skills |
 | `/stats` | Show token usage and cost breakdown |
+| `/status` | Show gateway health and agent status |
 | `/think` | Show current thinking level |
 | `/think <level>` | Set thinking level (`off`, `minimal`, `low`, `medium`, `high`) |
 | `/quit`, `/exit` | Quit lucinate |

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -238,6 +238,28 @@ func (c *Client) SessionDelete(ctx context.Context, sessionKey string) error {
 	})
 }
 
+// GatewayHealth retrieves the gateway health snapshot.
+func (c *Client) GatewayHealth(ctx context.Context) (*protocol.HealthEvent, error) {
+	raw, err := c.gw.Health(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("health: %w", err)
+	}
+	var h protocol.HealthEvent
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil, fmt.Errorf("parse health: %w", err)
+	}
+	return &h, nil
+}
+
+// HelloUptimeMs returns the gateway uptime in milliseconds from the connect
+// handshake, or 0 if not connected.
+func (c *Client) HelloUptimeMs() int64 {
+	if h := c.gw.Hello(); h != nil {
+		return h.Snapshot.UptimeMs
+	}
+	return 0
+}
+
 // GW returns the underlying gateway client (for direct RPC access).
 func (c *Client) GW() *gateway.Client { return c.gw }
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -218,6 +218,18 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.updateViewport()
 		return m, nil
 
+	case gatewayStatusMsg:
+		if msg.err != nil {
+			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+		} else {
+			m.messages = append(m.messages, chatMessage{
+				role:    "system",
+				content: formatGatewayStatus(msg.health, msg.uptimeMs),
+			})
+		}
+		m.updateViewport()
+		return m, nil
+
 	case thinkingChangedMsg:
 		if msg.err != nil {
 			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
@@ -18,7 +19,7 @@ type pendingConfirmation struct {
 }
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/agents", "/clear", "/commands", "/compact", "/config", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/think"}
+var slashCommands = []string{"/agents", "/clear", "/commands", "/compact", "/config", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -131,7 +132,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -150,6 +151,14 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		m.messages = append(m.messages, chatMessage{role: "system", content: m.formatStatsTable()})
 		m.updateViewport()
 		return true, nil
+	case "/status":
+		cl := m.client
+		return true, func() tea.Msg {
+			health, err := cl.GatewayHealth(context.Background())
+			uptimeMs := cl.HelloUptimeMs()
+			return gatewayStatusMsg{health: health, uptimeMs: uptimeMs, err: err}
+		}
+
 	case "/skills":
 		if len(m.skills) == 0 {
 			m.messages = append(m.messages, chatMessage{role: "system", content: "No agent skills found.\nPlace skills in <cwd>/.agents/skills/<name>/SKILL.md or ~/.agents/skills/<name>/SKILL.md"})
@@ -312,6 +321,84 @@ func localExecCommand(command string) tea.Cmd {
 		}
 		return localExecFinishedMsg{output: output, exitCode: exitCode}
 	}
+}
+
+// formatGatewayStatus renders a HealthEvent as a human-readable status block.
+func formatGatewayStatus(h *protocol.HealthEvent, uptimeMs int64) string {
+	var sb strings.Builder
+
+	// Overall status line.
+	status := "OK"
+	if !h.OK {
+		status = "DEGRADED"
+	}
+	sb.WriteString(fmt.Sprintf("Gateway: %s  (check: %dms, heartbeat: %ds)\n", status, h.DurationMs, h.HeartbeatSeconds))
+
+	if uptimeMs > 0 {
+		sb.WriteString(fmt.Sprintf("Uptime:  %s\n", formatDuration(uptimeMs)))
+	}
+
+	// Sessions summary.
+	sb.WriteString(fmt.Sprintf("Sessions: %d active\n", h.Sessions.Count))
+
+	// Agents table.
+	if len(h.Agents) > 0 {
+		sb.WriteString("\nAgents:\n")
+		for _, a := range h.Agents {
+			marker := "  "
+			if a.IsDefault {
+				marker = "* "
+			}
+			sb.WriteString(fmt.Sprintf("  %s%-30s  %d session(s)\n", marker, a.Name, a.Sessions.Count))
+		}
+	}
+
+	// Channels table.
+	if len(h.ChannelOrder) > 0 {
+		sb.WriteString("\nChannels:\n")
+		for _, key := range h.ChannelOrder {
+			label := key
+			if l, ok := h.ChannelLabels[key]; ok && l != "" {
+				label = l
+			}
+			ch := h.Channels[key]
+			configured := formatBoolPtr(ch.Configured)
+			linked := formatBoolPtr(ch.Linked)
+			var authAge string
+			if ch.AuthAgeMs != nil {
+				authAge = fmt.Sprintf(" auth: %s ago", formatDuration(*ch.AuthAgeMs))
+			}
+			sb.WriteString(fmt.Sprintf("  %-20s configured:%-3s  linked:%-3s%s\n",
+				label, configured, linked, authAge))
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// formatBoolPtr returns "yes", "no", or "?" for a *bool.
+func formatBoolPtr(b *bool) string {
+	if b == nil {
+		return "?"
+	}
+	if *b {
+		return "yes"
+	}
+	return "no"
+}
+
+// formatDuration renders a millisecond duration as a human-readable string.
+func formatDuration(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	return fmt.Sprintf("%dh%dm", h, m)
 }
 
 // handleThinkCommand handles `/think` and `/think <level>`.

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -1130,3 +1130,136 @@ func TestHandleEvent_FullStreamingFlow(t *testing.T) {
 		t.Errorf("after late delta: expected 2 messages, got %d", len(m.messages))
 	}
 }
+
+func TestGatewayStatusMsg_Success(t *testing.T) {
+	m := newTestChatModel()
+	configured := true
+	linked := true
+	health := &protocol.HealthEvent{
+		OK:               true,
+		DurationMs:       12,
+		HeartbeatSeconds: 30,
+		Sessions:         protocol.HealthSessionsSummary{Count: 3},
+		Agents: []protocol.AgentHealthSummary{
+			{AgentID: "a1", Name: "Alpha", IsDefault: true, Sessions: protocol.HealthSessionsSummary{Count: 2}},
+			{AgentID: "a2", Name: "Beta", IsDefault: false, Sessions: protocol.HealthSessionsSummary{Count: 1}},
+		},
+		ChannelOrder:  []string{"slack"},
+		ChannelLabels: map[string]string{"slack": "Slack"},
+		Channels: map[string]protocol.ChannelHealthSummary{
+			"slack": {Configured: &configured, Linked: &linked},
+		},
+	}
+
+	updated, _ := m.Update(gatewayStatusMsg{health: health, uptimeMs: 7200000})
+
+	if len(updated.messages) == 0 {
+		t.Fatal("expected a status message")
+	}
+	last := updated.messages[len(updated.messages)-1]
+	if last.role != "system" {
+		t.Errorf("expected system role, got %q", last.role)
+	}
+	if last.errMsg != "" {
+		t.Errorf("expected no error, got %q", last.errMsg)
+	}
+	if !strings.Contains(last.content, "Gateway: OK") {
+		t.Errorf("expected 'Gateway: OK' in content, got %q", last.content)
+	}
+	if !strings.Contains(last.content, "Alpha") {
+		t.Errorf("expected agent name 'Alpha' in content, got %q", last.content)
+	}
+	if !strings.Contains(last.content, "Slack") {
+		t.Errorf("expected channel label 'Slack' in content, got %q", last.content)
+	}
+	if !strings.Contains(last.content, "2h0m") {
+		t.Errorf("expected uptime '2h0m' in content, got %q", last.content)
+	}
+}
+
+func TestGatewayStatusMsg_Degraded(t *testing.T) {
+	m := newTestChatModel()
+	health := &protocol.HealthEvent{
+		OK:         false,
+		DurationMs: 500,
+	}
+
+	updated, _ := m.Update(gatewayStatusMsg{health: health, uptimeMs: 0})
+
+	last := updated.messages[len(updated.messages)-1]
+	if !strings.Contains(last.content, "DEGRADED") {
+		t.Errorf("expected 'DEGRADED' in content, got %q", last.content)
+	}
+}
+
+func TestGatewayStatusMsg_Error(t *testing.T) {
+	m := newTestChatModel()
+
+	updated, _ := m.Update(gatewayStatusMsg{err: errString("connection refused")})
+
+	last := updated.messages[len(updated.messages)-1]
+	if last.errMsg != "connection refused" {
+		t.Errorf("expected error message, got %q", last.errMsg)
+	}
+}
+
+func TestFormatGatewayStatus_DefaultAgent(t *testing.T) {
+	health := &protocol.HealthEvent{
+		OK: true,
+		Agents: []protocol.AgentHealthSummary{
+			{AgentID: "a1", Name: "Main", IsDefault: true},
+			{AgentID: "a2", Name: "Other", IsDefault: false},
+		},
+	}
+	out := formatGatewayStatus(health, 0)
+	if !strings.Contains(out, "* Main") {
+		t.Errorf("expected default agent marked with '*', got %q", out)
+	}
+	if strings.Contains(out, "* Other") {
+		t.Errorf("non-default agent should not be marked with '*'")
+	}
+}
+
+func TestFormatGatewayStatus_NoUptime(t *testing.T) {
+	health := &protocol.HealthEvent{OK: true}
+	out := formatGatewayStatus(health, 0)
+	if strings.Contains(out, "Uptime") {
+		t.Errorf("expected no Uptime line when uptimeMs=0, got %q", out)
+	}
+}
+
+func TestFormatGatewayStatus_ChannelNilConfigured(t *testing.T) {
+	health := &protocol.HealthEvent{
+		OK:            true,
+		ChannelOrder:  []string{"email"},
+		ChannelLabels: map[string]string{"email": "Email"},
+		Channels: map[string]protocol.ChannelHealthSummary{
+			"email": {Configured: nil, Linked: nil},
+		},
+	}
+	out := formatGatewayStatus(health, 0)
+	if !strings.Contains(out, "configured:?") {
+		t.Errorf("expected '?' for nil configured field, got %q", out)
+	}
+}
+
+func TestFormatDuration_Seconds(t *testing.T) {
+	got := formatDuration(45000)
+	if got != "45s" {
+		t.Errorf("expected '45s', got %q", got)
+	}
+}
+
+func TestFormatDuration_Minutes(t *testing.T) {
+	got := formatDuration(90000)
+	if got != "1m30s" {
+		t.Errorf("expected '1m30s', got %q", got)
+	}
+}
+
+func TestFormatDuration_Hours(t *testing.T) {
+	got := formatDuration(3661000)
+	if got != "1h1m" {
+		t.Errorf("expected '1h1m', got %q", got)
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -150,6 +150,13 @@ type prefsUpdatedMsg struct {
 	prefs config.Preferences
 }
 
+// gatewayStatusMsg is returned after fetching the gateway health.
+type gatewayStatusMsg struct {
+	health   *protocol.HealthEvent
+	uptimeMs int64
+	err      error
+}
+
 // thinkingChangedMsg is returned after changing the thinking level.
 type thinkingChangedMsg struct {
 	level string


### PR DESCRIPTION
Adds a `/status` command that queries the gateway's `health` RPC and renders a live snapshot of gateway state in the chat viewport.

## Summary

- New `/status` slash command calls `GatewayHealth()` and displays overall OK/DEGRADED status, uptime, active session count, per-agent session counts (default agent marked with `*`), and channel configuration/link state
- `GatewayHealth` and `HelloUptimeMs` added to `internal/client/client.go`, wrapping the SDK's `health` RPC and the uptime from the `hello-ok` snapshot respectively
- `formatGatewayStatus`, `formatBoolPtr`, and `formatDuration` helper functions render the response as a plain-text status block
- `/status` added to slash command autocomplete and `/help` output
- README commands table updated

Fixes #49