### PR TITLE
docs: add maintainer documentation for all major subsystems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,19 @@ repclaw is a TUI chat client for the OpenClaw gateway, built with bubbletea.
 
 `github.com/a3tai/openclaw-go` is a **local replace** (`../openclaw-go`) — the OpenClaw Go SDK must be checked out as a sibling directory.
 
+## Developer docs
+
+The `docs/` directory contains maintainer-level documentation for the main subsystems:
+
+- [authentication.md](docs/authentication.md) — device pairing flow, identity storage, gateway connection
+- [agents.md](docs/agents.md) — agent picker, auto-selection, agent creation
+- [sessions.md](docs/sessions.md) — session lifecycle, session browser, compact/reset, message queueing
+- [commands.md](docs/commands.md) — slash command dispatch, all built-in commands, tab completion, confirmation pattern
+- [shell-execution.md](docs/shell-execution.md) — `!` local and `!!` remote exec, two-phase approval
+- [skills.md](docs/skills.md) — skill file format, discovery, catalog injection, activation
+- [chat-ux.md](docs/chat-ux.md) — input bindings, streaming animation, thinking levels, header bar, history depth
+- [message-rendering.md](docs/message-rendering.md) — message roles, `System:` prefix convention, history cleanup, markdown rendering
+
 ## Testing requirements
 
 Add or update tests whenever you change behaviour. Focus on core functionality — tests should capture behaviour a user or caller actually depends on, not exist for coverage's sake.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Developer docs
+
+This directory contains maintainer-level documentation for repclaw. It covers how the major subsystems are implemented — intended as a starting point when working on a feature area, not as a user guide.
+
+## Index
+
+| Document | Covers |
+|---|---|
+| [authentication.md](authentication.md) | Device pairing, Ed25519 identity, gateway connection and token lifecycle |
+| [agents.md](agents.md) | Agent picker, auto-selection, agent creation |
+| [sessions.md](sessions.md) | Session lifecycle, session browser, compact/reset, message queueing |
+| [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
+| [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
+| [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
+| [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |
+| [message-rendering.md](message-rendering.md) | Message roles, `System:` prefix convention, history cleanup, markdown rendering |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,24 @@
+# Agent picker
+
+The agent picker is the first view shown on startup (`selectModel` in `internal/tui/select.go`). It loads the list of configured agents and either presents a selection UI or auto-selects when only one agent exists.
+
+## Loading agents
+
+`loadAgents()` calls `client.ListAgents()` and returns an `agentsLoadedMsg`. Each agent is an `agentItem` wrapping a `protocol.AgentSummary`. The list is displayed using a Bubble Tea list component with a custom delegate that shows the agent name (falling back to ID if no name is set).
+
+## Auto-selection
+
+If exactly one agent is returned, it is selected automatically without user interaction and a session is created immediately. The same auto-select fires after creating a new agent — the picker bypasses the list and proceeds straight to chat.
+
+## Selecting an agent
+
+Pressing Enter on a highlighted agent calls `client.CreateSession(agentID, key)`. On success, `sessionCreatedMsg` carries the new session key and the app transitions to the chat view (`newChatModel(...)`). See [sessions.md](sessions.md) for the session lifecycle from this point.
+
+## Creating an agent
+
+Pressing `n` in the picker switches to a two-field creation form (`subStateCreate`):
+
+- **Name** — must start with a lowercase letter and contain only alphanumeric characters and hyphens. The input is validated on submit; an error is shown inline on failure.
+- **Workspace** — a filesystem path that is auto-suggested but editable.
+
+On submit, `client.CreateAgent(name, workspace)` is called. The gateway creates the agent and seeds an `IDENTITY.md` file in the workspace. On success the agent list is reloaded and the new agent is auto-selected (see above). On failure the form stays open and the error is shown so the user can correct and retry.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,52 @@
+# Authentication
+
+Repclaw authenticates to the OpenClaw gateway using device pairing. There are no usernames or passwords — each device generates a persistent Ed25519 keypair and an administrator approves it on the gateway.
+
+## Configuration
+
+The gateway URL is required and read from the environment:
+
+```
+OPENCLAW_GATEWAY_URL=https://your-gateway-host
+```
+
+This can be set in the shell or in a `.env` file in the working directory. Repclaw derives the WebSocket endpoint automatically by replacing `https://` with `wss://` (or `http://` with `ws://`) and appending `/ws`. Both values are held in `internal/config/config.go` as `Config.GatewayURL` and `Config.WSURL`.
+
+## Device identity
+
+On first run, `identity.Store.LoadOrGenerate()` creates an Ed25519 keypair in `~/.openclaw-go/identity/`. This directory is shared with other openclaw-go clients on the same machine. The keypair acts as a stable device identity across restarts.
+
+## First-run pairing flow
+
+1. Run `repclaw` — the client connects to the gateway with the device identity but no token. The gateway registers a pending pairing request.
+2. On the gateway host, an administrator approves the device:
+   ```
+   openclaw device list --pending
+   openclaw device approve <device-id>
+   ```
+3. Restart `repclaw`. The client reconnects; the gateway issues a device token, which is saved to `~/.openclaw-go/identity/` via `client.store.SaveDeviceToken()`.
+
+The save is non-fatal — if it fails, a warning is logged but the session continues. On subsequent runs the saved token is loaded and presented on connect.
+
+**Note:** Bootstrap tokens were removed in v0.10.2. Device pairing is the only setup path.
+
+## Subsequent runs
+
+1. Load `OPENCLAW_GATEWAY_URL` from environment.
+2. Load the Ed25519 identity and stored device token from `~/.openclaw-go/identity/`.
+3. Open a WebSocket connection to the gateway with the identity and token. The gateway SDK (`github.com/a3tai/openclaw-go`) attaches the token to all API calls.
+4. On a successful `Hello` handshake, any refreshed token is saved back to disk.
+5. Proceed to the agent picker.
+
+If the token is expired or revoked the gateway rejects the connection and an error is shown in the agent picker. The user can press `r` to retry after the device has been re-approved.
+
+## Scopes
+
+The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are set in `internal/client/client.go` and are required for session management, exec approval, and agent administration.
+
+## Stored files
+
+| Path | Contents |
+|---|---|
+| `~/.openclaw-go/identity/` | Ed25519 keypair and device token (shared with other openclaw-go clients) |
+| `~/.repclaw/config.json` | UI preferences — not authentication-related |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -1,0 +1,56 @@
+# Chat UX
+
+## Input key bindings
+
+| Key | Action |
+|---|---|
+| Enter | Send message |
+| Alt+Enter | Insert newline |
+| Ctrl+W | Delete word backward |
+| Up arrow (empty input) | Recall last sent message for editing |
+| Tab | Complete slash command or skill name |
+| Page Up / Page Down | Scroll message history |
+| Esc | Return to agent picker (from chat) |
+
+Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter is not supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
+
+## Message recall
+
+When the textarea is empty and the user presses Up arrow, the last entry in `m.pendingMessages` is popped and inserted into the textarea with the cursor at the end. This allows editing and resending a recently queued message without retyping it.
+
+## Streaming animation
+
+When a message is sent, an assistant message with `streaming: true` is appended to the display immediately so there is always visible feedback. A braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) animates at 120 ms intervals via `spinnerTickCmd()`. Each frame increments `m.spinnerFrame` and re-renders the last message line.
+
+As delta events arrive from the gateway, the message content is built up in place. When the final event arrives, `streaming` is set to false and the spinner stops. If the final event arrives before any delta (empty response), the placeholder is removed from the display entirely.
+
+See [message-rendering.md](message-rendering.md#streaming-placeholder) for the rendering side of this.
+
+## Thinking levels
+
+The gateway supports extended thinking for supported models. The level is stored in `m.thinkingLevel` and displayed in the header bar when set and not `"off"`.
+
+Valid levels: `off`, `minimal`, `low`, `medium`, `high`.
+
+`/think` (no argument) shows the current level. `/think <level>` validates the input and calls `client.SessionPatchThinking(sessionKey, level)`. See [commands.md](commands.md) for the command dispatch.
+
+The spinner also appears while the model is thinking before any response deltas arrive, giving immediate feedback after sending.
+
+## Header bar
+
+The header line shows:
+
+- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`)
+- **Right:** token summary (input / output / cache) · total cost
+
+Stats are loaded on init and refreshed after each message exchange via `loadStats()`. The header is re-rendered on every `statsLoadedMsg`. Token and cost values come from `client.SessionUsage()`.
+
+## History depth
+
+The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/config` ("History limit") in steps of 10 (range 10–500), or overridden at startup with the `--history-limit` CLI flag. The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
+
+See [sessions.md](sessions.md#lifecycle) for how history loading fits into the session lifecycle.
+
+## Scrolling
+
+The message history is a Bubble Tea viewport. Mouse wheel events are forwarded to the viewport directly. Page Up/Down and arrow keys scroll when the input is not the active focus. New messages are anchored to the bottom via `GotoBottom()` after each update.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,44 @@
+# Slash commands
+
+Slash commands are local TUI commands that begin with `/`. They are intercepted by `handleSlashCommand()` in `internal/tui/commands.go` before any message is sent to the gateway. The function returns `(handled bool, cmd tea.Cmd)` — if `handled` is true, the input is consumed locally and never forwarded.
+
+## Dispatch
+
+Input that starts with `/` and contains no spaces is matched case-insensitively against a `switch` statement of built-in commands. Commands that accept an argument (e.g. `/model sonnet`, `/think high`) are matched by prefix check after the switch.
+
+Unrecognised slash commands fall through to a skill-name lookup. If no skill matches, an error system message is shown (see [skills.md](skills.md#activation)).
+
+## Built-in commands
+
+| Command | What it does |
+|---|---|
+| `/agents` | Return to the agent picker by emitting `goBackMsg{}` |
+| `/clear` | Wipe `m.messages` from the local display (does not affect gateway history) |
+| `/compact` | Compact the session context — see [sessions.md](sessions.md#compact-and-reset) |
+| `/config` | Open the preferences view by emitting `showConfigMsg{}` |
+| `/exit`, `/quit` | Exit via `tea.Quit` |
+| `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
+| `/model` | List available models |
+| `/model <name>` | Switch model — see below |
+| `/reset` | Delete the session and start fresh — see [sessions.md](sessions.md#compact-and-reset) |
+| `/sessions` | Open the session browser — see [sessions.md](sessions.md#session-browser) |
+| `/skills` | List discovered skills — see [skills.md](skills.md) |
+| `/stats` | Show a token usage and cost table for the current session |
+| `/think` | Show the current thinking level |
+| `/think <level>` | Set the thinking level — see [chat-ux.md](chat-ux.md#thinking-levels) |
+
+### /model
+
+`handleModelCommand()` calls `client.ModelsList()` to retrieve available models from the gateway. When a name argument is given it fuzzy-matches against model IDs and names (exact match first, then substring). On a match it calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header.
+
+### /stats
+
+Stats are loaded asynchronously via `client.SessionUsage()` on chat init and after each message exchange. `/stats` formats `m.stats` through `formatStatsTable()` in `internal/tui/render.go`, which produces a text table of input/output/cache tokens and cost breakdown.
+
+## Tab completion
+
+`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins. `slashCommandHint()` derives the completion suffix shown greyed-out in the input bar. Pressing Tab inserts the full command via `m.textarea.SetValue(match)` and `CursorEnd()`.
+
+## Confirmation pattern
+
+Destructive commands (`/compact`, `/reset`) use a two-step confirmation. On first invocation a `pendingConfirmation` struct is stored on the model containing the prompt string and an action closure. The prompt is displayed as a system message. On the next Enter keypress, if the input is `y` or `yes` the closure is executed; anything else cancels. This prevents accidental data loss.

--- a/docs/message-rendering.md
+++ b/docs/message-rendering.md
@@ -1,0 +1,42 @@
+# Message rendering
+
+## Message roles
+
+Each chat message has a role that determines how it is displayed in the TUI:
+
+- `user` — sent by the local user; shown right-aligned.
+- `assistant` — returned by the agent; rendered as markdown via Glamour.
+- `system` — local-only notices (errors, status, command output); shown in a muted style and never sent to the gateway.
+
+## The System: prefix convention
+
+Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but must not be shown in the local chat history when it is loaded back. The convention is to prefix every such line with `System: `:
+
+```
+System: Available agent skills (activate with /skill-name):
+System:   - review: Perform a code review
+```
+
+`prefixAllLines()` in `internal/tui/skills.go` applies this prefix to a block of text. Content that uses this convention includes:
+
+- The skill catalog prepended to the first user message (see [skills.md](skills.md)).
+- Injected skill bodies sent when the user activates a skill.
+
+## History cleanup
+
+When session history is fetched from the gateway, each user message may contain `System:` prefixed lines that were injected at send time. `stripSystemLines()` in `internal/tui/history.go` removes those lines before the messages are added to the display, so the user only sees what they actually typed.
+
+`isSystemLine()` matches two forms:
+
+- `System: ...` — the standard local prefix.
+- `System (<qualifier>): ...` — a variant the gateway may substitute (e.g. `System (untrusted):`) when rewriting message content for safety reasons.
+
+## Markdown rendering
+
+Assistant messages are conditionally rendered with Glamour. `looksLikeMarkdown()` in `internal/tui/history.go` checks for code fences, bold markers, pipe tables, list prefixes, headings, and numbered lists. If none are found the text is shown as plain text, avoiding unwanted paragraph indentation on short replies.
+
+The Glamour renderer is created in `setSize()` with a wrap width equal to the terminal width minus 4. `wordWrap()` in `render.go` is applied after rendering and preserves lines containing box-drawing characters (table borders) so they are not split.
+
+## Streaming placeholder
+
+When the user sends a message, an empty assistant message with `streaming: true` is appended immediately so there is always something to animate (see [chat-ux.md](chat-ux.md#streaming-animation)). As delta events arrive, the message content is built up incrementally. If the final event arrives before any delta (e.g. an error), the placeholder message is removed from the display.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,40 @@
+# Sessions
+
+## Lifecycle
+
+A session is created when the user selects an agent in the agent picker (see [agents.md](agents.md)). `client.CreateSession(agentID, key)` is called and the returned `sessionKey` is passed to `newChatModel()`. The session key is deterministic for non-default agents (based on agent ID) so the same session is restored on restart.
+
+On `chatModel.Init()`, two async commands run in parallel:
+
+- `loadHistory()` — fetches the last N messages from the gateway (`client.SessionHistory()`), strips `System:` lines (see [message-rendering.md](message-rendering.md#history-cleanup)), and populates the viewport.
+- `loadStats()` — fetches token usage and cost via `client.SessionUsage()` for the header bar.
+
+History depth (N) is configurable; see [chat-ux.md](chat-ux.md#history-depth).
+
+## Session browser
+
+`/sessions` emits `showSessionsMsg{}`, which navigates to the sessions view (`sessionsModel` in `internal/tui/sessions.go`). The model calls `client.SessionsList(agentID)` and parses the response into `sessionItem` values grouped into two lists:
+
+- **Conversations** — regular sessions.
+- **Scheduled** — sessions whose key contains `:cron:`, used by scheduled/automated agents.
+
+Both lists are sorted by `updatedAt` descending. Selecting a session returns `sessionSelectedMsg` and a new `chatModel` is constructed with the chosen key, loading its history.
+
+## Compact and reset
+
+Both commands use the [confirmation pattern](commands.md#confirmation-pattern) before taking action.
+
+**`/compact`** calls `client.SessionCompact()`, which asks the gateway to summarise older messages in the session context to reduce token usage. The local message list is not modified; a full history refresh runs after the RPC completes.
+
+**`/reset`** calls `client.SessionDelete()` to permanently remove the session, then immediately creates a replacement via `client.CreateSession()`. The new session key is returned as `sessionClearedMsg{newSessionKey}` and the chat model reinitialises with an empty history.
+
+## Message queueing
+
+While `m.sending == true` (a response is in flight), new user input is appended to `m.pendingMessages []string` rather than sent immediately. This prevents messages from being dropped when the user types quickly.
+
+After each response (`drainQueue()` in `chat.go`):
+
+1. If there are pending messages, the first one is dequeued and sent as if the user typed it fresh (including command detection, skill prepend, etc.).
+2. History is refreshed once the queue is fully drained.
+
+Local (`!`) and remote (`!!`) exec results also trigger queue draining. See [shell-execution.md](shell-execution.md) for the exec flow.

--- a/docs/shell-execution.md
+++ b/docs/shell-execution.md
@@ -1,0 +1,28 @@
+# Shell execution
+
+Repclaw supports running shell commands directly from the chat input using a prefix convention:
+
+| Prefix | Where it runs |
+|---|---|
+| `!<command>` | Local machine (user's shell) |
+| `!!<command>` | Gateway host (remote) |
+
+Both are handled in `chat.go`'s `Update()` before messages are sent to the gateway.
+
+## Local execution (`!`)
+
+Detected when the input starts with `!` but not `!!`. `localExecCommand()` in `commands.go` spawns `exec.Command("sh", "-c", command)` and captures combined stdout and stderr. The result is returned as `localExecFinishedMsg{output, exitCode, err}` and displayed as a system message. No gateway involvement; no approval required.
+
+## Remote execution (`!!`)
+
+Detected when the input starts with `!!`. The stripped command is passed to `execCommand()` in `commands.go`, which implements a two-phase approval flow:
+
+1. **Submit** — `client.ExecRequest(ctx, command, sessionKey)` is called. The gateway returns immediately with an `ExecApprovalRequestResult` containing `{ID, Status, Decision}`.
+2. **Approve** — If `Decision` is empty (not yet resolved by gateway policy), the client auto-approves via `client.ExecResolve(ctx, id, "allow-once")`. If the approval was already resolved (the gateway's own exec policy accepted it), the `"unknown or expired"` error is silently ignored.
+3. **Result** — Output arrives asynchronously via an `exec.finished` gateway event, processed in `handleEvent()` in `events.go`. The system message "running on gateway..." is replaced with the output or an error.
+
+If the gateway denies the request (`Decision == "deny"`), an error is shown immediately without waiting for the event.
+
+## Message queueing during execution
+
+Both local and remote execution can overlap with in-flight chat messages. New user input while `m.sending == true` is held in `m.pendingMessages` and drained after the current exchange completes. See [sessions.md](sessions.md#message-queueing) for details.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,75 @@
+# Agent Skills
+
+Agent skills are locally-stored prompt templates that users can inject into a chat session via slash commands (e.g. `/review`). They allow users to define reusable instructions without modifying gateway configuration.
+
+## Skill file format
+
+Each skill lives in its own directory and must contain a `SKILL.md` file with YAML frontmatter:
+
+```
+---
+name: review
+description: Perform a code review
+---
+
+Please review the following code for correctness, style, and potential bugs. Be concise.
+```
+
+Both `name` and `description` are required. The body is arbitrary markdown and is sent verbatim to the agent when the skill is activated.
+
+## Discovery
+
+Skills are discovered at startup by `discoverSkills()` in `internal/tui/skills.go`. It scans these directories in order:
+
+1. `<cwd>/.agents/skills/*/SKILL.md`
+2. `<cwd>/.agent/skills/*/SKILL.md`
+3. `~/.agents/skills/*/SKILL.md`
+4. `~/.agent/skills/*/SKILL.md`
+
+CWD directories are scanned first — if two skills share the same `name`, the first one found wins. Symlinked skill directories are resolved via `os.Stat`.
+
+Discovery runs as a Bubble Tea command in `chatModel.Init()` and returns a `skillsDiscoveredMsg` which stores the skill list in `chatModel.skills`.
+
+## Catalog injection
+
+The agent doesn't receive skill information unless it's explicitly included in a message. On the **first user message** of a session, `withSkillCatalog()` (`chat.go`) prepends a skill listing to the outgoing text before it is sent to the gateway:
+
+```
+System: Available agent skills (activate with /skill-name):
+System:   - review: Perform a code review
+```
+
+Lines are prefixed with `System: ` using the convention described in [message-rendering.md](message-rendering.md). The catalog is sent only once per session (`skillCatalogSent` flag).
+
+## Activation
+
+When the user types `/<name>`, `handleSlashCommand()` (`commands.go`) matches it against loaded skills (case-insensitive). On a match:
+
+1. The skill body is wrapped with a `[Skill: <name>]` header.
+2. Every line is prefixed with `System: ` (see [message-rendering.md](message-rendering.md)).
+3. The resulting text is sent to the gateway as the message content.
+4. The chat display shows the user message as `/<name>` (not the full body).
+
+Unknown slash commands that don't match a built-in or a skill name show an error.
+
+Tab completion (`completeSlashCommand()` in `commands.go`) includes skill names alongside built-in commands.
+
+## UI commands
+
+| Command | Behaviour |
+|---|---|
+| `/skills` | Lists all discovered skills with their descriptions |
+| `/<name>` | Activates the named skill |
+| `/help` | Mentions how many skills are loaded |
+
+The count of loaded skills also appears in the `/stats` table.
+
+## Adding a new skill
+
+Create a directory under one of the scanned paths:
+
+```
+~/.agents/skills/my-skill/SKILL.md
+```
+
+Skills are discovered once at startup — a restart is required to pick up new files.


### PR DESCRIPTION
Adds a `docs/` directory with maintainer-level documentation covering the main repclaw subsystems, derived from the source code.

## Summary

- `authentication.md` — device pairing flow, Ed25519 identity storage, gateway connection and token lifecycle
- `agents.md` — agent picker, auto-selection behaviour, agent creation form and validation
- `sessions.md` — session lifecycle, session browser, `/compact` and `/reset`, message queueing
- `commands.md` — slash command dispatch, all built-in commands, tab completion, confirmation pattern
- `shell-execution.md` — `!` local exec and `!!` remote exec with two-phase approval flow
- `skills.md` — skill file format, discovery, catalog injection, activation
- `chat-ux.md` — input key bindings, streaming animation, thinking levels, header bar, history depth, scrolling
- `message-rendering.md` — message roles, `System:` prefix convention, history cleanup, markdown rendering, streaming placeholder
- `AGENTS.md` updated with a Developer docs index linking to all new files

## Implementation details

Docs are cross-linked throughout to avoid repeating shared concepts — e.g. the `System:` prefix convention is explained once in `message-rendering.md` and referenced from `skills.md` and `shell-execution.md`; the confirmation pattern lives in `commands.md` and is linked from `sessions.md`.