### PR TITLE
feat: style pending messages as dim italic shadows

### DIFF
--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -58,15 +58,16 @@ func (m *chatModel) updateViewport() {
 		}
 	}
 
-	// Render queued messages that haven't been sent yet.
+	// Render queued messages that haven't been sent yet — shown as dim/italic
+	// shadows to distinguish them from confirmed messages.
 	for _, text := range m.pendingMessages {
 		b.WriteString("\n")
 		label := m.prefixLabel("You")
-		prefix := userPrefixStyle.Render(label)
+		prefix := pendingPrefixStyle.Render(label)
 		prefixIndent := strings.Repeat(" ", len(label))
 		b.WriteString(prefix)
 		body := wordWrap(text, contentWidth-len(label))
-		b.WriteString(indentMultiline(body, prefixIndent))
+		b.WriteString(pendingBodyStyle.Render(indentMultiline(body, prefixIndent)))
 	}
 
 	content := b.String()

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -70,6 +70,17 @@ var (
 				Bold(true).
 				Foreground(localExcClr)
 
+	// Pending (queued) message prefix — dimmed, italic shadow of the user style.
+	pendingPrefixStyle = lipgloss.NewStyle().
+				Italic(true).
+				Faint(true).
+				Foreground(userClr)
+
+	// Pending (queued) message body — dimmed italic to match prefix.
+	pendingBodyStyle = lipgloss.NewStyle().
+				Italic(true).
+				Faint(true)
+
 	// Help text.
 	helpStyle = lipgloss.NewStyle().
 			Foreground(subtle)


### PR DESCRIPTION
Pending (queued) messages in the message list now appear visually distinct from confirmed messages.

## Summary

- Add `pendingPrefixStyle` and `pendingBodyStyle` lipgloss styles — italic + faint, with the user colour retained on the prefix
- Render the pending-messages loop using these styles instead of the standard `userPrefixStyle`