### PR TITLE
fix: ignore chat events from other sessions

### DIFF
--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -155,7 +155,13 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		return nil
 	}
 
-	logEvent("EVENT state=%s runID=%s seq=%d msgLen=%d", chatEv.State, chatEv.RunID, chatEv.Seq, len(chatEv.Message))
+	logEvent("EVENT state=%s runID=%s seq=%d msgLen=%d sessionKey=%s", chatEv.State, chatEv.RunID, chatEv.Seq, len(chatEv.Message), chatEv.SessionKey)
+
+	// Ignore chat events from other sessions.
+	if chatEv.SessionKey != "" && chatEv.SessionKey != m.sessionKey {
+		logEvent("  CHAT ignored (different session)")
+		return nil
+	}
 
 	switch chatEv.State {
 	case "delta":

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -11,11 +11,17 @@ import (
 
 // makeChatEvent builds a protocol.Event wrapping a ChatEvent payload.
 func makeChatEvent(state, runID string, seq int, message json.RawMessage) protocol.Event {
+	return makeChatEventForSession(state, runID, "", seq, message)
+}
+
+// makeChatEventForSession builds a protocol.Event with an explicit sessionKey.
+func makeChatEventForSession(state, runID, sessionKey string, seq int, message json.RawMessage) protocol.Event {
 	chatEv := protocol.ChatEvent{
-		RunID:   runID,
-		State:   state,
-		Seq:     seq,
-		Message: message,
+		RunID:      runID,
+		SessionKey: sessionKey,
+		State:      state,
+		Seq:        seq,
+		Message:    message,
 	}
 	payload, _ := json.Marshal(chatEv)
 	return protocol.Event{
@@ -935,6 +941,163 @@ func TestHandleEvent_EmptyDeltaIgnored(t *testing.T) {
 
 	if len(m.messages) != 1 {
 		t.Errorf("expected 1 message, got %d", len(m.messages))
+	}
+}
+
+// --- Session-key filtering for chat events ---
+
+// TestHandleEvent_ChatDelta_DifferentSession_Ignored verifies that a delta
+// event carrying a sessionKey that doesn't match the model's session is silently
+// dropped and does not create or modify any assistant message.
+func TestHandleEvent_ChatDelta_DifferentSession_Ignored(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{{role: "user", content: "hello"}}
+
+	ev := makeChatEventForSession("delta", "run-B", "sess-B", 1, json.RawMessage(`"should not appear"`))
+	m.handleEvent(ev)
+
+	if len(m.messages) != 1 {
+		t.Fatalf("expected 1 message (no spurious assistant), got %d", len(m.messages))
+	}
+}
+
+// TestHandleEvent_ChatDelta_DifferentSession_DoesNotCorruptStreaming verifies
+// that a delta from another session does not overwrite an in-progress streaming
+// assistant message from the correct session.
+func TestHandleEvent_ChatDelta_DifferentSession_DoesNotCorruptStreaming(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "correct text", streaming: true},
+	}
+
+	ev := makeChatEventForSession("delta", "run-B", "sess-B", 1, json.RawMessage(`"wrong text"`))
+	m.handleEvent(ev)
+
+	if m.messages[1].content != "correct text" {
+		t.Errorf("streaming content corrupted: got %q, want %q", m.messages[1].content, "correct text")
+	}
+}
+
+// TestHandleEvent_ChatFinal_DifferentSession_Ignored verifies that a final
+// event from another session does not finalise the current streaming message.
+func TestHandleEvent_ChatFinal_DifferentSession_Ignored(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.sending = true
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "streaming…", streaming: true},
+	}
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"other"}],"timestamp":123}`)
+	cmd := m.handleEvent(makeChatEventForSession("final", "run-B", "sess-B", 1, finalMsg))
+
+	if cmd != nil {
+		t.Error("expected nil cmd — foreign final must not trigger any action")
+	}
+	if !m.messages[1].streaming {
+		t.Error("own streaming message should still be streaming")
+	}
+	if !m.sending {
+		t.Error("sending should remain true")
+	}
+}
+
+// TestHandleEvent_ChatFinal_DifferentSession_DoesNotDrainQueue is the critical
+// regression test: a final event from another session must NOT trigger drainQueue
+// and send pending messages prematurely.
+func TestHandleEvent_ChatFinal_DifferentSession_DoesNotDrainQueue(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.sending = true
+	m.pendingMessages = []string{"queued msg"}
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "streaming…", streaming: true},
+	}
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"other session done"}],"timestamp":123}`)
+	cmd := m.handleEvent(makeChatEventForSession("final", "run-B", "sess-B", 1, finalMsg))
+
+	if cmd != nil {
+		t.Error("expected nil cmd — foreign final must not drain the queue")
+	}
+	if len(m.pendingMessages) != 1 {
+		t.Errorf("queue should be untouched: got %d pending, want 1", len(m.pendingMessages))
+	}
+	if !m.sending {
+		t.Error("sending should remain true")
+	}
+}
+
+// TestHandleEvent_ChatError_DifferentSession_Ignored verifies that an error
+// event from another session does not affect the current model state.
+func TestHandleEvent_ChatError_DifferentSession_Ignored(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.sending = true
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "streaming…", streaming: true},
+	}
+
+	chatEv := protocol.ChatEvent{
+		RunID:        "run-B",
+		SessionKey:   "sess-B",
+		State:        "error",
+		ErrorMessage: "something failed",
+	}
+	payload, _ := json.Marshal(chatEv)
+	cmd := m.handleEvent(protocol.Event{EventName: protocol.EventChat, Payload: payload})
+
+	if cmd != nil {
+		t.Error("expected nil cmd for foreign error event")
+	}
+	if m.messages[1].errMsg != "" {
+		t.Errorf("errMsg should be empty, got %q", m.messages[1].errMsg)
+	}
+	if !m.messages[1].streaming {
+		t.Error("own streaming message should still be streaming")
+	}
+}
+
+// TestHandleEvent_ChatDelta_EmptySessionKey_Processed verifies that events
+// without a sessionKey (e.g. from older gateway versions) are still handled.
+func TestHandleEvent_ChatDelta_EmptySessionKey_Processed(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{{role: "user", content: "hello"}}
+
+	// sessionKey="" — should not be filtered out.
+	ev := makeChatEventForSession("delta", "run-1", "", 1, json.RawMessage(`"hello from gateway"`))
+	m.handleEvent(ev)
+
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages (delta processed), got %d", len(m.messages))
+	}
+	if m.messages[1].content != "hello from gateway" {
+		t.Errorf("content = %q, want %q", m.messages[1].content, "hello from gateway")
+	}
+}
+
+// TestHandleEvent_ChatDelta_MatchingSession_Processed verifies that events
+// with a matching sessionKey are handled normally.
+func TestHandleEvent_ChatDelta_MatchingSession_Processed(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{{role: "user", content: "hello"}}
+
+	ev := makeChatEventForSession("delta", "run-1", "sess-A", 1, json.RawMessage(`"correct response"`))
+	m.handleEvent(ev)
+
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(m.messages))
+	}
+	if m.messages[1].content != "correct response" {
+		t.Errorf("content = %q, want %q", m.messages[1].content, "correct response")
 	}
 }
 


### PR DESCRIPTION
Prevents cross-session contamination when multiple repclaw processes connect concurrently to the same gateway.

## Summary

- The gateway broadcasts `chat` events to all connected WebSocket clients; without a session key guard, events from other sessions were processed by the wrong client
- A foreign `delta` would corrupt or replace an in-progress streaming response; a foreign `final` would prematurely finalise it and trigger `drainQueue`, sending queued messages at the wrong time
- Adds a `sessionKey` check before processing `chat` events, matching the existing guard on `exec.finished` and `exec.denied`
- Events with an empty `sessionKey` are still processed for backwards compatibility with older gateway versions

## Implementation details

The fix is a client-side guard — the root cause is that the gateway uses an untargeted broadcast for `chat` events rather than per-session delivery. The guard is defensive and correct regardless of whether the gateway is later updated to use targeted broadcasts.