### PR TITLE
fix: prevent queued messages being dropped after early gateway ack

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -73,7 +73,7 @@ func (m *chatModel) hasStreamingMessage() bool {
 func (m *chatModel) removeThinkingPlaceholder() {
 	if len(m.messages) > 0 {
 		last := &m.messages[len(m.messages)-1]
-		if last.role == "assistant" && last.streaming && last.content == "" {
+		if last.role == "assistant" && last.streaming && last.awaitingDelta {
 			m.messages = m.messages[:len(m.messages)-1]
 		}
 	}
@@ -371,7 +371,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			}
 
 			m.messages = append(m.messages, chatMessage{role: "user", content: text})
-			m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true})
+			m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 			m.sending = true
 			m.updateViewport()
 			cmds = append(cmds, m.sendMessage(m.withSkillCatalog(text)), m.ensureSpinnerTicking())
@@ -547,7 +547,7 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 	}
 
 	m.messages = append(m.messages, chatMessage{role: "user", content: text})
-	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true})
+	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 	m.updateViewport()
 	return tea.Batch(m.sendMessage(text), m.ensureSpinnerTicking())
 }

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -21,6 +21,25 @@ type chatContentBlock struct {
 	Text string `json:"text"`
 }
 
+// extractThinkingFromMessage parses the Message field and extracts thinking blocks.
+// Only final events carry structured content blocks; delta events are plain strings.
+func extractThinkingFromMessage(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var msg chatFinalMessage
+	if json.Unmarshal(raw, &msg) != nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range msg.Content {
+		if block.Type == "thinking" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 // extractTextFromMessage parses the Message field and extracts readable text.
 // Delta events send a plain JSON string; final events send a structured object.
 func extractTextFromMessage(raw json.RawMessage) string {
@@ -151,6 +170,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			if last.role == "assistant" && last.streaming {
 				// Deltas are cumulative — each one contains the full text so far.
 				last.content = deltaText
+				last.awaitingDelta = false
 				m.updateViewport()
 				return nil
 			}
@@ -172,10 +192,11 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		finalised := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
-			if last.role == "assistant" && last.streaming {
+			if last.role == "assistant" && last.streaming && !last.awaitingDelta {
 				last.streaming = false
+				last.thinking = extractThinkingFromMessage(chatEv.Message)
 				finalised = true
-				logEvent("  FINALISED — refreshing history")
+				logEvent("  FINALISED — refreshing history thinking_len=%d", len(last.thinking))
 			}
 		}
 		m.updateViewport()

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -282,8 +282,8 @@ func TestDrainQueue_SendsFirstPendingMessage(t *testing.T) {
 		t.Errorf("expected second-to-last message to be user 'msg1', got %s %q", userMsg.role, userMsg.content)
 	}
 	placeholder := m.messages[n-1]
-	if placeholder.role != "assistant" || !placeholder.streaming || placeholder.content != "" {
-		t.Errorf("expected thinking placeholder (assistant streaming empty), got %s %q streaming=%v", placeholder.role, placeholder.content, placeholder.streaming)
+	if placeholder.role != "assistant" || !placeholder.streaming || !placeholder.awaitingDelta {
+		t.Errorf("expected thinking placeholder (assistant streaming awaitingDelta), got %s streaming=%v awaitingDelta=%v", placeholder.role, placeholder.streaming, placeholder.awaitingDelta)
 	}
 }
 
@@ -341,22 +341,27 @@ func TestFinalEvent_EmptyAckDoesNotDrain(t *testing.T) {
 	m := newTestChatModel()
 	m.sending = true
 	m.pendingMessages = []string{"queued"}
+	// Reflect real runtime state: a spinner placeholder is present but no delta has arrived.
 	m.messages = []chatMessage{
 		{role: "user", content: "hello"},
+		{role: "assistant", streaming: true, awaitingDelta: true},
 	}
 
-	// An empty final with no streaming assistant message (gateway ack).
+	// An early final ack from the gateway, arriving before any delta.
 	finalMsg := json.RawMessage(`{"role":"assistant","content":[],"timestamp":123}`)
 	cmd := m.handleEvent(makeChatEvent("final", "run1", 1, finalMsg))
 
 	if cmd != nil {
-		t.Error("expected nil cmd for empty ack final")
+		t.Error("expected nil cmd — placeholder should not be treated as a finalised response")
 	}
 	if len(m.pendingMessages) != 1 {
 		t.Errorf("queue should be unchanged, got %d pending", len(m.pendingMessages))
 	}
 	if !m.sending {
 		t.Error("sending should remain true — ack should not reset it")
+	}
+	if !m.messages[1].streaming {
+		t.Error("placeholder should remain streaming")
 	}
 }
 
@@ -388,8 +393,8 @@ func TestFinalEvent_DrainAfterStreamingResponse(t *testing.T) {
 		t.Errorf("expected dequeued user message at second-to-last, got %s %q", userMsg.role, userMsg.content)
 	}
 	placeholder := m.messages[n-1]
-	if placeholder.role != "assistant" || !placeholder.streaming || placeholder.content != "" {
-		t.Errorf("expected thinking placeholder (assistant streaming empty), got %s %q streaming=%v", placeholder.role, placeholder.content, placeholder.streaming)
+	if placeholder.role != "assistant" || !placeholder.streaming || !placeholder.awaitingDelta {
+		t.Errorf("expected thinking placeholder (assistant streaming awaitingDelta), got %s streaming=%v awaitingDelta=%v", placeholder.role, placeholder.streaming, placeholder.awaitingDelta)
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -8,11 +8,13 @@ import (
 
 // chatMessage represents a single message in the conversation.
 type chatMessage struct {
-	role      string // "user", "assistant", "system", or "separator"
-	content   string
-	streaming bool
-	errMsg    string
-	rendered  bool // true if content has been glamour-rendered (contains ANSI codes)
+	role          string // "user", "assistant", "system", or "separator"
+	content       string
+	thinking      string // reasoning/intermediate thought content from the model
+	streaming     bool
+	awaitingDelta bool // true for the pre-response spinner placeholder, before any delta arrives
+	errMsg        string
+	rendered      bool // true if content has been glamour-rendered (contains ANSI codes)
 }
 
 // sessionStats holds token usage stats for display.


### PR DESCRIPTION
Fixes a bug where the second message in a queue was silently ignored after the first response completed.

## Summary

- The spinner placeholder (`awaitingDelta: true`) added on send was being mistaken by the `final` event handler for a completed response when an early empty gateway ack arrived
- This caused `drainQueue` to fire prematurely, consuming the queued message's send slot before the real response had arrived
- Subsequent deltas for message one then landed on message two's placeholder; by the time message two's actual response arrived, that slot was already finalised and the deltas were dropped
- Fix adds `awaitingDelta bool` to `chatMessage`: set on placeholder creation, cleared on first delta, checked in the `final` handler to skip finalisaton until real content has started flowing

## Implementation details

Checking `content != ""` was considered but rejected — it would silently mishandle a model response with genuinely empty text. `awaitingDelta` makes the pre-response state explicit and the intent unambiguous.