### PR TITLE
fix: prevent placeholder 'm' appearing in new agent name field

### DIFF
--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -313,7 +313,7 @@ func TestRender_SelectView_CreateFormLabels(t *testing.T) {
 	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
 	defer finishProgram(t, tm)
 
-	waitForContains(t, tm.Output(), "Create new agent", "Name:", "Workspace:", "Tab: switch fields")
+	waitForContains(t, tm.Output(), "Create new agent", "Name (e.g. my-agent):", "Workspace:", "Tab: switch fields")
 }
 
 func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -150,7 +150,7 @@ func validateName(s string) string {
 	return ""
 }
 
-func (m *selectModel) initCreateForm() {
+func (m *selectModel) initCreateForm() tea.Cmd {
 	m.subState = subStateCreate
 	m.focusedField = 0
 	m.creating = false
@@ -159,25 +159,25 @@ func (m *selectModel) initCreateForm() {
 	m.nameValidMsg = "Required"
 
 	m.nameInput = textinput.New()
-	m.nameInput.Placeholder = "my-agent"
 	m.nameInput.CharLimit = 64
-	m.nameInput.Focus()
+	cmd := m.nameInput.Focus()
 
 	m.workInput = textinput.New()
 	m.workInput.Placeholder = "~/.openclaw/workspaces/my-agent"
 	m.workInput.CharLimit = 256
+
+	return cmd
 }
 
-func (m *selectModel) switchFocus() {
+func (m *selectModel) switchFocus() tea.Cmd {
 	if m.focusedField == 0 {
 		m.focusedField = 1
 		m.nameInput.Blur()
-		m.workInput.Focus()
-	} else {
-		m.focusedField = 0
-		m.workInput.Blur()
-		m.nameInput.Focus()
+		return m.workInput.Focus()
 	}
+	m.focusedField = 0
+	m.workInput.Blur()
+	return m.nameInput.Focus()
 }
 
 func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
@@ -259,8 +259,8 @@ func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 		}
 	case "n":
 		if !m.loading && m.err == nil {
-			m.initCreateForm()
-			return m, nil
+			cmd := m.initCreateForm()
+			return m, cmd
 		}
 	case "r":
 		if m.err != nil {
@@ -282,8 +282,7 @@ func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd)
 		return m, nil
 
 	case "tab", "shift+tab":
-		m.switchFocus()
-		return m, nil
+		return m, m.switchFocus()
 
 	case "enter":
 		if m.creating {
@@ -367,7 +366,7 @@ func (m selectModel) viewCreateForm() string {
 	b.WriteString(headerStyle.Render(" Create new agent "))
 	b.WriteString("\n\n")
 
-	b.WriteString("  Name:\n")
+	b.WriteString("  Name (e.g. my-agent):\n")
 	b.WriteString("  " + m.nameInput.View() + "\n")
 	if m.nameValidMsg != "" && m.nameInput.Value() != "" {
 		b.WriteString("  " + errorStyle.Render(m.nameValidMsg) + "\n")


### PR DESCRIPTION
Fixes a visual bug where the letter 'm' appeared to be typed in the name field when opening the create agent form.

## Summary

- Return the `tea.Cmd` from `textinput.Focus()` in `initCreateForm()` and `switchFocus()` so the cursor blink cycle is properly initialised
- Remove the `"my-agent"` placeholder from the name input — the textinput library renders its cursor on the first placeholder character, so with a static (non-blinking) cursor the highlighted 'm' was indistinguishable from actual typed text
- Move the example into the field label: `Name (e.g. my-agent):`

## Implementation details

`textinput.Focus()` returns a blink command that must be dispatched to the bubbletea runtime to start the cursor oscillation. Without it, the cursor is permanently visible in reverse-video on the first character of the placeholder (`'m'` of `"my-agent"`), making it look like the character has been typed. Removing the placeholder means an empty focused field renders a cursor on a space, which is unambiguous.