### PR TITLE
feat: add cancel turn via Escape key and /cancel command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,7 @@ Add or update tests whenever you change behaviour. Focus on core functionality â
 
 Run `make test` before committing. Pushes trigger CI; a failing test blocks review.
 
+## Documentation
+
+When you add or change commands, key bindings, event handlers, or user-visible behaviour, update the relevant file(s) in the `docs/` directory. The docs listed in [Developer docs](#developer-docs) are the canonical reference for each subsystem â€” keep them in sync with the code.
+

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -10,7 +10,7 @@
 | Up arrow (empty input) | Recall last sent message for editing |
 | Tab | Complete slash command or skill name |
 | Page Up / Page Down | Scroll message history |
-| Esc | Return to agent picker (from chat) |
+| Esc | Cancel in-progress response |
 
 Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter is not supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,7 @@ Unrecognised slash commands fall through to a skill-name lookup. If no skill mat
 | Command | What it does |
 |---|---|
 | `/agents` | Return to the agent picker by emitting `goBackMsg{}` |
+| `/cancel` | Cancel the in-progress response (also triggered by Escape) — see [chat-ux.md](chat-ux.md) |
 | `/clear` | Wipe `m.messages` from the local display (does not affect gateway history) |
 | `/compact` | Compact the session context — see [sessions.md](sessions.md#compact-and-reset) |
 | `/config` | Open the preferences view by emitting `showConfigMsg{}` |

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -224,6 +224,14 @@ func (c *Client) ExecResolve(ctx context.Context, id, decision string) (*protoco
 	})
 }
 
+// ChatAbort aborts a running chat turn.
+func (c *Client) ChatAbort(ctx context.Context, sessionKey, runID string) error {
+	return c.gw.ChatAbort(ctx, protocol.ChatAbortParams{
+		SessionKey: sessionKey,
+		RunID:      runID,
+	})
+}
+
 // SessionCompact compacts (summarises) the session context.
 func (c *Client) SessionCompact(ctx context.Context, sessionKey string) error {
 	return c.gw.SessionsCompact(ctx, protocol.SessionsCompactParams{Key: sessionKey})

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -21,7 +21,6 @@ const (
 // AppModel is the root bubbletea model.
 type AppModel struct {
 	state         viewState
-	prevState     viewState // where to return when pressing esc from chat
 	selectModel   selectModel
 	chatModel     chatModel
 	sessionsModel sessionsModel
@@ -105,7 +104,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionSelectedMsg:
 		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs)
 		m.chatModel.setSize(m.width, m.height)
-		m.prevState = viewSessions
 		m.state = viewChat
 		return m, m.chatModel.Init()
 
@@ -117,7 +115,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs)
 		m.chatModel.setSize(m.width, m.height)
-		m.prevState = viewSessions
 		m.state = viewChat
 		return m, m.chatModel.Init()
 
@@ -133,7 +130,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.chatModel = newChatModel(m.client, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs)
 		m.chatModel.setSize(m.width, m.height)
-		m.prevState = viewSelect
 		m.state = viewChat
 		return m, m.chatModel.Init()
 
@@ -150,14 +146,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.state = viewChat
 				return m, nil
 			}
-			if m.state == viewChat {
-				m.state = m.prevState
-				if m.state == viewSessions {
-					return m, m.sessionsModel.Init()
-				}
-				return m, nil
-			}
-			return m, tea.Quit
 		}
 	}
 
@@ -180,7 +168,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// Default agent: use the main session key directly.
 					m.chatModel = newChatModel(m.client, item.sessionKey, item.agent.ID, name, modelID, m.prefs)
 					m.chatModel.setSize(m.width, m.height)
-					m.prevState = viewSelect
 					m.state = viewChat
 					return m, m.chatModel.Init()
 				}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -36,6 +36,7 @@ type chatModel struct {
 	agentID          string
 	agentName        string
 	sending          bool
+	runID            string // active run ID for cancellation
 	pendingMessages  []string
 	width            int
 	height           int
@@ -294,6 +295,11 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	case tea.KeyPressMsg:
 		logEvent("KEY code=%d mod=%v string=%q", msg.Code, msg.Mod, msg.String())
 		switch msg.String() {
+		case "esc":
+			if m.sending {
+				return m, m.cancelTurn()
+			}
+			return m, nil
 		case "tab":
 			text := m.textarea.Value()
 			if strings.HasPrefix(text, "/") && !strings.Contains(text, " ") {
@@ -440,6 +446,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			cmd := m.drainQueue()
 			return m, cmd
 		}
+		m.runID = msg.runID
+		return m, nil
+
+	case chatAbortMsg:
+		if msg.err != nil {
+			logEvent("ABORT_ERROR: %v", msg.err)
+		}
 		return m, nil
 
 	case GatewayEventMsg:
@@ -491,8 +504,40 @@ func (m *chatModel) sendMessage(text string) tea.Cmd {
 	sessionKey := m.sessionKey
 	return func() tea.Msg {
 		idemKey := fmt.Sprintf("lucinate-%d", time.Now().UnixNano())
-		_, err := m.client.ChatSend(context.Background(), sessionKey, text, idemKey)
-		return chatSentMsg{err: err}
+		result, err := m.client.ChatSend(context.Background(), sessionKey, text, idemKey)
+		if err != nil {
+			return chatSentMsg{err: err}
+		}
+		return chatSentMsg{runID: result.RunID}
+	}
+}
+
+// cancelTurn aborts the active turn and clears pending messages.
+func (m *chatModel) cancelTurn() tea.Cmd {
+	if !m.sending || m.runID == "" {
+		m.messages = append(m.messages, chatMessage{role: "system", content: "Nothing to cancel."})
+		m.updateViewport()
+		return nil
+	}
+	cl := m.client
+	sessionKey := m.sessionKey
+	runID := m.runID
+	m.pendingMessages = nil
+	m.runID = ""
+	m.sending = false
+	// Stop streaming immediately so the spinner stops.
+	if len(m.messages) > 0 {
+		last := &m.messages[len(m.messages)-1]
+		if last.role == "assistant" && last.streaming {
+			last.streaming = false
+			last.content += "\n[aborted]"
+		}
+	}
+	m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled."})
+	m.updateViewport()
+	return func() tea.Msg {
+		err := cl.ChatAbort(context.Background(), sessionKey, runID)
+		return chatAbortMsg{err: err}
 	}
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -19,7 +19,7 @@ type pendingConfirmation struct {
 }
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/agents", "/clear", "/commands", "/compact", "/config", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/cancel", "/clear", "/commands", "/compact", "/config", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -68,6 +68,8 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, tea.Quit
 	case "/agents":
 		return true, func() tea.Msg { return goBackMsg{} }
+	case "/cancel":
+		return true, m.cancelTurn()
 	case "/clear":
 		m.messages = nil
 		m.updateViewport()
@@ -132,7 +134,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 )
 
 func newSlashTestModel() *chatModel {
@@ -301,7 +302,7 @@ func TestCompleteSlashCommand(t *testing.T) {
 		{"/he", "/help"},
 		{"/help", "/help"},
 		{"/q", "/quit"},
-		{"/c", "/clear"},
+		{"/c", "/cancel"},
 		{"/e", "/exit"},
 		{"/a", "/agents"},
 		{"/agents", "/agents"},
@@ -435,6 +436,103 @@ func TestSlashCommand_Help_IncludesNewCommands(t *testing.T) {
 		if !strings.Contains(last.content, want) {
 			t.Errorf("/help text missing %q\ngot: %s", want, last.content)
 		}
+	}
+}
+
+func TestSlashCommand_Cancel_WhileSending(t *testing.T) {
+	m := newSlashTestModel()
+	m.sending = true
+	m.runID = "run-1"
+	m.pendingMessages = []string{"queued msg"}
+
+	handled, cmd := m.handleSlashCommand("/cancel")
+	if !handled {
+		t.Fatal("expected /cancel to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd from /cancel while sending")
+	}
+	if len(m.pendingMessages) != 0 {
+		t.Errorf("expected pending queue to be cleared, got %d", len(m.pendingMessages))
+	}
+}
+
+func TestSlashCommand_Cancel_WhileIdle(t *testing.T) {
+	m := newSlashTestModel()
+	m.sending = false
+	initialCount := len(m.messages)
+
+	handled, cmd := m.handleSlashCommand("/cancel")
+	if !handled {
+		t.Fatal("expected /cancel to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from /cancel when not sending")
+	}
+	if len(m.messages) != initialCount+1 {
+		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || last.content != "Nothing to cancel." {
+		t.Errorf("unexpected message: role=%q content=%q", last.role, last.content)
+	}
+}
+
+func TestSlashCommand_Cancel_NoRunID(t *testing.T) {
+	m := newSlashTestModel()
+	m.sending = true
+	m.runID = "" // sending but no runID yet
+
+	handled, cmd := m.handleSlashCommand("/cancel")
+	if !handled {
+		t.Fatal("expected /cancel to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd when sending but no runID")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.content != "Nothing to cancel." {
+		t.Errorf("expected 'Nothing to cancel.', got %q", last.content)
+	}
+}
+
+func TestSlashCommand_Help_IncludesCancel(t *testing.T) {
+	m := newSlashTestModel()
+	m.handleSlashCommand("/help")
+	last := m.messages[len(m.messages)-1]
+	if !strings.Contains(last.content, "/cancel") {
+		t.Errorf("/help text missing /cancel\ngot: %s", last.content)
+	}
+}
+
+func TestEscKey_WhileSending_CancelsTurn(t *testing.T) {
+	m := newSlashTestModel()
+	m.sending = true
+	m.runID = "run-1"
+	m.pendingMessages = []string{"queued"}
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if cmd == nil {
+		t.Fatal("expected a cmd from Escape while sending")
+	}
+	if len(updated.pendingMessages) != 0 {
+		t.Errorf("expected pending queue to be cleared, got %d", len(updated.pendingMessages))
+	}
+}
+
+func TestEscKey_WhileIdle_NoOp(t *testing.T) {
+	m := newSlashTestModel()
+	m.sending = false
+	initialCount := len(m.messages)
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if cmd != nil {
+		t.Error("expected nil cmd from Escape when not sending")
+	}
+	if len(updated.messages) != initialCount {
+		t.Errorf("expected no new messages, got %d (was %d)", len(updated.messages), initialCount)
 	}
 }
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -195,6 +195,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 
 	case "final":
 		logEvent("  FINAL msgContent=%s", string(chatEv.Message))
+		m.runID = ""
 		finalised := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
@@ -227,6 +228,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 
 	case "error":
 		logEvent("  ERROR: %s", chatEv.ErrorMessage)
+		m.runID = ""
 		finalised := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
@@ -244,6 +246,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 
 	case "aborted":
 		logEvent("  ABORTED")
+		m.runID = ""
 		finalised := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -258,6 +258,66 @@ func TestHandleEvent_AbortedAppendsMarker(t *testing.T) {
 	}
 }
 
+func TestHandleEvent_FinalClearsRunID(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.runID = "run1"
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "response", streaming: true},
+	}
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"response"}],"timestamp":123}`)
+	m.handleEvent(makeChatEvent("final", "run1", 3, finalMsg))
+
+	if m.runID != "" {
+		t.Errorf("expected runID to be cleared, got %q", m.runID)
+	}
+}
+
+func TestHandleEvent_ErrorClearsRunID(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.runID = "run1"
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "partial", streaming: true},
+	}
+
+	m.handleEvent(makeChatEventWithError("error", "run1", "something went wrong"))
+
+	if m.runID != "" {
+		t.Errorf("expected runID to be cleared, got %q", m.runID)
+	}
+}
+
+func TestHandleEvent_AbortedClearsRunID(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.runID = "run1"
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "partial", streaming: true},
+	}
+
+	m.handleEvent(makeChatEvent("aborted", "run1", 3, nil))
+
+	if m.runID != "" {
+		t.Errorf("expected runID to be cleared, got %q", m.runID)
+	}
+}
+
+func TestChatSentMsg_StoresRunID(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+
+	updated, _ := m.Update(chatSentMsg{runID: "run-42"})
+
+	if updated.runID != "run-42" {
+		t.Errorf("expected runID %q, got %q", "run-42", updated.runID)
+	}
+}
+
 func TestDrainQueue_SendsFirstPendingMessage(t *testing.T) {
 	m := newTestChatModel()
 	m.sending = true

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -47,6 +47,12 @@ type historyRefreshMsg struct {
 
 // chatSentMsg is returned after a message is sent.
 type chatSentMsg struct {
+	runID string
+	err   error
+}
+
+// chatAbortMsg is returned after a cancel request is sent.
+type chatAbortMsg struct {
 	err error
 }
 


### PR DESCRIPTION
Allow users to cancel an in-progress response using Escape or `/cancel`.

## Summary

- Add `/cancel` slash command and Escape key binding to abort the active turn via the gateway `chat.abort` RPC
- Track the active `runID` from `ChatSendResult` so the correct turn can be targeted for cancellation
- Clear the pending message queue when cancelling to prevent queued messages from being sent after abort
- Remove Escape-from-chat navigation to agent/session picker (use `/agents` and `/sessions` commands instead)
- Remove the now-unused `prevState` field from `AppModel`

## Implementation details

The gateway SDK already supported `ChatAbort` and the TUI already handled `"aborted"` events — this wires up the user-facing trigger. The `runID` is captured from the `ChatSendResult` ack returned by `ChatSend` and cleared on terminal event states (`final`, `error`, `aborted`). If Escape is pressed before the `runID` arrives (between send and ack), the cancel is a no-op with a "Nothing to cancel." message.