### PR TITLE
refactor: remove --history-limit CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ The gateway URL can use `https`, `http`, `wss`, or `ws` schemes. lucinate derive
 
 | Flag | Description |
 |------|-------------|
-| `--history-limit <n>` | Number of messages to load per session (overrides the preference; default 50) |
 | `--version`, `-v` | Print version and exit |
 
 ### 2. Connect and approve the device

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -47,7 +47,7 @@ Stats are loaded on init and refreshed after each message exchange via `loadStat
 
 ## History depth
 
-The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/config` ("History limit") in steps of 10 (range 10–500), or overridden at startup with the `--history-limit` CLI flag. The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
+The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/config` ("History limit") in steps of 10 (range 10–500). The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
 
 See [sessions.md](sessions.md#lifecycle) for how history loading fits into the session lifecycle.
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -32,28 +32,14 @@ type AppModel struct {
 	height        int
 }
 
-// AppOption configures the application model.
-type AppOption func(*AppModel)
-
-// WithHistoryLimit overrides the preference-based history limit.
-func WithHistoryLimit(n int) AppOption {
-	return func(m *AppModel) {
-		m.prefs.HistoryLimit = n
-	}
-}
-
 // NewApp creates the root application model.
-func NewApp(c *client.Client, opts ...AppOption) AppModel {
-	m := AppModel{
+func NewApp(c *client.Client) AppModel {
+	return AppModel{
 		state:       viewSelect,
 		selectModel: newSelectModel(c),
 		client:      c,
 		prefs:       config.LoadPreferences(),
 	}
-	for _, opt := range opts {
-		opt(&m)
-	}
-	return m
 }
 
 func (m AppModel) Init() tea.Cmd {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ func main() {
 	fs := flag.NewFlagSet("lucinate", flag.ExitOnError)
 	showVersion := fs.Bool("version", false, "print version and exit")
 	fs.BoolVar(showVersion, "v", false, "print version and exit")
-	historyLimit := fs.Int("history-limit", 0, "number of messages to load per session (overrides preference)")
 	_ = fs.Parse(os.Args[1:])
 
 	if *showVersion {
@@ -48,11 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var opts []tui.AppOption
-	if *historyLimit > 0 {
-		opts = append(opts, tui.WithHistoryLimit(*historyLimit))
-	}
-	app := tui.NewApp(c, opts...)
+	app := tui.NewApp(c)
 	p := tea.NewProgram(app)
 
 	// Pump gateway events into the bubbletea program from a dedicated goroutine.


### PR DESCRIPTION
History limit is configurable via `/config` within the program, making the CLI flag redundant.

## Summary

- Remove `--history-limit` flag from CLI flag parsing in `main.go`
- Remove `AppOption` type and `WithHistoryLimit` function from `internal/tui/app.go`
- Simplify `NewApp` to accept only the client (preferences are always loaded from persisted config)
- Update docs to remove CLI flag references