### PR TITLE
fix: resolve session key via gateway for default agent

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -150,19 +150,16 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if item.agent.Model != nil {
 					modelID = item.agent.Model.Primary
 				}
-				if item.sessionKey == m.selectModel.mainKey {
-					// Default agent: use the main session key directly.
-					m.chatModel = newChatModel(m.client, item.sessionKey, item.agent.ID, name, modelID, m.prefs)
-					m.chatModel.setSize(m.width, m.height)
-					m.state = viewChat
-					return m, m.chatModel.Init()
-				}
-				// Non-default agent: create a session so the gateway
-				// routes to the correct agent and workspace.
+				// Create/resume a session so the gateway returns
+				// the resolved session key for event filtering.
 				cl := m.client
 				agentID := item.agent.ID
+				createKey := "main"
+				if item.sessionKey == m.selectModel.mainKey {
+					createKey = item.sessionKey
+				}
 				return m, func() tea.Msg {
-					key, err := cl.CreateSession(context.Background(), agentID, "main")
+					key, err := cl.CreateSession(context.Background(), agentID, createKey)
 					return sessionCreatedMsg{
 						sessionKey: key,
 						agentID:    agentID,


### PR DESCRIPTION
Fix default agent receiving no streaming events after session filtering was added in #55.

## Summary

- The default agent bypassed `CreateSession` and used the raw `mainKey` from `AgentsListResult` directly, which doesn't match the resolved `sessionKey` the gateway attaches to chat events
- The session filter added in #55 then silently dropped all delta/final/error events for the default agent
- All agents now go through `CreateSession` to obtain the gateway-resolved session key, unifying the two code paths

## Implementation details

The default agent previously had a fast path that skipped the `sessions.create` RPC and used `mainKey` as the session key. This worked before session filtering existed, but the raw `mainKey` differs from the resolved key the gateway uses on `ChatEvent.SessionKey`. Removing the special case and routing all agents through `CreateSession` ensures the `chatModel.sessionKey` always matches what the gateway emits, at the cost of one additional RPC for the default agent on startup.