### PR TITLE
refactor: isolate device identity per gateway endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ lucinate is a TUI chat client for the OpenClaw gateway, built with bubbletea.
 ### Packages
 
 - **`internal/config`** — Loads `OPENCLAW_GATEWAY_URL` from env/`.env` file. Auto-derives WebSocket URL from HTTP URL (`https` → `wss`).
-- **`internal/client`** — Wraps the `openclaw-go` gateway SDK. Manages WebSocket connection, device identity (`~/.openclaw-go/identity/`), and bridges gateway events to a buffered channel for the TUI event loop.
+- **`internal/client`** — Wraps the `openclaw-go` gateway SDK. Manages WebSocket connection, device identity (`~/.lucinate/identity/<endpoint>/`), and bridges gateway events to a buffered channel for the TUI event loop.
 - **`internal/tui`** — Bubbletea TUI with two views: agent selection (`selectModel`) and chat (`chatModel`). Chat supports streaming responses with markdown rendering via glamour.
 
 ### Flow

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The gateway URL can use `https`, `http`, `wss`, or `ws` schemes. lucinate derive
 lucinate
 ```
 
-On first run, lucinate generates an Ed25519 device identity under `~/.openclaw-go/identity/` and sends a pairing request to the gateway. On the gateway host, run:
+On first run, lucinate generates an Ed25519 device identity under `~/.lucinate/identity/<endpoint>/` (keyed by gateway host) and sends a pairing request to the gateway. On the gateway host, run:
 
 ```sh
 openclaw device list --pending
@@ -170,7 +170,7 @@ The gateway's exec security policy controls which remote commands are allowed. I
 
 lucinate uses the [openclaw-go](https://github.com/a3tai/openclaw-go) SDK for gateway communication. The TUI is built with [Bubble Tea](https://github.com/charmbracelet/bubbletea), [Bubbles](https://github.com/charmbracelet/bubbles), and [Lip Gloss](https://github.com/charmbracelet/lipgloss), with markdown rendered via [Glamour](https://github.com/charmbracelet/glamour).
 
-Device identity (Ed25519 keypair) is stored at `~/.openclaw-go/identity/` and shared with other openclaw-go clients.
+Device identity (Ed25519 keypair and device token) is stored at `~/.lucinate/identity/<endpoint>/`, isolated per gateway endpoint.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Developer docs
 
-This directory contains maintainer-level documentation for repclaw. It covers how the major subsystems are implemented — intended as a starting point when working on a feature area, not as a user guide.
+This directory contains maintainer-level documentation for lucinate. It covers how the major subsystems are implemented — intended as a starting point when working on a feature area, not as a user guide.
 
 ## Index
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Repclaw authenticates to the OpenClaw gateway using device pairing. There are no usernames or passwords — each device generates a persistent Ed25519 keypair and an administrator approves it on the gateway.
+Lucinate authenticates to the OpenClaw gateway using device pairing. There are no usernames or passwords — each device generates a persistent Ed25519 keypair and an administrator approves it on the gateway.
 
 ## Configuration
 
@@ -10,21 +10,21 @@ The gateway URL is required and read from the environment:
 OPENCLAW_GATEWAY_URL=https://your-gateway-host
 ```
 
-This can be set in the shell or in a `.env` file in the working directory. Repclaw derives the WebSocket endpoint automatically by replacing `https://` with `wss://` (or `http://` with `ws://`) and appending `/ws`. Both values are held in `internal/config/config.go` as `Config.GatewayURL` and `Config.WSURL`.
+This can be set in the shell or in a `.env` file in the working directory. Lucinate derives the WebSocket endpoint automatically by replacing `https://` with `wss://` (or `http://` with `ws://`) and appending `/ws`. Both values are held in `internal/config/config.go` as `Config.GatewayURL` and `Config.WSURL`.
 
 ## Device identity
 
-On first run, `identity.Store.LoadOrGenerate()` creates an Ed25519 keypair in `~/.openclaw-go/identity/`. This directory is shared with other openclaw-go clients on the same machine. The keypair acts as a stable device identity across restarts.
+On first run, `identity.Store.LoadOrGenerate()` creates an Ed25519 keypair under `~/.lucinate/identity/<endpoint>/`, where `<endpoint>` is derived from the gateway URL's host and port (e.g. `gateway.example.com` or `localhost_8789`). Each gateway endpoint gets its own keypair and device token, so switching `OPENCLAW_GATEWAY_URL` does not overwrite existing credentials. The keypair acts as a stable device identity across restarts.
 
 ## First-run pairing flow
 
-1. Run `repclaw` — the client connects to the gateway with the device identity but no token. The gateway registers a pending pairing request.
+1. Run `lucinate` — the client connects to the gateway with the device identity but no token. The gateway registers a pending pairing request.
 2. On the gateway host, an administrator approves the device:
    ```
    openclaw device list --pending
    openclaw device approve <device-id>
    ```
-3. Restart `repclaw`. The client reconnects; the gateway issues a device token, which is saved to `~/.openclaw-go/identity/` via `client.store.SaveDeviceToken()`.
+3. Restart `lucinate`. The client reconnects; the gateway issues a device token, which is saved to the endpoint's identity directory via `client.store.SaveDeviceToken()`.
 
 The save is non-fatal — if it fails, a warning is logged but the session continues. On subsequent runs the saved token is loaded and presented on connect.
 
@@ -33,7 +33,7 @@ The save is non-fatal — if it fails, a warning is logged but the session conti
 ## Subsequent runs
 
 1. Load `OPENCLAW_GATEWAY_URL` from environment.
-2. Load the Ed25519 identity and stored device token from `~/.openclaw-go/identity/`.
+2. Load the Ed25519 identity and stored device token from `~/.lucinate/identity/<endpoint>/`.
 3. Open a WebSocket connection to the gateway with the identity and token. The gateway SDK (`github.com/a3tai/openclaw-go`) attaches the token to all API calls.
 4. On a successful `Hello` handshake, any refreshed token is saved back to disk.
 5. Proceed to the agent picker.
@@ -48,5 +48,5 @@ The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOpera
 
 | Path | Contents |
 |---|---|
-| `~/.openclaw-go/identity/` | Ed25519 keypair and device token (shared with other openclaw-go clients) |
-| `~/.repclaw/config.json` | UI preferences — not authentication-related |
+| `~/.lucinate/identity/<endpoint>/` | Ed25519 keypair and device token (per gateway endpoint) |
+| `~/.lucinate/config.json` | UI preferences — not authentication-related |

--- a/docs/shell-execution.md
+++ b/docs/shell-execution.md
@@ -1,6 +1,6 @@
 # Shell execution
 
-Repclaw supports running shell commands directly from the chat input using a prefix convention:
+Lucinate supports running shell commands directly from the chat input using a prefix convention:
 
 | Prefix | Where it runs |
 |---|---|

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/a3tai/openclaw-go/gateway"
 	"github.com/a3tai/openclaw-go/identity"
@@ -26,12 +28,11 @@ type Client struct {
 
 // New creates a new client from the given config.
 func New(cfg *config.Config) (*Client, error) {
-	home, err := os.UserHomeDir()
+	identityDir, err := identityDirForEndpoint(cfg.GatewayURL)
 	if err != nil {
-		return nil, fmt.Errorf("user home dir: %w", err)
+		return nil, fmt.Errorf("identity dir: %w", err)
 	}
 
-	identityDir := filepath.Join(home, ".openclaw-go", "identity")
 	store, err := identity.NewStore(identityDir)
 	if err != nil {
 		return nil, fmt.Errorf("identity store: %w", err)
@@ -42,6 +43,42 @@ func New(cfg *config.Config) (*Client, error) {
 		cfg:    cfg,
 		store:  store,
 	}, nil
+}
+
+// identityDirForEndpoint returns a per-endpoint identity directory under
+// ~/.lucinate/identity/<host_port>/.  This keeps keys and device tokens
+// isolated per gateway so switching endpoints doesn't overwrite them.
+func identityDirForEndpoint(gatewayURL string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home dir: %w", err)
+	}
+
+	u, err := url.Parse(gatewayURL)
+	if err != nil {
+		return "", fmt.Errorf("parse gateway URL: %w", err)
+	}
+
+	key := sanitiseHost(u.Host)
+	if key == "" {
+		return "", fmt.Errorf("gateway URL has no host: %s", gatewayURL)
+	}
+
+	return filepath.Join(home, ".lucinate", "identity", key), nil
+}
+
+// sanitiseHost converts a host or host:port into a filesystem-safe directory
+// name.  Colons (from the port separator) are replaced with underscores; any
+// other characters that are not alphanumeric, '.', '-', or '_' are dropped.
+func sanitiseHost(host string) string {
+	host = strings.ReplaceAll(host, ":", "_")
+	var b strings.Builder
+	for _, r := range host {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // Connect establishes a WebSocket connection to the gateway.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitiseHost(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"localhost:8789", "localhost_8789"},
+		{"gateway.example.com", "gateway.example.com"},
+		{"gateway.example.com:443", "gateway.example.com_443"},
+		{"my-host", "my-host"},
+		{"host/with/slashes", "hostwithslashes"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitiseHost(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitiseHost(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIdentityDirForEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		gatewayURL string
+		wantSuffix string
+		wantErr    bool
+	}{
+		{
+			name:       "https with default port",
+			gatewayURL: "https://gateway.example.com",
+			wantSuffix: filepath.Join(".lucinate", "identity", "gateway.example.com"),
+		},
+		{
+			name:       "http with explicit port",
+			gatewayURL: "http://localhost:8789",
+			wantSuffix: filepath.Join(".lucinate", "identity", "localhost_8789"),
+		},
+		{
+			name:       "different endpoints produce different dirs",
+			gatewayURL: "https://other.example.com",
+			wantSuffix: filepath.Join(".lucinate", "identity", "other.example.com"),
+		},
+		{
+			name:       "no host",
+			gatewayURL: "file:///tmp/foo",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := identityDirForEndpoint(tt.gatewayURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !filepath.IsAbs(got) {
+				t.Errorf("expected absolute path, got %q", got)
+			}
+			suffix := filepath.Join(".lucinate", "identity")
+			if got[len(got)-len(tt.wantSuffix):] != tt.wantSuffix {
+				t.Errorf("got %q, want suffix %q", got, tt.wantSuffix)
+			}
+			_ = suffix
+		})
+	}
+}


### PR DESCRIPTION
Store device identity under `~/.lucinate/identity/<endpoint>/` instead of the shared `~/.openclaw-go/identity/` directory, allowing multiple gateway endpoints without credential conflicts.

## Summary

- Move identity storage from shared `~/.openclaw-go/identity/` to per-app `~/.lucinate/identity/<endpoint>/`
- Derive endpoint key from the gateway URL host and port (e.g. `gateway.example.com`, `localhost_8789`)
- Switching `OPENCLAW_GATEWAY_URL` now preserves each endpoint's keypair and device token
- Update all docs to reflect new identity path and replace stale `repclaw` references with `lucinate`
- Add unit tests for host sanitisation and identity directory derivation