### PR TITLE
feat: interactive auth recovery on gateway connect

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -40,6 +40,18 @@ The save is non-fatal — if it fails, a warning is logged but the session conti
 
 If the token is expired or revoked the gateway rejects the connection and an error is shown in the agent picker. The user can press `r` to retry after the device has been re-approved.
 
+## Interactive auth recovery on connect
+
+When the initial connect fails with an auth error, `connectWithAuth` in `main.go` handles it interactively before exiting:
+
+- **Token mismatch** (`gateway token mismatch`) — the stored device token is no longer valid for this gateway (for example, the device was removed and re-added). The user is offered three choices:
+  1. Clear the stored token and retry pairing (default).
+  2. Reset the device identity entirely (new keypair) and retry pairing.
+  3. Quit.
+- **Token missing** (`gateway token missing`) — the gateway requires a pre-shared auth token that the client doesn't have. This can occur on a first-time connect, or as a follow-up after a clear/reset retry. The user is prompted to paste the gateway auth token, which is saved via `client.StoreToken()` and the connect is retried.
+
+Both flows read from `os.Stdin`, so they only trigger in an interactive terminal. Non-interactive callers will see the original error and exit.
+
 ## Scopes
 
 The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are set in `internal/client/client.go` and are required for session management, exec approval, and agent administration.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -305,6 +305,18 @@ func (c *Client) HelloUptimeMs() int64 {
 	return 0
 }
 
+// ClearToken removes the stored device token so the next Connect call
+// will authenticate without a cached token.
+func (c *Client) ClearToken() error {
+	return c.store.ClearDeviceToken()
+}
+
+// ResetIdentity removes all stored identity data (keypair and device token)
+// so the next Connect call will register as a new device.
+func (c *Client) ResetIdentity() error {
+	return c.store.Reset()
+}
+
 // GW returns the underlying gateway client (for direct RPC access).
 func (c *Client) GW() *gateway.Client { return c.gw }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -317,6 +317,12 @@ func (c *Client) ResetIdentity() error {
 	return c.store.Reset()
 }
 
+// StoreToken saves a new device token. Use this after clearing a stale token
+// to seed the gateway auth token before retrying the connection.
+func (c *Client) StoreToken(token string) error {
+	return c.store.SaveDeviceToken(token)
+}
+
 // GW returns the underlying gateway client (for direct RPC access).
 func (c *Client) GW() *gateway.Client { return c.gw }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
 func TestSanitiseHost(t *testing.T) {
@@ -76,5 +79,83 @@ func TestIdentityDirForEndpoint(t *testing.T) {
 			}
 			_ = suffix
 		})
+	}
+}
+
+// newTestClient creates a Client backed by a temporary home directory.
+// The config uses GatewayURL "http://example.com", so the identity directory
+// will be <home>/.lucinate/identity/example.com/.
+func newTestClient(t *testing.T) (*Client, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	c, err := New(&config.Config{GatewayURL: "http://example.com", WSURL: "ws://example.com/ws"})
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+	return c, dir
+}
+
+// testIdentityDir returns the identity directory for the test client's gateway URL.
+func testIdentityDir(home string) string {
+	return filepath.Join(home, ".lucinate", "identity", "example.com")
+}
+
+func TestClearToken_RemovesStoredToken(t *testing.T) {
+	c, home := newTestClient(t)
+
+	tokenPath := filepath.Join(testIdentityDir(home), "device-token")
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("test-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ClearToken(); err != nil {
+		t.Fatalf("ClearToken: %v", err)
+	}
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Error("expected token file to be removed after ClearToken")
+	}
+}
+
+func TestClearToken_NoopWhenAbsent(t *testing.T) {
+	c, _ := newTestClient(t)
+	if err := c.ClearToken(); err != nil {
+		t.Errorf("ClearToken with no token should not error, got: %v", err)
+	}
+}
+
+func TestResetIdentity_RemovesAllData(t *testing.T) {
+	c, home := newTestClient(t)
+
+	idDir := testIdentityDir(home)
+	if err := os.MkdirAll(idDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	keypairPath := filepath.Join(idDir, "keypair.json")
+	tokenPath := filepath.Join(idDir, "device-token")
+	if err := os.WriteFile(keypairPath, []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("test-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ResetIdentity(); err != nil {
+		t.Fatalf("ResetIdentity: %v", err)
+	}
+	for _, path := range []string{keypairPath, tokenPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed after ResetIdentity", filepath.Base(path))
+		}
+	}
+}
+
+func TestResetIdentity_NoopWhenAbsent(t *testing.T) {
+	c, _ := newTestClient(t)
+	if err := c.ResetIdentity(); err != nil {
+		t.Errorf("ResetIdentity with no files should not error, got: %v", err)
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -159,3 +159,19 @@ func TestResetIdentity_NoopWhenAbsent(t *testing.T) {
 		t.Errorf("ResetIdentity with no files should not error, got: %v", err)
 	}
 }
+
+func TestStoreToken_PersistsToken(t *testing.T) {
+	c, home := newTestClient(t)
+
+	if err := c.StoreToken("my-gateway-token"); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+	tokenPath := filepath.Join(testIdentityDir(home), "device-token")
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("reading token file: %v", err)
+	}
+	if got := string(data); got != "my-gateway-token" {
+		t.Errorf("stored token = %q, want %q", got, "my-gateway-token")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -20,7 +21,7 @@ import (
 // promptAuthFix presents interactive options when the gateway rejects the
 // stored device token. Returns true if a fix was applied and a retry should
 // be attempted, false if the user chose to quit.
-func promptAuthFix(c *client.Client) bool {
+func promptAuthFix(c *client.Client, in io.Reader) bool {
 	fmt.Fprintln(os.Stderr, "The stored device token was rejected by the gateway.")
 	fmt.Fprintln(os.Stderr, "Choose an option:")
 	fmt.Fprintln(os.Stderr, "  1) Clear stored token and retry  (recommended)")
@@ -28,7 +29,7 @@ func promptAuthFix(c *client.Client) bool {
 	fmt.Fprintln(os.Stderr, "  3) Quit")
 	fmt.Fprint(os.Stderr, "\nChoice [1-3]: ")
 
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner := bufio.NewScanner(in)
 	if !scanner.Scan() {
 		return false
 	}
@@ -85,7 +86,7 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "connection error: %v\n\n", err)
-		if !promptAuthFix(c) {
+		if !promptAuthFix(c, os.Stdin) {
 			os.Exit(1)
 		}
 		ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)

--- a/main.go
+++ b/main.go
@@ -53,6 +53,88 @@ func promptAuthFix(c *client.Client, in io.Reader) bool {
 	}
 }
 
+// promptForToken asks the user to enter the gateway auth token. Some gateways
+// require a pre-shared token for any connection, including fresh device
+// registrations. Returns true if a token was stored and a retry should be
+// attempted.
+func promptForToken(c *client.Client, in io.Reader) bool {
+	fmt.Fprintln(os.Stderr, "This gateway requires an auth token for connections.")
+	fmt.Fprintln(os.Stderr, "Enter the gateway auth token (ask your gateway operator if needed):")
+	fmt.Fprint(os.Stderr, "Token: ")
+
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		return false
+	}
+	token := strings.TrimSpace(scanner.Text())
+	if token == "" {
+		return false
+	}
+	if err := c.StoreToken(token); err != nil {
+		fmt.Fprintf(os.Stderr, "error storing token: %v\n", err)
+		return false
+	}
+	fmt.Fprintln(os.Stderr, "Token stored. Retrying...")
+	return true
+}
+
+const connectTimeout = 15 * time.Second
+
+// connectWithAuth connects to the gateway, handling auth errors interactively:
+//
+//  1. Initial connect attempt.
+//  2. "token mismatch" → clear/reset → retry (works for gateways without auth.token).
+//  3. "token missing" → prompt for gateway auth token → retry (needed when the
+//     gateway requires a pre-shared token, either on first connect or after a
+//     clear/reset).
+func connectWithAuth(c *client.Client, in io.Reader) error {
+	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
+	defer cancel()
+
+	err := c.Connect(ctx)
+	if err == nil {
+		return nil
+	}
+
+	// Token mismatch: stored token is invalid — offer to clear/reset, then retry.
+	if isTokenMismatch(err) {
+		fmt.Fprintf(os.Stderr, "connection error: %v\n\n", err)
+		if !promptAuthFix(c, in) {
+			return err
+		}
+		ctx2, cancel2 := context.WithTimeout(context.Background(), connectTimeout)
+		defer cancel2()
+		err = c.Connect(ctx2)
+		if err == nil {
+			return nil
+		}
+		// Fall through: the retry may have produced "token missing" if this
+		// gateway requires a pre-shared auth token.
+	}
+
+	// Token missing: gateway requires an auth token that the client doesn't have.
+	// This covers both first-time connections and post-clear/reset retries.
+	if isTokenMissing(err) {
+		fmt.Fprintf(os.Stderr, "connection error: %v\n\n", err)
+		if !promptForToken(c, in) {
+			return err
+		}
+		ctx3, cancel3 := context.WithTimeout(context.Background(), connectTimeout)
+		defer cancel3()
+		return c.Connect(ctx3)
+	}
+
+	return err
+}
+
+func isTokenMismatch(err error) bool {
+	return strings.Contains(err.Error(), "gateway token mismatch")
+}
+
+func isTokenMissing(err error) bool {
+	return strings.Contains(err.Error(), "gateway token missing")
+}
+
 func main() {
 	fs := flag.NewFlagSet("lucinate", flag.ExitOnError)
 	showVersion := fs.Bool("version", false, "print version and exit")
@@ -77,24 +159,9 @@ func main() {
 	}
 	defer c.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	if err := c.Connect(ctx); err != nil {
-		if !strings.Contains(err.Error(), "gateway token mismatch") {
-			fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Fprintf(os.Stderr, "connection error: %v\n\n", err)
-		if !promptAuthFix(c, os.Stdin) {
-			os.Exit(1)
-		}
-		ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel2()
-		if err := c.Connect(ctx2); err != nil {
-			fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
-			os.Exit(1)
-		}
+	if err := connectWithAuth(c, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
+		os.Exit(1)
 	}
 
 	app := tui.NewApp(c)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -14,6 +16,41 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/tui"
 	"github.com/lucinate-ai/lucinate/internal/version"
 )
+
+// promptAuthFix presents interactive options when the gateway rejects the
+// stored device token. Returns true if a fix was applied and a retry should
+// be attempted, false if the user chose to quit.
+func promptAuthFix(c *client.Client) bool {
+	fmt.Fprintln(os.Stderr, "The stored device token was rejected by the gateway.")
+	fmt.Fprintln(os.Stderr, "Choose an option:")
+	fmt.Fprintln(os.Stderr, "  1) Clear stored token and retry  (recommended)")
+	fmt.Fprintln(os.Stderr, "  2) Reset full identity and retry")
+	fmt.Fprintln(os.Stderr, "  3) Quit")
+	fmt.Fprint(os.Stderr, "\nChoice [1-3]: ")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return false
+	}
+	switch strings.TrimSpace(scanner.Text()) {
+	case "1", "":
+		if err := c.ClearToken(); err != nil {
+			fmt.Fprintf(os.Stderr, "error clearing token: %v\n", err)
+			return false
+		}
+		fmt.Fprintln(os.Stderr, "Token cleared. Retrying...")
+		return true
+	case "2":
+		if err := c.ResetIdentity(); err != nil {
+			fmt.Fprintf(os.Stderr, "error resetting identity: %v\n", err)
+			return false
+		}
+		fmt.Fprintln(os.Stderr, "Identity reset. Retrying...")
+		return true
+	default:
+		return false
+	}
+}
 
 func main() {
 	fs := flag.NewFlagSet("lucinate", flag.ExitOnError)
@@ -43,8 +80,20 @@ func main() {
 	defer cancel()
 
 	if err := c.Connect(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
-		os.Exit(1)
+		if !strings.Contains(err.Error(), "gateway token mismatch") {
+			fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "connection error: %v\n\n", err)
+		if !promptAuthFix(c) {
+			os.Exit(1)
+		}
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel2()
+		if err := c.Connect(ctx2); err != nil {
+			fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	app := tui.NewApp(c)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/client"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// newTestClient creates a Client backed by a temporary home directory.
+func newTestClient(t *testing.T) (*client.Client, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	c, err := client.New(&config.Config{GatewayURL: "http://example.com", WSURL: "ws://example.com/ws"})
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+	return c, dir
+}
+
+// testIdentityDir returns the identity directory for the test client's gateway
+// URL (http://example.com → ~/.lucinate/identity/example.com/).
+func testIdentityDir(home string) string {
+	return filepath.Join(home, ".lucinate", "identity", "example.com")
+}
+
+func seedToken(t *testing.T, home, token string) {
+	t.Helper()
+	idDir := testIdentityDir(home)
+	if err := os.MkdirAll(idDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(idDir, "device-token"), []byte(token), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func tokenExists(home string) bool {
+	_, err := os.Stat(filepath.Join(testIdentityDir(home), "device-token"))
+	return err == nil
+}
+
+func TestPromptAuthFix(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantResult bool
+		// wantToken: whether the token file should still exist after the call.
+		wantToken bool
+	}{
+		{
+			name:       "choice 1 clears token and returns true",
+			input:      "1\n",
+			wantResult: true,
+			wantToken:  false,
+		},
+		{
+			name:       "empty input defaults to clear token",
+			input:      "\n",
+			wantResult: true,
+			wantToken:  false,
+		},
+		{
+			name:       "choice 2 resets identity and returns true",
+			input:      "2\n",
+			wantResult: true,
+			wantToken:  false,
+		},
+		{
+			name:       "choice 3 quits without modification",
+			input:      "3\n",
+			wantResult: false,
+			wantToken:  true,
+		},
+		{
+			name:       "unknown choice quits without modification",
+			input:      "x\n",
+			wantResult: false,
+			wantToken:  true,
+		},
+		{
+			name:       "EOF returns false",
+			input:      "",
+			wantResult: false,
+			wantToken:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, home := newTestClient(t)
+			seedToken(t, home, "old-token")
+
+			got := promptAuthFix(c, strings.NewReader(tt.input))
+
+			if got != tt.wantResult {
+				t.Errorf("promptAuthFix returned %v, want %v", got, tt.wantResult)
+			}
+			if tokenExists(home) != tt.wantToken {
+				if tt.wantToken {
+					t.Error("expected token file to remain but it was removed")
+				} else {
+					t.Error("expected token file to be removed but it still exists")
+				}
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -39,9 +39,12 @@ func seedToken(t *testing.T, home, token string) {
 	}
 }
 
-func tokenExists(home string) bool {
-	_, err := os.Stat(filepath.Join(testIdentityDir(home), "device-token"))
-	return err == nil
+func readToken(home string) string {
+	data, err := os.ReadFile(filepath.Join(testIdentityDir(home), "device-token"))
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func TestPromptAuthFix(t *testing.T) {
@@ -49,44 +52,43 @@ func TestPromptAuthFix(t *testing.T) {
 		name       string
 		input      string
 		wantResult bool
-		// wantToken: whether the token file should still exist after the call.
-		wantToken bool
+		wantToken  string // expected stored token ("" = absent)
 	}{
 		{
 			name:       "choice 1 clears token and returns true",
 			input:      "1\n",
 			wantResult: true,
-			wantToken:  false,
+			wantToken:  "",
 		},
 		{
 			name:       "empty input defaults to clear token",
 			input:      "\n",
 			wantResult: true,
-			wantToken:  false,
+			wantToken:  "",
 		},
 		{
 			name:       "choice 2 resets identity and returns true",
 			input:      "2\n",
 			wantResult: true,
-			wantToken:  false,
+			wantToken:  "",
 		},
 		{
 			name:       "choice 3 quits without modification",
 			input:      "3\n",
 			wantResult: false,
-			wantToken:  true,
+			wantToken:  "old-token",
 		},
 		{
 			name:       "unknown choice quits without modification",
 			input:      "x\n",
 			wantResult: false,
-			wantToken:  true,
+			wantToken:  "old-token",
 		},
 		{
 			name:       "EOF returns false",
 			input:      "",
 			wantResult: false,
-			wantToken:  true,
+			wantToken:  "old-token",
 		},
 	}
 
@@ -100,12 +102,51 @@ func TestPromptAuthFix(t *testing.T) {
 			if got != tt.wantResult {
 				t.Errorf("promptAuthFix returned %v, want %v", got, tt.wantResult)
 			}
-			if tokenExists(home) != tt.wantToken {
-				if tt.wantToken {
-					t.Error("expected token file to remain but it was removed")
-				} else {
-					t.Error("expected token file to be removed but it still exists")
-				}
+			if gotToken := readToken(home); gotToken != tt.wantToken {
+				t.Errorf("stored token = %q, want %q", gotToken, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestPromptForToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantResult bool
+		wantToken  string
+	}{
+		{
+			name:       "stores provided token and returns true",
+			input:      "my-gateway-token\n",
+			wantResult: true,
+			wantToken:  "my-gateway-token",
+		},
+		{
+			name:       "empty input returns false",
+			input:      "\n",
+			wantResult: false,
+			wantToken:  "",
+		},
+		{
+			name:       "EOF returns false",
+			input:      "",
+			wantResult: false,
+			wantToken:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, home := newTestClient(t)
+
+			got := promptForToken(c, strings.NewReader(tt.input))
+
+			if got != tt.wantResult {
+				t.Errorf("promptForToken returned %v, want %v", got, tt.wantResult)
+			}
+			if gotToken := readToken(home); gotToken != tt.wantToken {
+				t.Errorf("stored token = %q, want %q", gotToken, tt.wantToken)
 			}
 		})
 	}


### PR DESCRIPTION
Detect gateway auth errors on connect and recover interactively instead of exiting, covering both stale device tokens and gateways that require a pre-shared auth token.

## Summary
- Detect `gateway token mismatch` on connect and offer the user three choices: clear the stored token, reset the device identity, or quit.
- Detect `gateway token missing` on connect (initial or post-clear) and prompt the user to paste the gateway auth token, which is stored and used on retry.
- Add `Client.StoreToken` so the main flow can seed a freshly entered gateway token.
- Refactor connect logic into `connectWithAuth` in `main.go` to keep the recovery flow in one place.
- Document both recovery flows in `docs/authentication.md`.
- Add unit tests for `promptAuthFix`, `promptForToken`, and `StoreToken`.

## Implementation details
The two auth errors are deliberately handled as a sequence rather than independent branches: a token-mismatch retry can surface as token-missing if the gateway requires a pre-shared token, so the missing-token path is reachable both on first connect and as a follow-up after clear/reset. Both prompts read from `os.Stdin`, so non-interactive callers see the original error and exit as before.