### PR TITLE
fix: skip empty skills when building catalog block

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -548,8 +548,12 @@ func (m *chatModel) withSkillCatalog(text string) string {
 	if m.skillCatalogSent || len(m.skills) == 0 {
 		return text
 	}
+	catalog := skillCatalogBlock(m.skills)
+	if catalog == "" {
+		return text
+	}
 	m.skillCatalogSent = true
-	return skillCatalogBlock(m.skills) + "\n" + text
+	return catalog + "\n" + text
 }
 
 // drainQueue sends the next queued message if any are pending.

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -132,13 +132,14 @@ func prefixAllLines(text string) string {
 // Every line is prefixed with "System:" so that stripSystemLines removes the
 // entire block from display after a history refresh.
 func skillCatalogBlock(skills []agentSkill) string {
-	if len(skills) == 0 {
+	var entries strings.Builder
+	for _, s := range skills {
+		if s.Name != "" {
+			entries.WriteString(fmt.Sprintf("  - %s: %s\n", s.Name, s.Description))
+		}
+	}
+	if entries.Len() == 0 {
 		return ""
 	}
-	var b strings.Builder
-	b.WriteString("Available agent skills (activate with /skill-name):\n")
-	for _, s := range skills {
-		b.WriteString(fmt.Sprintf("  - %s: %s\n", s.Name, s.Description))
-	}
-	return prefixAllLines(b.String())
+	return prefixAllLines("Available agent skills (activate with /skill-name):\n" + entries.String())
 }

--- a/internal/tui/skills_test.go
+++ b/internal/tui/skills_test.go
@@ -71,6 +71,16 @@ func TestSkillCatalogBlock_Empty(t *testing.T) {
 	}
 }
 
+func TestSkillCatalogBlock_EmptyNames(t *testing.T) {
+	skills := []agentSkill{
+		{Name: "", Description: "no name"},
+		{Name: "", Description: "also no name"},
+	}
+	if block := skillCatalogBlock(skills); block != "" {
+		t.Errorf("expected empty block when all skills have empty names, got %q", block)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }
@@ -188,6 +198,19 @@ func TestWithSkillCatalog_NoSkills(t *testing.T) {
 	result := m.withSkillCatalog("hello")
 	if result != "hello" {
 		t.Errorf("expected unmodified text with no skills, got %q", result)
+	}
+}
+
+func TestWithSkillCatalog_EmptyCatalog(t *testing.T) {
+	m := newSlashTestModel()
+	// Skills with empty names produce an empty catalog block.
+	m.skills = []agentSkill{{Name: "", Description: "no name"}}
+	result := m.withSkillCatalog("hello")
+	if result != "hello" {
+		t.Errorf("expected unmodified text when catalog is empty, got %q", result)
+	}
+	if m.skillCatalogSent {
+		t.Error("skillCatalogSent should not be set when catalog is empty")
 	}
 }
 


### PR DESCRIPTION
Avoid sending an empty agent skills catalog when discovered skills have no usable names.

## Summary
- Filter out skills with empty names when constructing the catalog block
- Return early from `withSkillCatalog` when the catalog is empty so `skillCatalogSent` is not prematurely flipped
- Add tests covering the empty-name and empty-catalog cases