### PR TITLE
feat(tui): stack message prefix above body in narrow terminals

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -617,8 +617,13 @@ func (m *chatModel) setSize(w, h int) {
 	m.width = w
 	m.height = h
 
-	// Recreate the glamour renderer with the new wrap width.
-	wrapWidth := w - 4 - m.prefixWidth() // contentWidth minus aligned prefix
+	// Recreate the glamour renderer with the new wrap width. In narrow mode the
+	// body uses the full content width (no inline prefix), so size accordingly.
+	contentWidth := w - 4
+	wrapWidth := contentWidth - m.prefixWidth()
+	if m.narrowLayout() {
+		wrapWidth = contentWidth
+	}
 	if wrapWidth < 20 {
 		wrapWidth = 20
 	}
@@ -628,6 +633,15 @@ func (m *chatModel) setSize(w, h int) {
 	)
 	if err == nil {
 		m.renderer = renderer
+		// Re-render any previously glamour-rendered messages so markdown
+		// reflows when the terminal is resized.
+		for i := range m.messages {
+			if m.messages[i].rendered && m.messages[i].raw != "" {
+				if out, rerr := m.renderer.Render(m.messages[i].raw); rerr == nil {
+					m.messages[i].content = strings.TrimSpace(out)
+				}
+			}
+		}
 	}
 
 	headerH := 1

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -80,13 +80,15 @@ func fetchHistory(cl *client.Client, sessionKey string, renderer *glamour.TermRe
 			}
 		}
 		rendered := false
+		raw := ""
 		if role == "assistant" && renderer != nil && looksLikeMarkdown(text) {
 			if out, err := renderer.Render(text); err == nil {
+				raw = text
 				text = strings.TrimSpace(out)
 				rendered = true
 			}
 		}
-		msgs = append(msgs, chatMessage{role: role, content: text, thinking: thinking, rendered: rendered})
+		msgs = append(msgs, chatMessage{role: role, content: text, raw: raw, thinking: thinking, rendered: rendered})
 	}
 	return msgs, nil
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -10,6 +10,7 @@ import (
 type chatMessage struct {
 	role          string // "user", "assistant", "system", or "separator"
 	content       string
+	raw           string // original markdown source when rendered is true; used to re-render on resize
 	thinking      string // reasoning/intermediate thought content from the model
 	streaming     bool
 	awaitingDelta bool // true for the pre-response spinner placeholder, before any delta arrives

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -21,19 +22,12 @@ func (m *chatModel) updateViewport() {
 			b.WriteString(statusStyle.Render(sep))
 
 		case "user":
-			label := m.prefixLabel("You")
-			prefix := userPrefixStyle.Render(label)
-			prefixIndent := strings.Repeat(" ", len(label))
-			b.WriteString(prefix)
-			body := wordWrap(msg.content, contentWidth-len(label))
+			prefixIndent, wrapWidth := m.writePrefix(&b, userPrefixStyle, "You")
+			body := wordWrap(msg.content, wrapWidth)
 			b.WriteString(indentMultiline(body, prefixIndent))
 
 		case "assistant":
-			label := m.prefixLabel(m.agentName)
-			prefix := assistantPrefixStyle.Render(label)
-			prefixIndent := strings.Repeat(" ", len(label))
-			b.WriteString(prefix)
-			wrapWidth := contentWidth - len(label)
+			prefixIndent, wrapWidth := m.writePrefix(&b, assistantPrefixStyle, m.agentName)
 			if msg.errMsg != "" {
 				body := wordWrap(msg.errMsg, wrapWidth)
 				b.WriteString(errorStyle.Render(indentMultiline(body, prefixIndent)))
@@ -52,7 +46,13 @@ func (m *chatModel) updateViewport() {
 					b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
 				} else if msg.rendered {
 					// Glamour-rendered content is already wrapped and contains ANSI codes.
-					b.WriteString(indentMultiline(msg.content, prefixIndent))
+					content := msg.content
+					if m.narrowLayout() {
+						// In stacked layout, strip glamour's left margin from each
+						// line so the body sits flush under the prefix.
+						content = stripLeadingSpacesPerLine(content)
+					}
+					b.WriteString(indentMultiline(content, prefixIndent))
 				} else {
 					body := wordWrap(msg.content, wrapWidth)
 					b.WriteString(indentMultiline(body, prefixIndent))
@@ -72,11 +72,8 @@ func (m *chatModel) updateViewport() {
 	// shadows to distinguish them from confirmed messages.
 	for _, text := range m.pendingMessages {
 		b.WriteString("\n")
-		label := m.prefixLabel("You")
-		prefix := pendingPrefixStyle.Render(label)
-		prefixIndent := strings.Repeat(" ", len(label))
-		b.WriteString(prefix)
-		body := wordWrap(text, contentWidth-len(label))
+		prefixIndent, wrapWidth := m.writePrefix(&b, pendingPrefixStyle, "You")
+		body := wordWrap(text, wrapWidth)
 		b.WriteString(pendingBodyStyle.Render(indentMultiline(body, prefixIndent)))
 	}
 
@@ -91,6 +88,32 @@ func (m *chatModel) updateViewport() {
 
 	m.viewport.SetContent(content)
 	m.viewport.GotoBottom()
+}
+
+// narrowBodyMinWidth is the minimum body column width below which the inline
+// prefix layout flips to a stacked layout with the prefix on its own line.
+const narrowBodyMinWidth = 60
+
+// narrowLayout reports whether the viewport is too narrow for an inline
+// prefix to leave enough room for the message body.
+func (m *chatModel) narrowLayout() bool {
+	return (m.width - 4) - m.prefixWidth() < narrowBodyMinWidth
+}
+
+// writePrefix renders the message prefix into b and returns the per-continuation
+// indent and the wrap width for the message body. In narrow mode the prefix is
+// followed by a literal newline (written outside the styled Render call to avoid
+// lipgloss right-padding the trailing empty line) so the body stacks beneath.
+func (m *chatModel) writePrefix(b *strings.Builder, style lipgloss.Style, name string) (indent string, wrapWidth int) {
+	contentWidth := m.width - 4
+	if m.narrowLayout() {
+		b.WriteString(style.Render(name + ":"))
+		b.WriteString("\n")
+		return "", contentWidth
+	}
+	label := m.prefixLabel(name)
+	b.WriteString(style.Render(label))
+	return strings.Repeat(" ", len(label)), contentWidth - len(label)
 }
 
 // prefixWidth returns the shared width used for message prefixes so message
@@ -222,6 +245,46 @@ func indentMultiline(s, indent string) string {
 		b.WriteString(line)
 	}
 	return b.String()
+}
+
+// stripLeadingSpacesPerLine drops leading ASCII spaces from each line while
+// preserving any ANSI escape sequences that precede them. Glamour adds a left
+// document margin to its rendered output; in narrow stacked layout we want the
+// body flush against column 0 so it lines up under the prefix.
+func stripLeadingSpacesPerLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		var sb strings.Builder
+		j := 0
+		seenContent := false
+		for j < len(line) {
+			c := line[j]
+			if c == 0x1b {
+				k := j + 1
+				if k < len(line) && line[k] == '[' {
+					k++
+					for k < len(line) && !((line[k] >= 0x40) && (line[k] <= 0x7e)) {
+						k++
+					}
+					if k < len(line) {
+						k++
+					}
+				}
+				sb.WriteString(line[j:k])
+				j = k
+				continue
+			}
+			if !seenContent && c == ' ' {
+				j++
+				continue
+			}
+			seenContent = true
+			sb.WriteByte(c)
+			j++
+		}
+		lines[i] = sb.String()
+	}
+	return strings.Join(lines, "\n")
 }
 
 // isTableLine returns true if the line appears to be part of a rendered table.

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -245,6 +245,37 @@ func TestUpdateViewport_BottomAnchoring(t *testing.T) {
 
 func TestUpdateViewport_IndentsWrappedContentAfterPrefix(t *testing.T) {
 	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(20)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "user", content: strings.Repeat("alpha ", 20) + "gamma"},
+			{role: "assistant", content: "line one\nline two", rendered: true},
+		},
+	}
+
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+
+	if !strings.Contains(view, "You:  alpha") {
+		t.Fatalf("expected first user line with prefix, got %q", view)
+	}
+	if !strings.Contains(view, "\n      ") {
+		t.Fatalf("expected wrapped user continuation to be indented, got %q", view)
+	}
+	if !strings.Contains(view, "main: line one") {
+		t.Fatalf("expected first assistant line with prefix, got %q", view)
+	}
+	if !strings.Contains(view, "\n      line two") {
+		t.Fatalf("expected assistant continuation to be indented, got %q", view)
+	}
+}
+
+func TestUpdateViewport_NarrowLayoutStacksPrefixAboveBody(t *testing.T) {
+	vp := viewport.New()
 	vp.SetWidth(20)
 	vp.SetHeight(20)
 	m := &chatModel{
@@ -258,18 +289,65 @@ func TestUpdateViewport_IndentsWrappedContentAfterPrefix(t *testing.T) {
 	}
 
 	m.updateViewport()
-	view := ansi.Strip(m.viewport.View())
+	// Strip ANSI and right-trim each viewport line so we can match logical
+	// content without the viewport's per-line trailing-space padding.
+	lines := strings.Split(ansi.Strip(m.viewport.View()), "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, " ")
+	}
+	view := strings.Join(lines, "\n")
 
-	if !strings.Contains(view, "You:  alpha beta") {
-		t.Fatalf("expected first user line with prefix, got %q", view)
+	if !strings.Contains(view, "You:\nalpha beta gamma") {
+		t.Fatalf("expected stacked user prefix above body, got %q", view)
 	}
-	if !strings.Contains(view, "\n      gamma") {
-		t.Fatalf("expected wrapped user continuation to be indented, got %q", view)
+	if !strings.Contains(view, "main:\nline one\nline two") {
+		t.Fatalf("expected stacked assistant prefix above body, got %q", view)
 	}
-	if !strings.Contains(view, "main: line one") {
-		t.Fatalf("expected first assistant line with prefix, got %q", view)
+}
+
+func TestStripLeadingSpacesPerLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "  hello\n  world", "hello\nworld"},
+		{"no_leading", "hello\nworld", "hello\nworld"},
+		{"ansi_then_spaces", "\x1b[0m  hello\n\x1b[31m  world\x1b[0m", "\x1b[0mhello\n\x1b[31mworld\x1b[0m"},
+		{"interior_spaces_preserved", "  a b\n  c d", "a b\nc d"},
+		{"empty_lines", "\n  hi\n", "\nhi\n"},
 	}
-	if !strings.Contains(view, "\n      line two") {
-		t.Fatalf("expected assistant continuation to be indented, got %q", view)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripLeadingSpacesPerLine(tt.in); got != tt.want {
+				t.Errorf("stripLeadingSpacesPerLine(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNarrowLayout_Threshold(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentName  string
+		width      int
+		wantNarrow bool
+	}{
+		{"wide_short_agent", "main", 100, false},
+		{"narrow_short_agent", "main", 30, true},
+		{"boundary_short_agent_narrow", "main", 69, true},
+		{"boundary_short_agent_wide", "main", 70, false},
+		{"wide_long_agent", "longagentname", 100, false},
+		{"narrow_long_agent", "longagentname", 70, true},
+		{"zero_width", "main", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &chatModel{agentName: tt.agentName, width: tt.width}
+			if got := m.narrowLayout(); got != tt.wantNarrow {
+				t.Errorf("narrowLayout() width=%d agent=%q = %v, want %v",
+					tt.width, tt.agentName, got, tt.wantNarrow)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Switches the chat view to a stacked layout when the terminal is too narrow for the inline `prefix: body` format, so messages stay readable on small windows.

## Summary
- Add a dynamic narrow-mode predicate based on remaining body column width (prefix + 60 char minimum body).
- Stack the `You:` / agent prefix on its own line with body flush left when narrow; keep the existing inline + indented-continuation layout when wide.
- Reflow glamour-rendered markdown on terminal resize by preserving the original markdown source on each rendered message.
- Strip glamour's left margin from rendered content in stacked layout so the first line aligns under the prefix.

## Implementation details
The narrow threshold is computed as `(width - 4) - prefixWidth() < 60` rather than a flat width cutoff so it adapts to long agent names — what we actually care about is whether the body column is usable, not the raw terminal width.

Glamour-rendered messages previously cached only the ANSI output, so resize changed `glamour.WithWordWrap` but couldn't reflow existing messages. The `chatMessage.raw` field now retains the markdown source, and `setSize` re-renders every glamour-rendered message after recreating the renderer.

The narrow-mode label newline is written outside `lipgloss.Style.Render` because lipgloss right-pads multi-line styled output to the longest line, which would prepend phantom spaces to the body's first line.