### PR TITLE
feat: reconnect to gateway after disconnection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ lucinate is a TUI chat client for the OpenClaw gateway, built with bubbletea.
 ### Packages
 
 - **`internal/config`** — Loads `OPENCLAW_GATEWAY_URL` from env/`.env` file. Auto-derives WebSocket URL from HTTP URL (`https` → `wss`).
-- **`internal/client`** — Wraps the `openclaw-go` gateway SDK. Manages WebSocket connection, device identity (`~/.lucinate/identity/<endpoint>/`), and bridges gateway events to a buffered channel for the TUI event loop.
+- **`internal/client`** — Wraps the `openclaw-go` gateway SDK. Manages WebSocket connection, device identity (`~/.lucinate/identity/<endpoint>/`), and bridges gateway events to a buffered channel for the TUI event loop. A `Supervise` goroutine reconnects with exponential backoff if the WebSocket drops (gateway restart, network blip).
 - **`internal/tui`** — Bubbletea TUI with two views: agent selection (`selectModel`) and chat (`chatModel`). Chat supports streaming responses with markdown rendering via glamour.
 
 ### Flow

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -52,6 +52,15 @@ When the initial connect fails with an auth error, `connectWithAuth` in `main.go
 
 Both flows read from `os.Stdin`, so they only trigger in an interactive terminal. Non-interactive callers will see the original error and exit.
 
+## Reconnect after disconnection
+
+Once the TUI is running, a supervisor in `internal/client/supervisor.go` watches the gateway connection (`Client.Done()`) and reconnects automatically if it drops — for example, when the gateway is restarted.
+
+- **Backoff schedule:** 1s, 2s, 4s, 8s, 15s, then 30s for every subsequent attempt. Each attempt has a 15s connect timeout (matching `connectTimeout` for the initial connect).
+- **State surface:** the supervisor pushes `tui.ConnStateMsg` into the bubbletea program. The chat header shows `⚠ disconnected`, `⟳ reconnecting (attempt N)`, or `✖ auth failed — restart`. A one-line system message is added to the chat scrollback on disconnect and on recovery.
+- **In-flight streams:** if a reply was streaming when the connection dropped, the placeholder is cleared so the input is usable again. The gateway has no resume protocol for an interrupted run; the partial reply is abandoned.
+- **Auth failures:** if the gateway rejects the device token after restart (`gateway token mismatch` / `token missing`), the supervisor stops retrying. The chat banner instructs the user to quit (Ctrl+C) and restart so the interactive `connectWithAuth` flow can prompt for a fix — that flow needs `os.Stdin`, which bubbletea owns once the TUI is up.
+
 ## Scopes
 
 The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are set in `internal/client/client.go` and are required for session management, exec approval, and agent administration.

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -40,10 +40,20 @@ The spinner also appears while the model is thinking before any response deltas 
 
 The header line shows:
 
-- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`)
+- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected)
 - **Right:** token summary (input / output / cache) · total cost
 
 Stats are loaded on init and refreshed after each message exchange via `loadStats()`. The header is re-rendered on every `statsLoadedMsg`. Token and cost values come from `client.SessionUsage()`.
+
+The connection-status badge is rendered in the error colour and only appears when the gateway connection is degraded:
+
+| Badge | Meaning |
+|---|---|
+| `⚠ disconnected` | The supervisor has just observed the WebSocket close; reconnect not yet attempted. |
+| `⟳ reconnecting` (or `attempt N`) | A reconnect attempt is in progress. The attempt counter is shown from the second attempt onwards. |
+| `✖ auth failed — restart` | The gateway rejected the device token after restart. The supervisor has stopped retrying — Ctrl+C and re-run `lucinate` so the interactive auth recovery flow can run on stdin. |
+
+A matching one-line system message is also added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. See [authentication.md](authentication.md#reconnect-after-disconnection) for the full lifecycle.
 
 ## History depth
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/a3tai/openclaw-go/gateway"
 	"github.com/a3tai/openclaw-go/identity"
@@ -20,6 +21,7 @@ import (
 // Client wraps the gateway SDK client and bridges events to a channel
 // for consumption by the bubbletea event loop.
 type Client struct {
+	mu     sync.RWMutex
 	gw     *gateway.Client
 	events chan protocol.Event
 	cfg    *config.Config
@@ -83,9 +85,54 @@ func sanitiseHost(host string) string {
 
 // Connect establishes a WebSocket connection to the gateway.
 func (c *Client) Connect(ctx context.Context) error {
+	return c.dial(ctx)
+}
+
+// Reconnect tears down the current gateway client and dials a fresh one.
+// The events channel is preserved so existing TUI consumers keep working.
+func (c *Client) Reconnect(ctx context.Context) error {
+	c.mu.Lock()
+	old := c.gw
+	c.gw = nil
+	c.mu.Unlock()
+	if old != nil {
+		_ = old.Close()
+	}
+	return c.dial(ctx)
+}
+
+// dial loads identity, builds options, and performs the SDK handshake.
+func (c *Client) dial(ctx context.Context) error {
+	opts, err := c.buildOptions()
+	if err != nil {
+		return err
+	}
+
+	gw := gateway.NewClient(opts...)
+	if err := gw.Connect(ctx, c.cfg.WSURL); err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+
+	c.mu.Lock()
+	c.gw = gw
+	c.mu.Unlock()
+
+	// Save device token if issued.
+	if hello := gw.Hello(); hello != nil && hello.Auth != nil && hello.Auth.DeviceToken != "" {
+		if err := c.store.SaveDeviceToken(hello.Auth.DeviceToken); err != nil {
+			log.Printf("warning: failed to save device token: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// buildOptions assembles the gateway SDK options for a connection attempt.
+// Called on every (re)connect so any newly-saved device token is picked up.
+func (c *Client) buildOptions() ([]gateway.Option, error) {
 	id, err := c.store.LoadOrGenerate()
 	if err != nil {
-		return fmt.Errorf("identity: %w", err)
+		return nil, fmt.Errorf("identity: %w", err)
 	}
 
 	deviceToken := c.store.LoadDeviceToken()
@@ -107,26 +154,24 @@ func (c *Client) Connect(ctx context.Context) error {
 				// drop event if channel is full
 			}
 		}),
+		gateway.WithIdentity(id, deviceToken),
 	}
+	return opts, nil
+}
 
-	// Include device identity for authentication.
-	opts = append(opts, gateway.WithIdentity(id, deviceToken))
-
-	c.gw = gateway.NewClient(opts...)
-
-	if err := c.gw.Connect(ctx, c.cfg.WSURL); err != nil {
-		return fmt.Errorf("connect: %w", err)
+// Done returns a channel that is closed when the current gateway connection
+// terminates (clean close, network drop, or gateway restart). Returns a
+// pre-closed channel if there is no active connection.
+func (c *Client) Done() <-chan struct{} {
+	c.mu.RLock()
+	gw := c.gw
+	c.mu.RUnlock()
+	if gw == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
 	}
-
-	// Save device token if issued.
-	hello := c.gw.Hello()
-	if hello != nil && hello.Auth != nil && hello.Auth.DeviceToken != "" {
-		if err := c.store.SaveDeviceToken(hello.Auth.DeviceToken); err != nil {
-			log.Printf("warning: failed to save device token: %v", err)
-		}
-	}
-
-	return nil
+	return gw.Done()
 }
 
 // Events returns the channel of gateway events.
@@ -134,15 +179,24 @@ func (c *Client) Events() <-chan protocol.Event {
 	return c.events
 }
 
+// gw returns the current gateway client under read-lock. Callers must
+// handle nil (returned only before the first Connect succeeds).
+func (c *Client) currentGW() *gateway.Client {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gw
+}
+
 // ListAgents returns the list of available agents.
 func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, error) {
-	return c.gw.AgentsList(ctx)
+	return c.currentGW().AgentsList(ctx)
 }
 
 // CreateAgent provisions a new agent via the gateway API and seeds an
 // IDENTITY.md file for it.
 func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error {
-	result, err := c.gw.AgentsCreate(ctx, protocol.AgentsCreateParams{
+	gw := c.currentGW()
+	result, err := gw.AgentsCreate(ctx, protocol.AgentsCreateParams{
 		Name:      name,
 		Workspace: workspace,
 	})
@@ -152,7 +206,7 @@ func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error 
 
 	// Seed IDENTITY.md so the agent has a name.
 	identity := fmt.Sprintf("# Identity\n\nName: %s\n", name)
-	if _, err := c.gw.AgentsFilesSet(ctx, protocol.AgentsFilesSetParams{
+	if _, err := gw.AgentsFilesSet(ctx, protocol.AgentsFilesSetParams{
 		AgentID: result.AgentID,
 		Name:    "IDENTITY.md",
 		Content: identity,
@@ -168,7 +222,7 @@ func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error 
 func (c *Client) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
 	includeTitles := true
 	includeLastMsg := true
-	return c.gw.SessionsList(ctx, protocol.SessionsListParams{
+	return c.currentGW().SessionsList(ctx, protocol.SessionsListParams{
 		AgentID:              agentID,
 		IncludeDerivedTitles: &includeTitles,
 		IncludeLastMessage:   &includeLastMsg,
@@ -178,7 +232,7 @@ func (c *Client) SessionsList(ctx context.Context, agentID string) (json.RawMess
 // CreateSession creates or resumes a session for the given agent and returns
 // the gateway-assigned session key.
 func (c *Client) CreateSession(ctx context.Context, agentID, key string) (string, error) {
-	raw, err := c.gw.SessionsCreate(ctx, protocol.SessionsCreateParams{
+	raw, err := c.currentGW().SessionsCreate(ctx, protocol.SessionsCreateParams{
 		Key:     key,
 		AgentID: agentID,
 	})
@@ -196,7 +250,7 @@ func (c *Client) CreateSession(ctx context.Context, agentID, key string) (string
 
 // ChatSend sends a chat message and returns the initial ack.
 func (c *Client) ChatSend(ctx context.Context, sessionKey, message, idemKey string) (*protocol.ChatSendResult, error) {
-	return c.gw.ChatSend(ctx, protocol.ChatSendParams{
+	return c.currentGW().ChatSend(ctx, protocol.ChatSendParams{
 		SessionKey:     sessionKey,
 		Message:        message,
 		IdempotencyKey: idemKey,
@@ -205,7 +259,7 @@ func (c *Client) ChatSend(ctx context.Context, sessionKey, message, idemKey stri
 
 // ChatHistory retrieves recent chat history for a session.
 func (c *Client) ChatHistory(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
-	return c.gw.ChatHistory(ctx, protocol.ChatHistoryParams{
+	return c.currentGW().ChatHistory(ctx, protocol.ChatHistoryParams{
 		SessionKey: sessionKey,
 		Limit:      &limit,
 	})
@@ -214,7 +268,7 @@ func (c *Client) ChatHistory(ctx context.Context, sessionKey string, limit int) 
 // SessionUsage retrieves usage data for a session.
 func (c *Client) SessionUsage(ctx context.Context, sessionKey string) (json.RawMessage, error) {
 	includeContext := true
-	return c.gw.SessionsUsage(ctx, protocol.SessionsUsageParams{
+	return c.currentGW().SessionsUsage(ctx, protocol.SessionsUsageParams{
 		Key:                  sessionKey,
 		IncludeContextWeight: &includeContext,
 	})
@@ -222,12 +276,12 @@ func (c *Client) SessionUsage(ctx context.Context, sessionKey string) (json.RawM
 
 // ModelsList returns the available models.
 func (c *Client) ModelsList(ctx context.Context) (*protocol.ModelsListResult, error) {
-	return c.gw.ModelsList(ctx)
+	return c.currentGW().ModelsList(ctx)
 }
 
 // SessionPatchModel changes the model for a session.
 func (c *Client) SessionPatchModel(ctx context.Context, sessionKey, modelID string) error {
-	return c.gw.SessionsPatch(ctx, protocol.SessionsPatchParams{
+	return c.currentGW().SessionsPatch(ctx, protocol.SessionsPatchParams{
 		Key:   sessionKey,
 		Model: &modelID,
 	})
@@ -235,7 +289,7 @@ func (c *Client) SessionPatchModel(ctx context.Context, sessionKey, modelID stri
 
 // SessionPatchThinking sets the thinking level for a session.
 func (c *Client) SessionPatchThinking(ctx context.Context, sessionKey, level string) error {
-	return c.gw.SessionsPatch(ctx, protocol.SessionsPatchParams{
+	return c.currentGW().SessionsPatch(ctx, protocol.SessionsPatchParams{
 		Key:           sessionKey,
 		ThinkingLevel: &level,
 	})
@@ -246,7 +300,7 @@ func (c *Client) SessionPatchThinking(ctx context.Context, sessionKey, level str
 // and the decision arrives asynchronously via an exec.approval.resolved event.
 func (c *Client) ExecRequest(ctx context.Context, command, sessionKey string) (*protocol.ExecApprovalRequestResult, error) {
 	twoPhase := true
-	return c.gw.ExecApprovalRequest(ctx, protocol.ExecApprovalRequestParams{
+	return c.currentGW().ExecApprovalRequest(ctx, protocol.ExecApprovalRequestParams{
 		Command:    command,
 		SessionKey: &sessionKey,
 		TwoPhase:   &twoPhase,
@@ -255,7 +309,7 @@ func (c *Client) ExecRequest(ctx context.Context, command, sessionKey string) (*
 
 // ExecResolve approves or denies a pending exec approval.
 func (c *Client) ExecResolve(ctx context.Context, id, decision string) (*protocol.ExecApprovalResolveResult, error) {
-	return c.gw.ExecApprovalResolve(ctx, protocol.ExecApprovalResolveParams{
+	return c.currentGW().ExecApprovalResolve(ctx, protocol.ExecApprovalResolveParams{
 		ID:       id,
 		Decision: decision,
 	})
@@ -263,7 +317,7 @@ func (c *Client) ExecResolve(ctx context.Context, id, decision string) (*protoco
 
 // ChatAbort aborts a running chat turn.
 func (c *Client) ChatAbort(ctx context.Context, sessionKey, runID string) error {
-	return c.gw.ChatAbort(ctx, protocol.ChatAbortParams{
+	return c.currentGW().ChatAbort(ctx, protocol.ChatAbortParams{
 		SessionKey: sessionKey,
 		RunID:      runID,
 	})
@@ -271,13 +325,13 @@ func (c *Client) ChatAbort(ctx context.Context, sessionKey, runID string) error 
 
 // SessionCompact compacts (summarises) the session context.
 func (c *Client) SessionCompact(ctx context.Context, sessionKey string) error {
-	return c.gw.SessionsCompact(ctx, protocol.SessionsCompactParams{Key: sessionKey})
+	return c.currentGW().SessionsCompact(ctx, protocol.SessionsCompactParams{Key: sessionKey})
 }
 
 // SessionDelete deletes a session and its transcript.
 func (c *Client) SessionDelete(ctx context.Context, sessionKey string) error {
 	deleteTranscript := true
-	return c.gw.SessionsDelete(ctx, protocol.SessionsDeleteParams{
+	return c.currentGW().SessionsDelete(ctx, protocol.SessionsDeleteParams{
 		Key:              sessionKey,
 		DeleteTranscript: &deleteTranscript,
 	})
@@ -285,7 +339,7 @@ func (c *Client) SessionDelete(ctx context.Context, sessionKey string) error {
 
 // GatewayHealth retrieves the gateway health snapshot.
 func (c *Client) GatewayHealth(ctx context.Context) (*protocol.HealthEvent, error) {
-	raw, err := c.gw.Health(ctx)
+	raw, err := c.currentGW().Health(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("health: %w", err)
 	}
@@ -299,7 +353,11 @@ func (c *Client) GatewayHealth(ctx context.Context) (*protocol.HealthEvent, erro
 // HelloUptimeMs returns the gateway uptime in milliseconds from the connect
 // handshake, or 0 if not connected.
 func (c *Client) HelloUptimeMs() int64 {
-	if h := c.gw.Hello(); h != nil {
+	gw := c.currentGW()
+	if gw == nil {
+		return 0
+	}
+	if h := gw.Hello(); h != nil {
 		return h.Snapshot.UptimeMs
 	}
 	return 0
@@ -324,12 +382,18 @@ func (c *Client) StoreToken(token string) error {
 }
 
 // GW returns the underlying gateway client (for direct RPC access).
-func (c *Client) GW() *gateway.Client { return c.gw }
+// May return nil if no connection has been established yet, or briefly
+// during a reconnect cycle.
+func (c *Client) GW() *gateway.Client { return c.currentGW() }
 
 // Close closes the gateway connection.
 func (c *Client) Close() error {
-	if c.gw != nil {
-		return c.gw.Close()
+	c.mu.Lock()
+	gw := c.gw
+	c.gw = nil
+	c.mu.Unlock()
+	if gw != nil {
+		return gw.Close()
 	}
 	return nil
 }

--- a/internal/client/supervisor.go
+++ b/internal/client/supervisor.go
@@ -1,0 +1,172 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ConnStatus describes the current state of the gateway WebSocket connection.
+type ConnStatus int
+
+const (
+	// StatusConnected: the WebSocket is up and the SDK has completed handshake.
+	StatusConnected ConnStatus = iota
+	// StatusDisconnected: the previous connection has dropped; reconnect not yet attempted.
+	StatusDisconnected
+	// StatusReconnecting: a reconnect attempt is in progress (or about to retry).
+	StatusReconnecting
+	// StatusAuthFailed: reconnect was rejected for auth reasons; supervisor has stopped.
+	// The user must restart the client so the interactive auth recovery flow can run.
+	StatusAuthFailed
+)
+
+// ConnState is the value emitted by the supervisor each time the connection
+// state changes.
+type ConnState struct {
+	Status  ConnStatus
+	Attempt int   // 1-based attempt count for Reconnecting; 0 for other statuses
+	Err     error // non-nil for Disconnected/Reconnecting/AuthFailed
+}
+
+// reconnectFn is the connect-attempt function used by the supervisor. The
+// real one is Client.Reconnect; tests inject a fake.
+type reconnectFn func(ctx context.Context) error
+
+// doneFn returns a channel that closes when the active connection drops.
+// The real one is Client.Done.
+type doneFn func() <-chan struct{}
+
+// supervisorConfig is exposed for tests; production callers use Supervise.
+type supervisorConfig struct {
+	reconnect      reconnectFn
+	done           doneFn
+	notify         func(ConnState)
+	attemptTimeout time.Duration
+	backoff        []time.Duration
+	isAuthFatal    func(error) bool
+}
+
+// defaultBackoff is the schedule of waits between reconnect attempts. The
+// final entry caps every subsequent retry.
+var defaultBackoff = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+}
+
+// defaultAttemptTimeout is the per-attempt connect deadline. Matches the
+// startup connect timeout in main.go.
+const defaultAttemptTimeout = 15 * time.Second
+
+// Supervise watches the client's connection and reconnects with exponential
+// backoff if it drops. It blocks until ctx is cancelled or the connection
+// hits a fatal auth error (in which case the supervisor returns and the
+// last emitted state is StatusAuthFailed).
+//
+// notify is called from the supervisor goroutine and must not block.
+func (c *Client) Supervise(ctx context.Context, notify func(ConnState)) {
+	cfg := supervisorConfig{
+		reconnect:      c.Reconnect,
+		done:           c.Done,
+		notify:         notify,
+		attemptTimeout: defaultAttemptTimeout,
+		backoff:        defaultBackoff,
+		isAuthFatal:    isAuthFatal,
+	}
+	runSupervisor(ctx, cfg)
+}
+
+// runSupervisor is the testable inner loop.
+func runSupervisor(ctx context.Context, cfg supervisorConfig) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-cfg.done():
+		}
+
+		// Connection dropped. If the parent ctx was the cause, exit.
+		if ctx.Err() != nil {
+			return
+		}
+
+		emit(cfg.notify, ConnState{Status: StatusDisconnected})
+
+		if !attemptReconnect(ctx, cfg) {
+			return
+		}
+	}
+}
+
+// attemptReconnect retries with backoff until success, fatal error, or ctx
+// cancellation. Returns true if reconnected, false if the supervisor should
+// stop (auth-fatal or ctx done).
+func attemptReconnect(ctx context.Context, cfg supervisorConfig) bool {
+	for attempt := 1; ; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, cfg.attemptTimeout)
+		err := cfg.reconnect(attemptCtx)
+		cancel()
+
+		if err == nil {
+			emit(cfg.notify, ConnState{Status: StatusConnected})
+			return true
+		}
+
+		if cfg.isAuthFatal(err) {
+			emit(cfg.notify, ConnState{Status: StatusAuthFailed, Attempt: attempt, Err: err})
+			return false
+		}
+
+		emit(cfg.notify, ConnState{Status: StatusReconnecting, Attempt: attempt, Err: err})
+
+		wait := backoffFor(cfg.backoff, attempt)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(wait):
+		}
+	}
+}
+
+// backoffFor returns the wait duration for the given 1-based attempt number,
+// clamping to the last entry once the schedule is exhausted.
+func backoffFor(schedule []time.Duration, attempt int) time.Duration {
+	if len(schedule) == 0 {
+		return time.Second
+	}
+	if attempt-1 >= len(schedule) {
+		return schedule[len(schedule)-1]
+	}
+	return schedule[attempt-1]
+}
+
+func emit(notify func(ConnState), s ConnState) {
+	if notify != nil {
+		notify(s)
+	}
+}
+
+// isAuthFatal reports whether the gateway error indicates the device token is
+// missing or wrong. These errors will not resolve themselves; the user must
+// restart so the interactive auth recovery flow can prompt for a new token.
+func isAuthFatal(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "gateway token mismatch") ||
+		strings.Contains(msg, "gateway token missing")
+}
+
+// IsAuthFatal exposes the auth-error predicate so main.go's startup auth
+// recovery can share the same classification.
+func IsAuthFatal(err error) bool { return isAuthFatal(err) }
+
+// ErrSupervisorStopped is returned from helpers that observe a stopped
+// supervisor; reserved for future use by callers that want a sentinel.
+var ErrSupervisorStopped = errors.New("connection supervisor stopped")

--- a/internal/client/supervisor_test.go
+++ b/internal/client/supervisor_test.go
@@ -1,0 +1,312 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stateRecorder captures the sequence of ConnState values the supervisor emits.
+type stateRecorder struct {
+	mu     sync.Mutex
+	states []ConnState
+}
+
+func (r *stateRecorder) notify(s ConnState) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.states = append(r.states, s)
+}
+
+func (r *stateRecorder) snapshot() []ConnState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ConnState, len(r.states))
+	copy(out, r.states)
+	return out
+}
+
+// fakeConn drives the supervisor: it owns a "done" channel and a queue of
+// reconnect outcomes. Each reconnect attempt pops the next outcome and (if
+// successful) replaces the done channel with a new open one.
+type fakeConn struct {
+	mu       sync.Mutex
+	done     chan struct{}
+	outcomes []error
+	calls    int
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{done: make(chan struct{})}
+}
+
+func (f *fakeConn) doneCh() <-chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.done
+}
+
+func (f *fakeConn) reconnect(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if len(f.outcomes) == 0 {
+		// No more outcomes scripted: behave as a permanent failure so the
+		// supervisor doesn't loop forever in a misconfigured test.
+		return errors.New("test: no more outcomes")
+	}
+	err := f.outcomes[0]
+	f.outcomes = f.outcomes[1:]
+	if err == nil {
+		// Reconnected: install a fresh "alive" done channel.
+		f.done = make(chan struct{})
+	}
+	return err
+}
+
+// trip closes the current done channel to simulate a connection drop.
+func (f *fakeConn) trip() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	close(f.done)
+}
+
+// instantBackoff is used in tests so the supervisor doesn't actually sleep.
+var instantBackoff = []time.Duration{0, 0, 0, 0, 0, 0}
+
+func TestSupervisor_ReconnectsAfterDrop(t *testing.T) {
+	fc := newFakeConn()
+	fc.outcomes = []error{nil} // one successful reconnect
+
+	rec := &stateRecorder{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runSupervisor(ctx, supervisorConfig{
+			reconnect:      fc.reconnect,
+			done:           fc.doneCh,
+			notify:         rec.notify,
+			attemptTimeout: time.Second,
+			backoff:        instantBackoff,
+			isAuthFatal:    isAuthFatal,
+		})
+		close(done)
+	}()
+
+	fc.trip()
+
+	// Wait for the supervisor to emit Connected then block on the new done.
+	waitFor(t, func() bool {
+		for _, s := range rec.snapshot() {
+			if s.Status == StatusConnected {
+				return true
+			}
+		}
+		return false
+	}, time.Second)
+
+	cancel()
+	<-done
+
+	got := rec.snapshot()
+	if len(got) < 2 {
+		t.Fatalf("expected at least 2 states (disconnected, connected), got %d: %+v", len(got), got)
+	}
+	if got[0].Status != StatusDisconnected {
+		t.Errorf("first emit: want Disconnected, got %v", got[0].Status)
+	}
+	if got[1].Status != StatusConnected {
+		t.Errorf("second emit: want Connected, got %v", got[1].Status)
+	}
+}
+
+func TestSupervisor_BackoffSequenceOnFailure(t *testing.T) {
+	fc := newFakeConn()
+	// Three transient failures then success.
+	fc.outcomes = []error{errors.New("dial: ECONNREFUSED"), errors.New("dial: ECONNREFUSED"), errors.New("dial: ECONNREFUSED"), nil}
+
+	rec := &stateRecorder{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runSupervisor(ctx, supervisorConfig{
+			reconnect:      fc.reconnect,
+			done:           fc.doneCh,
+			notify:         rec.notify,
+			attemptTimeout: time.Second,
+			backoff:        instantBackoff,
+			isAuthFatal:    isAuthFatal,
+		})
+		close(done)
+	}()
+
+	fc.trip()
+
+	waitFor(t, func() bool {
+		for _, s := range rec.snapshot() {
+			if s.Status == StatusConnected {
+				return true
+			}
+		}
+		return false
+	}, time.Second)
+
+	cancel()
+	<-done
+
+	got := rec.snapshot()
+
+	// Expect: Disconnected, Reconnecting(1), Reconnecting(2), Reconnecting(3), Connected
+	var reconnectingAttempts []int
+	var sawConnected bool
+	for _, s := range got {
+		if s.Status == StatusReconnecting {
+			reconnectingAttempts = append(reconnectingAttempts, s.Attempt)
+		}
+		if s.Status == StatusConnected {
+			sawConnected = true
+		}
+	}
+	if !sawConnected {
+		t.Fatalf("never saw Connected: %+v", got)
+	}
+	wantAttempts := []int{1, 2, 3}
+	if len(reconnectingAttempts) != len(wantAttempts) {
+		t.Fatalf("reconnecting attempts: got %v want %v (full: %+v)", reconnectingAttempts, wantAttempts, got)
+	}
+	for i, a := range reconnectingAttempts {
+		if a != wantAttempts[i] {
+			t.Errorf("attempt %d: got %d want %d", i, a, wantAttempts[i])
+		}
+	}
+}
+
+func TestSupervisor_HaltsOnAuthFailure(t *testing.T) {
+	fc := newFakeConn()
+	fc.outcomes = []error{errors.New("connect: gateway token mismatch")}
+
+	rec := &stateRecorder{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runSupervisor(ctx, supervisorConfig{
+			reconnect:      fc.reconnect,
+			done:           fc.doneCh,
+			notify:         rec.notify,
+			attemptTimeout: time.Second,
+			backoff:        instantBackoff,
+			isAuthFatal:    isAuthFatal,
+		})
+		close(done)
+	}()
+
+	fc.trip()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not halt on auth-fatal error within 1s")
+	}
+
+	got := rec.snapshot()
+	if len(got) == 0 || got[len(got)-1].Status != StatusAuthFailed {
+		t.Fatalf("last state: want StatusAuthFailed, got %+v", got)
+	}
+	// And the supervisor must NOT have retried after the auth failure.
+	if fc.calls != 1 {
+		t.Errorf("reconnect calls after auth-fatal: want 1, got %d", fc.calls)
+	}
+}
+
+func TestSupervisor_StopsOnContextCancel(t *testing.T) {
+	fc := newFakeConn()
+	// Never close fc.done; supervisor should sit on the initial wait.
+
+	rec := &stateRecorder{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		runSupervisor(ctx, supervisorConfig{
+			reconnect:      fc.reconnect,
+			done:           fc.doneCh,
+			notify:         rec.notify,
+			attemptTimeout: time.Second,
+			backoff:        instantBackoff,
+			isAuthFatal:    isAuthFatal,
+		})
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not exit within 1s of ctx cancel")
+	}
+
+	if fc.calls != 0 {
+		t.Errorf("reconnect should not have been called: got %d calls", fc.calls)
+	}
+}
+
+func TestBackoffFor_ClampsToLastEntry(t *testing.T) {
+	schedule := []time.Duration{1, 2, 3}
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 1}, {2, 2}, {3, 3}, {4, 3}, {99, 3},
+	}
+	for _, tc := range cases {
+		got := backoffFor(schedule, tc.attempt)
+		if got != tc.want {
+			t.Errorf("backoffFor(attempt=%d): got %v want %v", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestIsAuthFatal(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("connect: dial tcp: connection refused"), false},
+		{errors.New("connect: gateway token mismatch"), true},
+		{errors.New("connect: gateway token missing"), true},
+		{errors.New("websocket: bad handshake"), false},
+	}
+	for _, tc := range cases {
+		got := isAuthFatal(tc.err)
+		if got != tc.want {
+			t.Errorf("isAuthFatal(%v): got %v want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+// waitFor polls until cond returns true or the deadline expires.
+func waitFor(t *testing.T, cond func() bool, max time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(max)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -81,6 +81,10 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.chatModel.prefs = msg.prefs
 		return m, nil
 
+	case ConnStateMsg:
+		m.chatModel.applyConnState(msg)
+		return m, nil
+
 	case showSessionsMsg:
 		m.sessionsModel = newSessionsModel(m.client, msg.agentID, msg.agentName, msg.modelID, msg.mainKey)
 		m.sessionsModel.setSize(m.width, m.height)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -18,6 +18,68 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
+// connectionBadge returns a short status string for the chat header when the
+// gateway connection is not in the steady-state Connected condition. Returns
+// empty when connected so the header stays clean.
+func connectionBadge(s ConnStateMsg) string {
+	switch s.Status {
+	case client.StatusDisconnected:
+		return headerBadgeWarnStyle.Render("⚠ disconnected")
+	case client.StatusReconnecting:
+		if s.Attempt > 1 {
+			return headerBadgeWarnStyle.Render(fmt.Sprintf("⟳ reconnecting (attempt %d)", s.Attempt))
+		}
+		return headerBadgeWarnStyle.Render("⟳ reconnecting")
+	case client.StatusAuthFailed:
+		return headerBadgeErrStyle.Render("✖ auth failed — restart")
+	default:
+		return ""
+	}
+}
+
+// applyConnState updates the chat view in response to a connection-state
+// transition: stores the new state, and on Connected→non-Connected
+// transitions during a streaming reply, clears the stale streaming
+// placeholder so the input is usable again.
+func (m *chatModel) applyConnState(next ConnStateMsg) {
+	prev := m.connState
+	m.connState = next
+
+	switch next.Status {
+	case client.StatusDisconnected:
+		// Only emit the system note on a real Connected→Disconnected edge,
+		// not on an initial state push at startup.
+		if prev.Status == client.StatusConnected {
+			// Drop the stale spinner placeholder if a turn was in flight.
+			// The gateway will not deliver any further deltas after a restart;
+			// holding the placeholder forever would lock the input.
+			m.removeThinkingPlaceholder()
+			m.sending = false
+			m.runID = ""
+			m.messages = append(m.messages, chatMessage{
+				role:    "system",
+				content: "Lost gateway connection — attempting to reconnect…",
+			})
+			m.updateViewport()
+		}
+	case client.StatusConnected:
+		if prev.Status == client.StatusDisconnected || prev.Status == client.StatusReconnecting {
+			m.messages = append(m.messages, chatMessage{
+				role:    "system",
+				content: "Reconnected to gateway.",
+			})
+			m.updateViewport()
+		}
+	case client.StatusAuthFailed:
+		errLine := "Reconnect failed: gateway rejected the device token. Quit (Ctrl+C) and restart to re-authenticate."
+		if next.Err != nil {
+			errLine = fmt.Sprintf("Reconnect failed (%v). Quit (Ctrl+C) and restart to re-authenticate.", next.Err)
+		}
+		m.messages = append(m.messages, chatMessage{role: "system", errMsg: errLine})
+		m.updateViewport()
+	}
+}
+
 const inputHeight = 3
 
 // spinnerFrames cycles the streaming-response placeholder through a braille
@@ -51,6 +113,7 @@ type chatModel struct {
 	pendingConfirm   *pendingConfirmation
 	historyLimit     int
 	thinkingLevel    string // current thinking level; "" means not set / using gateway default
+	connState        ConnStateMsg
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -667,6 +730,9 @@ func (m chatModel) View() string {
 	}
 	if m.thinkingLevel != "" && m.thinkingLevel != "off" {
 		left += " · think:" + m.thinkingLevel
+	}
+	if badge := connectionBadge(m.connState); badge != "" {
+		left += " · " + badge
 	}
 	right := ""
 	if m.stats != nil {

--- a/internal/tui/connstate_test.go
+++ b/internal/tui/connstate_test.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/client"
+)
+
+func TestApplyConnState_DropsStreamingPlaceholderOnDisconnect(t *testing.T) {
+	m := newTestChatModel()
+	m.connState = ConnStateMsg{Status: client.StatusConnected}
+	m.sending = true
+	m.runID = "run-123"
+	m.messages = []chatMessage{
+		{role: "user", content: "hi"},
+		{role: "assistant", streaming: true, awaitingDelta: true},
+	}
+
+	m.applyConnState(ConnStateMsg{Status: client.StatusDisconnected})
+
+	if m.sending {
+		t.Errorf("sending should be cleared on disconnect during in-flight stream")
+	}
+	if m.runID != "" {
+		t.Errorf("runID should be cleared on disconnect: got %q", m.runID)
+	}
+	if len(m.messages) != 2 {
+		t.Fatalf("want 2 messages (user + system note), got %d: %+v", len(m.messages), m.messages)
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || !strings.Contains(last.content, "Lost gateway connection") {
+		t.Errorf("expected system disconnect note, got role=%s content=%q", last.role, last.content)
+	}
+}
+
+func TestApplyConnState_NoSystemNoteOnInitialDisconnect(t *testing.T) {
+	// If the supervisor sends a Disconnected state before we ever observed
+	// Connected (e.g. a startup race), don't pollute the chat with a stale
+	// "lost connection" note for a connection we never had.
+	m := newTestChatModel()
+	// Note: m.connState defaults to zero value, which is StatusConnected (iota 0).
+	// To exercise the "never connected" path we set it explicitly to a non-Connected sentinel.
+	m.connState = ConnStateMsg{Status: client.StatusReconnecting}
+
+	m.applyConnState(ConnStateMsg{Status: client.StatusDisconnected})
+
+	for _, msg := range m.messages {
+		if strings.Contains(msg.content, "Lost gateway connection") {
+			t.Fatalf("should not have added disconnect note when prev was not Connected; messages=%+v", m.messages)
+		}
+	}
+}
+
+func TestApplyConnState_AddsReconnectedNoteOnRecovery(t *testing.T) {
+	m := newTestChatModel()
+	m.connState = ConnStateMsg{Status: client.StatusReconnecting, Attempt: 3}
+
+	m.applyConnState(ConnStateMsg{Status: client.StatusConnected})
+
+	if len(m.messages) != 1 {
+		t.Fatalf("want 1 message, got %d", len(m.messages))
+	}
+	if !strings.Contains(m.messages[0].content, "Reconnected") {
+		t.Errorf("expected reconnected note, got %q", m.messages[0].content)
+	}
+}
+
+func TestApplyConnState_AuthFailedAddsErrorMessage(t *testing.T) {
+	m := newTestChatModel()
+	m.applyConnState(ConnStateMsg{
+		Status: client.StatusAuthFailed,
+		Err:    errors.New("connect: gateway token mismatch"),
+	})
+
+	if len(m.messages) != 1 {
+		t.Fatalf("want 1 message, got %d", len(m.messages))
+	}
+	if m.messages[0].errMsg == "" {
+		t.Errorf("expected errMsg on auth-failed system message")
+	}
+	if !strings.Contains(m.messages[0].errMsg, "restart") {
+		t.Errorf("auth-failed message should instruct user to restart: %q", m.messages[0].errMsg)
+	}
+}
+
+func TestConnectionBadge(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    ConnStateMsg
+		wantSubs string // substring expected in the rendered (styled) badge
+	}{
+		{"connected is empty", ConnStateMsg{Status: client.StatusConnected}, ""},
+		{"disconnected", ConnStateMsg{Status: client.StatusDisconnected}, "disconnected"},
+		{"reconnecting first attempt", ConnStateMsg{Status: client.StatusReconnecting, Attempt: 1}, "reconnecting"},
+		{"reconnecting later attempt", ConnStateMsg{Status: client.StatusReconnecting, Attempt: 4}, "attempt 4"},
+		{"auth failed", ConnStateMsg{Status: client.StatusAuthFailed}, "auth failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := connectionBadge(tc.state)
+			if tc.wantSubs == "" {
+				if got != "" {
+					t.Errorf("badge: want empty, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSubs) {
+				t.Errorf("badge: want substring %q, got %q", tc.wantSubs, got)
+			}
+		})
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"github.com/a3tai/openclaw-go/protocol"
 
+	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
@@ -181,3 +182,12 @@ type sessionClearedMsg struct {
 
 // spinnerTickMsg advances the streaming-response placeholder animation.
 type spinnerTickMsg struct{}
+
+// ConnStateMsg carries a gateway connection-state transition from the
+// reconnect supervisor into the bubbletea event loop. Exported so main.go
+// can dispatch it via p.Send().
+type ConnStateMsg struct {
+	Status  client.ConnStatus
+	Attempt int
+	Err     error
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -52,6 +52,18 @@ var (
 			Foreground(errClr).
 			Bold(true)
 
+	// Connection-status badge styles, sized to read against the purple
+	// header background where the badge is rendered.
+	headerBadgeWarnStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#1A0033")).
+				Background(accent)
+	headerBadgeErrStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Background(lipgloss.Color("#B00020")).
+				Padding(0, 1)
+
 	// Input area border for exec mode.
 	execBorderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).

--- a/main.go
+++ b/main.go
@@ -128,11 +128,11 @@ func connectWithAuth(c *client.Client, in io.Reader) error {
 }
 
 func isTokenMismatch(err error) bool {
-	return strings.Contains(err.Error(), "gateway token mismatch")
+	return err != nil && strings.Contains(err.Error(), "gateway token mismatch")
 }
 
 func isTokenMissing(err error) bool {
-	return strings.Contains(err.Error(), "gateway token missing")
+	return err != nil && strings.Contains(err.Error(), "gateway token missing")
 }
 
 func main() {
@@ -174,6 +174,14 @@ func main() {
 			p.Send(tui.GatewayEventMsg(ev))
 		}
 	}()
+
+	// Watch the gateway connection and reconnect if it drops (e.g. gateway
+	// restart). The supervisor pushes state transitions to the TUI.
+	supervisorCtx, stopSupervisor := context.WithCancel(context.Background())
+	defer stopSupervisor()
+	go c.Supervise(supervisorCtx, func(s client.ConnState) {
+		p.Send(tui.ConnStateMsg{Status: s.Status, Attempt: s.Attempt, Err: s.Err})
+	})
 
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)


### PR DESCRIPTION
Automatically re-establish the gateway WebSocket after a drop (e.g. gateway restart) instead of leaving the TUI in a broken state.

## Summary
- Add a reconnect supervisor in `internal/client` that watches the gateway connection and redials with exponential backoff (1s → 30s, capped) when it drops.
- Surface connection state to the TUI via a new `ConnStateMsg`; the chat header shows a status badge (`⚠ disconnected`, `⟳ reconnecting (attempt N)`, `✖ auth failed — restart`) and matching system messages appear in the scrollback.
- Drop the streaming-reply placeholder on disconnect so the input stays usable; the gateway has no resume protocol for an interrupted run.
- Halt retries on auth-fatal errors (`gateway token mismatch` / `token missing`) and instruct the user to restart, since interactive auth recovery needs `os.Stdin` — owned by bubbletea once the TUI is up.
- Update `docs/authentication.md`, `docs/chat-ux.md`, and `AGENTS.md` to describe the new behaviour.

## Implementation details
- `Client` now holds a `sync.RWMutex` around the underlying `*gateway.Client`; all RPC methods route through `currentGW()` so they pick up the post-reconnect instance. `Reconnect` builds a fresh SDK client per attempt while preserving the events channel that the TUI captured at startup.
- The badge uses dedicated `headerBadgeWarnStyle` / `headerBadgeErrStyle` so the text reads against the purple header background — the original red-on-purple was unreadable.