### PR TITLE
refactor: extract reusable Run and embedder hooks for native clients

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,9 @@
 // The CLI entry point in main.go is a thin wrapper around Run; embedders
 // that need to host the program with their own input source or output sink
 // (for example, tests or alternative front-ends) construct a *client.Client,
-// connect it, and then call Run with a RunOptions value.
+// connect it, and then either call Run for a one-shot blocking invocation
+// or build a *Program directly when they need to send window-size updates
+// or request a quit from another goroutine.
 package app
 
 import (
@@ -19,10 +21,10 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/tui"
 )
 
-// RunOptions configures a single Run invocation.
+// RunOptions configures a Program.
 type RunOptions struct {
 	// Client is the already-connected gateway client whose events drive the
-	// UI. Run does not call Connect or Close on the client; lifecycle is the
+	// UI. Neither Run nor Program closes the client; lifecycle is the
 	// caller's responsibility.
 	Client *client.Client
 
@@ -34,16 +36,19 @@ type RunOptions struct {
 	Output io.Writer
 }
 
-// Run starts the Bubble Tea program and blocks until it exits or ctx is
-// cancelled. The events-pump goroutine that bridges gateway events into the
-// program is owned by Run and stops when the program exits or ctx is
-// cancelled, whichever comes first.
-//
-// Run never closes the client; the caller is expected to Close it after Run
-// returns.
-func Run(ctx context.Context, opts RunOptions) error {
+// Program wraps a Bubble Tea program with the lucinate model and a
+// gateway-events pump goroutine. It is safe to call Resize and Quit from
+// goroutines other than the one running Run.
+type Program struct {
+	tp     *tea.Program
+	client *client.Client
+}
+
+// New constructs a Program with the given options. It does not start the
+// underlying Bubble Tea loop; call Run to block on it.
+func New(opts RunOptions) (*Program, error) {
 	if opts.Client == nil {
-		return errors.New("app.Run: Client is required")
+		return nil, errors.New("app: Client is required")
 	}
 	in := opts.Input
 	if in == nil {
@@ -54,34 +59,53 @@ func Run(ctx context.Context, opts RunOptions) error {
 		out = os.Stdout
 	}
 
-	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	model := tui.NewApp(opts.Client)
-	p := tea.NewProgram(model,
-		tea.WithContext(runCtx),
+	tp := tea.NewProgram(model,
 		tea.WithInput(in),
 		tea.WithOutput(out),
 	)
+	return &Program{tp: tp, client: opts.Client}, nil
+}
+
+// Run starts the Bubble Tea program and blocks until it exits or ctx is
+// cancelled. The events-pump goroutine that bridges gateway events into the
+// program is owned by Run for the duration of the call.
+//
+// Run is single-shot per Program; calling it more than once is a programming
+// error and the second call's behaviour is undefined.
+func (p *Program) Run(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	pumpDone := make(chan struct{})
 	go func() {
 		defer close(pumpDone)
-		events := opts.Client.Events()
+		events := p.client.Events()
 		for {
 			select {
 			case ev, ok := <-events:
 				if !ok {
 					return
 				}
-				p.Send(tui.GatewayEventMsg(ev))
+				p.tp.Send(tui.GatewayEventMsg(ev))
 			case <-runCtx.Done():
 				return
 			}
 		}
 	}()
 
-	_, err := p.Run()
+	// Quit the program if the caller cancels the context.
+	stopWatcher := make(chan struct{})
+	go func() {
+		select {
+		case <-runCtx.Done():
+			p.tp.Quit()
+		case <-stopWatcher:
+		}
+	}()
+
+	_, err := p.tp.Run()
+	close(stopWatcher)
 	cancel()
 	<-pumpDone
 
@@ -89,4 +113,27 @@ func Run(ctx context.Context, opts RunOptions) error {
 		return fmt.Errorf("program: %w", err)
 	}
 	return nil
+}
+
+// Resize sends a window-size update to the running program. Safe to call
+// from any goroutine. A no-op if the program has already exited.
+func (p *Program) Resize(cols, rows int) {
+	p.tp.Send(tea.WindowSizeMsg{Width: cols, Height: rows})
+}
+
+// Quit requests the program to exit cleanly. Safe to call from any
+// goroutine. The corresponding Run call will return shortly afterwards.
+func (p *Program) Quit() {
+	p.tp.Quit()
+}
+
+// Run is a convenience wrapper that constructs a Program and runs it to
+// completion. Embedders that need Resize or Quit should use New + Program.Run
+// instead.
+func Run(ctx context.Context, opts RunOptions) error {
+	p, err := New(opts)
+	if err != nil {
+		return err
+	}
+	return p.Run(ctx)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -95,6 +95,21 @@ type RunOptions struct {
 	// on a main thread should trampoline accordingly. The CLI leaves
 	// it nil.
 	OnInputFocusChanged func(wantsInput bool)
+
+	// OnActionsChanged, if non-nil, is invoked whenever the active
+	// view's set of exposed Actions changes. The active view is the
+	// authoritative source of its discoverable, view-level commands
+	// (e.g. "new agent", "back", "retry"); the desktop TUI renders
+	// these as inline help and dispatches the bound key, while
+	// embedders typically render them as buttons whose tap calls back
+	// in via Program.TriggerAction.
+	//
+	// The callback fires once at start-up with the initial list and
+	// again on every transition. It runs from a tea.Cmd goroutine, so
+	// embedders that touch UI on a main thread should trampoline
+	// accordingly. The CLI leaves it nil — its inline help is the
+	// surface that matters there.
+	OnActionsChanged func(actions []Action)
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -124,6 +139,7 @@ func New(opts RunOptions) (*Program, error) {
 		HideInputArea:       opts.HideInputArea,
 		DisableMouse:        opts.DisableMouse,
 		OnInputFocusChanged: opts.OnInputFocusChanged,
+		OnActionsChanged:    opts.OnActionsChanged,
 	})
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
@@ -197,6 +213,16 @@ func (p *Program) Resize(cols, rows int) {
 // goroutine. The corresponding Run call will return shortly afterwards.
 func (p *Program) Quit() {
 	p.tp.Quit()
+}
+
+// TriggerAction invokes the named action on the active view. Embedders
+// pass the ID of one of the actions the program most recently published
+// via OnActionsChanged. Safe to call from any goroutine; a no-op if the
+// program has already exited or the active view does not recognise the
+// ID (the latter typically means the embedder's UI is one transition
+// behind the program — not an error).
+func (p *Program) TriggerAction(id string) {
+	p.tp.Send(tui.TriggerActionMsg{ID: id})
 }
 
 // Run is a convenience wrapper that constructs a Program and runs it to

--- a/app/app.go
+++ b/app/app.go
@@ -44,6 +44,25 @@ type RunOptions struct {
 	// screen until the next full repaint.
 	InitialCols int
 	InitialRows int
+
+	// ForceFullRepaintOnInput, when true, batches a tea.ClearScreen into
+	// every input-shaped Update (key/mouse/window-size). The renderer's
+	// diff state is reset and the next View output is emitted in full,
+	// rather than as a delta against the renderer's model of the screen.
+	//
+	// Embedders driving the program through a virtual terminal whose
+	// actual screen state can drift from the cursed renderer's model
+	// — typically because the host emulator handles a subset of the
+	// renderer's positioning sequences differently to a hardware TTY —
+	// should set this. The CLI never needs to: the renderer's
+	// incremental diffs are correct against a real terminal, and a
+	// CLI-side full repaint on every keypress would be visibly wasteful.
+	//
+	// Server-driven messages (gateway events, streamed chat tokens) are
+	// not gated by this flag — those arrive at high frequency and a
+	// per-event full repaint would defeat the whole point of an
+	// incremental renderer.
+	ForceFullRepaintOnInput bool
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -69,7 +88,10 @@ func New(opts RunOptions) (*Program, error) {
 		out = os.Stdout
 	}
 
-	model := tui.NewApp(opts.Client)
+	var model tea.Model = tui.NewApp(opts.Client)
+	if opts.ForceFullRepaintOnInput {
+		model = repaintOnInput{Model: model}
+	}
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
 		tea.WithOutput(out),
@@ -79,6 +101,37 @@ func New(opts RunOptions) (*Program, error) {
 	}
 	tp := tea.NewProgram(model, teaOpts...)
 	return &Program{tp: tp, client: opts.Client}, nil
+}
+
+// repaintOnInput wraps a tea.Model and, after every input-shaped Update,
+// batches tea.ClearScreen into the returned Cmd. The clearScreen message
+// is then processed in order on the program's update loop, after the
+// inner Update has produced the new state, guaranteeing a fresh full
+// repaint on the next render. This lives in app/ rather than the binding
+// repo because it needs the bubbletea.Model interface.
+type repaintOnInput struct {
+	tea.Model
+}
+
+func (r repaintOnInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	inner, cmd := r.Model.Update(msg)
+	if !shouldForceRepaint(msg) {
+		return repaintOnInput{Model: inner}, cmd
+	}
+	return repaintOnInput{Model: inner}, tea.Batch(cmd, tea.ClearScreen)
+}
+
+func (r repaintOnInput) View() tea.View {
+	return r.Model.View()
+}
+
+func shouldForceRepaint(msg tea.Msg) bool {
+	switch msg.(type) {
+	case tea.KeyPressMsg, tea.KeyReleaseMsg, tea.MouseMsg, tea.WindowSizeMsg, tea.PasteMsg:
+		return true
+	default:
+		return false
+	}
 }
 
 // Run starts the Bubble Tea program and blocks until it exits or ctx is

--- a/app/app.go
+++ b/app/app.go
@@ -44,25 +44,6 @@ type RunOptions struct {
 	// screen until the next full repaint.
 	InitialCols int
 	InitialRows int
-
-	// ForceFullRepaintOnInput, when true, batches a tea.ClearScreen into
-	// every input-shaped Update (key/mouse/window-size). The renderer's
-	// diff state is reset and the next View output is emitted in full,
-	// rather than as a delta against the renderer's model of the screen.
-	//
-	// Embedders driving the program through a virtual terminal whose
-	// actual screen state can drift from the cursed renderer's model
-	// — typically because the host emulator handles a subset of the
-	// renderer's positioning sequences differently to a hardware TTY —
-	// should set this. The CLI never needs to: the renderer's
-	// incremental diffs are correct against a real terminal, and a
-	// CLI-side full repaint on every keypress would be visibly wasteful.
-	//
-	// Server-driven messages (gateway events, streamed chat tokens) are
-	// not gated by this flag — those arrive at high frequency and a
-	// per-event full repaint would defeat the whole point of an
-	// incremental renderer.
-	ForceFullRepaintOnInput bool
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -88,10 +69,7 @@ func New(opts RunOptions) (*Program, error) {
 		out = os.Stdout
 	}
 
-	var model tea.Model = tui.NewApp(opts.Client)
-	if opts.ForceFullRepaintOnInput {
-		model = repaintOnInput{Model: model}
-	}
+	model := tui.NewApp(opts.Client)
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
 		tea.WithOutput(out),
@@ -101,37 +79,6 @@ func New(opts RunOptions) (*Program, error) {
 	}
 	tp := tea.NewProgram(model, teaOpts...)
 	return &Program{tp: tp, client: opts.Client}, nil
-}
-
-// repaintOnInput wraps a tea.Model and, after every input-shaped Update,
-// batches tea.ClearScreen into the returned Cmd. The clearScreen message
-// is then processed in order on the program's update loop, after the
-// inner Update has produced the new state, guaranteeing a fresh full
-// repaint on the next render. This lives in app/ rather than the binding
-// repo because it needs the bubbletea.Model interface.
-type repaintOnInput struct {
-	tea.Model
-}
-
-func (r repaintOnInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	inner, cmd := r.Model.Update(msg)
-	if !shouldForceRepaint(msg) {
-		return repaintOnInput{Model: inner}, cmd
-	}
-	return repaintOnInput{Model: inner}, tea.Batch(cmd, tea.ClearScreen)
-}
-
-func (r repaintOnInput) View() tea.View {
-	return r.Model.View()
-}
-
-func shouldForceRepaint(msg tea.Msg) bool {
-	switch msg.(type) {
-	case tea.KeyPressMsg, tea.KeyReleaseMsg, tea.MouseMsg, tea.WindowSizeMsg, tea.PasteMsg:
-		return true
-	default:
-		return false
-	}
 }
 
 // Run starts the Bubble Tea program and blocks until it exits or ctx is

--- a/app/app.go
+++ b/app/app.go
@@ -34,6 +34,16 @@ type RunOptions struct {
 	// Output is the destination for rendered frames. If nil, os.Stdout is
 	// used.
 	Output io.Writer
+
+	// InitialCols and InitialRows seed the program with a window-size
+	// message before its first render. Embedders that drive a fixed-size
+	// virtual terminal (e.g. an in-process renderer) should set these so
+	// the first paint already fits the visible grid; otherwise Bubble Tea
+	// renders against its default size and reflows on the first
+	// post-layout WindowSizeMsg, which can leave stale characters on
+	// screen until the next full repaint.
+	InitialCols int
+	InitialRows int
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -60,10 +70,14 @@ func New(opts RunOptions) (*Program, error) {
 	}
 
 	model := tui.NewApp(opts.Client)
-	tp := tea.NewProgram(model,
+	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
 		tea.WithOutput(out),
-	)
+	}
+	if opts.InitialCols > 0 && opts.InitialRows > 0 {
+		teaOpts = append(teaOpts, tea.WithWindowSize(opts.InitialCols, opts.InitialRows))
+	}
+	tp := tea.NewProgram(model, teaOpts...)
 	return &Program{tp: tp, client: opts.Client}, nil
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -166,7 +166,8 @@ func New(opts RunOptions) (*Program, error) {
 
 // Run starts the Bubble Tea program and blocks until it exits or ctx is
 // cancelled. The events-pump goroutine that bridges gateway events into the
-// program is owned by Run for the duration of the call.
+// program — and the connection supervisor that pushes reconnect state
+// transitions — are owned by Run for the duration of the call.
 //
 // Run is single-shot per Program; calling it more than once is a programming
 // error and the second call's behaviour is undefined.
@@ -190,6 +191,13 @@ func (p *Program) Run(ctx context.Context) error {
 			}
 		}
 	}()
+
+	// Watch the gateway connection and push reconnect-state transitions
+	// into the program so the chat view can surface a "lost connection /
+	// reconnecting" badge and clear stale streaming placeholders.
+	go p.client.Supervise(runCtx, func(s client.ConnState) {
+		p.tp.Send(tui.ConnStateMsg{Status: s.Status, Attempt: s.Attempt, Err: s.Err})
+	})
 
 	// Quit the program if the caller cancels the context.
 	stopWatcher := make(chan struct{})

--- a/app/app.go
+++ b/app/app.go
@@ -78,6 +78,23 @@ type RunOptions struct {
 	// program then ignores. The CLI relies on mouse tracking for
 	// selection and should leave it false.
 	DisableMouse bool
+
+	// OnInputFocusChanged, if non-nil, is invoked whenever the active
+	// view's preferred input mode changes. wantsInput is true when the
+	// active view has a focused free-form text input (the chat
+	// textarea, the new-agent form fields) and false when only
+	// navigation keys are expected (the agent list, the session
+	// browser, the config view). The callback fires once during start-up
+	// with the initial state so the embedder need not assume a default,
+	// and again on every subsequent transition.
+	//
+	// Embedders on platforms with an on-screen keyboard use this to
+	// surface it only when the program actually wants typing, instead
+	// of pinning it permanently and losing screen real estate. The
+	// callback runs from a tea.Cmd goroutine — embedders that touch UI
+	// on a main thread should trampoline accordingly. The CLI leaves
+	// it nil.
+	OnInputFocusChanged func(wantsInput bool)
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -104,8 +121,9 @@ func New(opts RunOptions) (*Program, error) {
 	}
 
 	model := tui.NewApp(opts.Client, tui.AppOptions{
-		HideInputArea: opts.HideInputArea,
-		DisableMouse:  opts.DisableMouse,
+		HideInputArea:       opts.HideInputArea,
+		DisableMouse:        opts.DisableMouse,
+		OnInputFocusChanged: opts.OnInputFocusChanged,
 	})
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),

--- a/app/app.go
+++ b/app/app.go
@@ -16,6 +16,7 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/colorprofile"
 
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/tui"
@@ -45,16 +46,38 @@ type RunOptions struct {
 	InitialCols int
 	InitialRows int
 
-	// HideInputArea suppresses the chat view's textarea and help line so
-	// the embedder can supply its own input surface (for example, a
-	// platform-native text field whose typed bytes are written into
-	// Input). The underlying textarea model is still updated by the
-	// incoming byte stream so command parsing, history, and Enter-to-send
-	// behave exactly as in the CLI; only its rendering and the help line
-	// below it are skipped, and the chat viewport reclaims the freed
-	// rows. The CLI never needs this; embedders without a separate input
-	// surface should leave it false.
+	// ColorProfile, when non-zero, overrides Bubble Tea's automatic
+	// colour-profile detection. Bubble Tea inspects Output to decide
+	// what palette Lipgloss is allowed to emit; when Output is not a
+	// real TTY (an in-process virtual terminal driven by an embedder,
+	// say) the auto-detected profile is NoTTY, which strips every SGR
+	// sequence and produces a monochrome render. Embedders whose
+	// terminal supports colour should set this to the appropriate
+	// profile (typically colorprofile.TrueColor). The CLI leaves it
+	// zero so its existing detection still applies.
+	ColorProfile colorprofile.Profile
+
+	// HideInputArea suppresses the chat view's textarea so the embedder
+	// can supply its own input surface (for example, a platform-native
+	// text field whose typed bytes are written into Input). The
+	// underlying textarea model is still updated by the incoming byte
+	// stream so command parsing, slash-command autocomplete, history,
+	// and Enter-to-send behave exactly as in the CLI; only the textarea
+	// view and its border are skipped, and the help line below
+	// continues to surface slash-command hints. The CLI never needs
+	// this; embedders without a separate input surface should leave it
+	// false.
 	HideInputArea bool
+
+	// DisableMouse stops the program from emitting the
+	// alt-screen mouse-tracking enable sequence. Embedders driving the
+	// program through a virtual terminal whose host wants to handle
+	// pan/swipe gestures natively (translating them into PgUp/PgDown
+	// keystrokes for example) should set this so the host's gesture
+	// recogniser doesn't capture pans into mouse motion events that the
+	// program then ignores. The CLI relies on mouse tracking for
+	// selection and should leave it false.
+	DisableMouse bool
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -80,13 +103,19 @@ func New(opts RunOptions) (*Program, error) {
 		out = os.Stdout
 	}
 
-	model := tui.NewApp(opts.Client, tui.AppOptions{HideInputArea: opts.HideInputArea})
+	model := tui.NewApp(opts.Client, tui.AppOptions{
+		HideInputArea: opts.HideInputArea,
+		DisableMouse:  opts.DisableMouse,
+	})
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
 		tea.WithOutput(out),
 	}
 	if opts.InitialCols > 0 && opts.InitialRows > 0 {
 		teaOpts = append(teaOpts, tea.WithWindowSize(opts.InitialCols, opts.InitialRows))
+	}
+	if opts.ColorProfile != 0 {
+		teaOpts = append(teaOpts, tea.WithColorProfile(opts.ColorProfile))
 	}
 	tp := tea.NewProgram(model, teaOpts...)
 	return &Program{tp: tp, client: opts.Client}, nil

--- a/app/app.go
+++ b/app/app.go
@@ -69,6 +69,14 @@ type RunOptions struct {
 	// false.
 	HideInputArea bool
 
+	// HideActionHints suppresses the inline help line each view renders
+	// listing its action keys ("  n: new agent · r: retry"). Embedders
+	// that surface the same actions through OnActionsChanged as native
+	// controls (buttons, toolbar items) want this true so the hint text
+	// isn't doubled up on screen. The CLI, whose only action surface is
+	// the inline hint, leaves it false.
+	HideActionHints bool
+
 	// DisableMouse stops the program from emitting the
 	// alt-screen mouse-tracking enable sequence. Embedders driving the
 	// program through a virtual terminal whose host wants to handle
@@ -137,6 +145,7 @@ func New(opts RunOptions) (*Program, error) {
 
 	model := tui.NewApp(opts.Client, tui.AppOptions{
 		HideInputArea:       opts.HideInputArea,
+		HideActionHints:     opts.HideActionHints,
 		DisableMouse:        opts.DisableMouse,
 		OnInputFocusChanged: opts.OnInputFocusChanged,
 		OnActionsChanged:    opts.OnActionsChanged,

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,92 @@
+// Package app runs the lucinate Bubble Tea program with pluggable I/O.
+//
+// The CLI entry point in main.go is a thin wrapper around Run; embedders
+// that need to host the program with their own input source or output sink
+// (for example, tests or alternative front-ends) construct a *client.Client,
+// connect it, and then call Run with a RunOptions value.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/client"
+	"github.com/lucinate-ai/lucinate/internal/tui"
+)
+
+// RunOptions configures a single Run invocation.
+type RunOptions struct {
+	// Client is the already-connected gateway client whose events drive the
+	// UI. Run does not call Connect or Close on the client; lifecycle is the
+	// caller's responsibility.
+	Client *client.Client
+
+	// Input is the source of user input bytes. If nil, os.Stdin is used.
+	Input io.Reader
+
+	// Output is the destination for rendered frames. If nil, os.Stdout is
+	// used.
+	Output io.Writer
+}
+
+// Run starts the Bubble Tea program and blocks until it exits or ctx is
+// cancelled. The events-pump goroutine that bridges gateway events into the
+// program is owned by Run and stops when the program exits or ctx is
+// cancelled, whichever comes first.
+//
+// Run never closes the client; the caller is expected to Close it after Run
+// returns.
+func Run(ctx context.Context, opts RunOptions) error {
+	if opts.Client == nil {
+		return errors.New("app.Run: Client is required")
+	}
+	in := opts.Input
+	if in == nil {
+		in = os.Stdin
+	}
+	out := opts.Output
+	if out == nil {
+		out = os.Stdout
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	model := tui.NewApp(opts.Client)
+	p := tea.NewProgram(model,
+		tea.WithContext(runCtx),
+		tea.WithInput(in),
+		tea.WithOutput(out),
+	)
+
+	pumpDone := make(chan struct{})
+	go func() {
+		defer close(pumpDone)
+		events := opts.Client.Events()
+		for {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					return
+				}
+				p.Send(tui.GatewayEventMsg(ev))
+			case <-runCtx.Done():
+				return
+			}
+		}
+	}()
+
+	_, err := p.Run()
+	cancel()
+	<-pumpDone
+
+	if err != nil {
+		return fmt.Errorf("program: %w", err)
+	}
+	return nil
+}

--- a/app/app.go
+++ b/app/app.go
@@ -44,6 +44,17 @@ type RunOptions struct {
 	// screen until the next full repaint.
 	InitialCols int
 	InitialRows int
+
+	// HideInputArea suppresses the chat view's textarea and help line so
+	// the embedder can supply its own input surface (for example, a
+	// platform-native text field whose typed bytes are written into
+	// Input). The underlying textarea model is still updated by the
+	// incoming byte stream so command parsing, history, and Enter-to-send
+	// behave exactly as in the CLI; only its rendering and the help line
+	// below it are skipped, and the chat viewport reclaims the freed
+	// rows. The CLI never needs this; embedders without a separate input
+	// surface should leave it false.
+	HideInputArea bool
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and a
@@ -69,7 +80,7 @@ func New(opts RunOptions) (*Program, error) {
 		out = os.Stdout
 	}
 
-	model := tui.NewApp(opts.Client)
+	model := tui.NewApp(opts.Client, tui.AppOptions{HideInputArea: opts.HideInputArea})
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(in),
 		tea.WithOutput(out),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+func TestNew_RequiresClient(t *testing.T) {
+	_, err := New(RunOptions{})
+	if err == nil {
+		t.Fatal("expected error when Client is nil")
+	}
+	if !strings.Contains(err.Error(), "Client is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRun_RequiresClient(t *testing.T) {
 	err := Run(context.Background(), RunOptions{})
 	if err == nil {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRun_RequiresClient(t *testing.T) {
+	err := Run(context.Background(), RunOptions{})
+	if err == nil {
+		t.Fatal("expected error when Client is nil")
+	}
+	if !strings.Contains(err.Error(), "Client is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/app/external.go
+++ b/app/external.go
@@ -8,12 +8,18 @@ import (
 
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
+	"github.com/lucinate-ai/lucinate/internal/tui"
 )
 
 // IdentityStore is the persistence interface for the device keypair and
 // device token. Type-aliased here so embedders do not need to import
 // internal packages.
 type IdentityStore = client.IdentityStore
+
+// Action mirrors tui.Action so embedders can read the slice published
+// through RunOptions.OnActionsChanged without importing the internal
+// tui package.
+type Action = tui.Action
 
 // Identity is the loaded device identity. Re-exported so embedders that
 // implement IdentityStore can return values of this type.

--- a/app/external.go
+++ b/app/external.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/a3tai/openclaw-go/identity"
+
+	"github.com/lucinate-ai/lucinate/internal/client"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// IdentityStore is the persistence interface for the device keypair and
+// device token. Type-aliased here so embedders do not need to import
+// internal packages.
+type IdentityStore = client.IdentityStore
+
+// Identity is the loaded device identity. Re-exported so embedders that
+// implement IdentityStore can return values of this type.
+type Identity = identity.Identity
+
+// Client is an opaque, connected handle to the OpenClaw gateway. Embedders
+// obtain one from Connect and pass it to RunOptions.Client. The only method
+// they need to call directly is Close.
+type Client = client.Client
+
+// Connect builds a gateway client for the given URL, hooks it up to the
+// supplied IdentityStore, and performs the connect handshake. The returned
+// *Client must be Closed after Run completes.
+func Connect(ctx context.Context, gatewayURL string, store IdentityStore) (*Client, error) {
+	cfg, err := config.New(gatewayURL)
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	c := client.NewWithIdentityStore(cfg, store)
+	if err := c.Connect(ctx); err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	return c, nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -22,8 +22,8 @@ import (
 //
 // The default filesystem implementation is provided by the openclaw-go
 // identity package (*identity.Store satisfies this interface). Alternative
-// implementations — e.g. an iOS Keychain-backed store — can be supplied via
-// NewWithIdentityStore so the gateway client logic stays platform-agnostic.
+// implementations can be supplied via NewWithIdentityStore so the gateway
+// client logic stays decoupled from any particular storage backend.
 type IdentityStore interface {
 	LoadOrGenerate() (*identity.Identity, error)
 	LoadDeviceToken() string
@@ -59,8 +59,9 @@ func New(cfg *config.Config) (*Client, error) {
 }
 
 // NewWithIdentityStore creates a new client using a caller-supplied identity
-// store. This entry point is intended for non-CLI hosts (mobile, tests) that
-// need to persist the device keypair somewhere other than the filesystem.
+// store. This entry point lets embedders persist the device keypair somewhere
+// other than the default filesystem location (for example, in tests, or in
+// alternative host environments).
 func NewWithIdentityStore(cfg *config.Config, store IdentityStore) *Client {
 	return &Client{
 		events: make(chan protocol.Event, 256),

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,6 +18,20 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
+// IdentityStore abstracts persistence of the device keypair and device token.
+//
+// The default filesystem implementation is provided by the openclaw-go
+// identity package (*identity.Store satisfies this interface). Alternative
+// implementations — e.g. an iOS Keychain-backed store — can be supplied via
+// NewWithIdentityStore so the gateway client logic stays platform-agnostic.
+type IdentityStore interface {
+	LoadOrGenerate() (*identity.Identity, error)
+	LoadDeviceToken() string
+	SaveDeviceToken(token string) error
+	ClearDeviceToken() error
+	Reset() error
+}
+
 // Client wraps the gateway SDK client and bridges events to a channel
 // for consumption by the bubbletea event loop.
 type Client struct {
@@ -25,10 +39,11 @@ type Client struct {
 	gw     *gateway.Client
 	events chan protocol.Event
 	cfg    *config.Config
-	store  *identity.Store
+	store  IdentityStore
 }
 
-// New creates a new client from the given config.
+// New creates a new client from the given config, using the default
+// per-endpoint filesystem identity store at ~/.lucinate/identity/<host>/.
 func New(cfg *config.Config) (*Client, error) {
 	identityDir, err := identityDirForEndpoint(cfg.GatewayURL)
 	if err != nil {
@@ -40,11 +55,18 @@ func New(cfg *config.Config) (*Client, error) {
 		return nil, fmt.Errorf("identity store: %w", err)
 	}
 
+	return NewWithIdentityStore(cfg, store), nil
+}
+
+// NewWithIdentityStore creates a new client using a caller-supplied identity
+// store. This entry point is intended for non-CLI hosts (mobile, tests) that
+// need to persist the device keypair somewhere other than the filesystem.
+func NewWithIdentityStore(cfg *config.Config, store IdentityStore) *Client {
 	return &Client{
 		events: make(chan protocol.Event, 256),
 		cfg:    cfg,
 		store:  store,
-	}, nil
+	}
 }
 
 // identityDirForEndpoint returns a per-endpoint identity directory under

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,8 +5,32 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/a3tai/openclaw-go/identity"
+
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
+
+var _ IdentityStore = (*identity.Store)(nil)
+
+type fakeIdentityStore struct {
+	token string
+}
+
+func (f *fakeIdentityStore) LoadOrGenerate() (*identity.Identity, error) { return &identity.Identity{}, nil }
+func (f *fakeIdentityStore) LoadDeviceToken() string                     { return f.token }
+func (f *fakeIdentityStore) SaveDeviceToken(t string) error              { f.token = t; return nil }
+func (f *fakeIdentityStore) ClearDeviceToken() error                     { f.token = ""; return nil }
+func (f *fakeIdentityStore) Reset() error                                { f.token = ""; return nil }
+
+func TestNewWithIdentityStore(t *testing.T) {
+	c := NewWithIdentityStore(&config.Config{}, &fakeIdentityStore{})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if c.store == nil {
+		t.Fatal("expected store to be set")
+	}
+}
 
 func TestSanitiseHost(t *testing.T) {
 	tests := []struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,11 +23,17 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("OPENCLAW_GATEWAY_URL is required")
 	}
 
+	return New(gatewayURL)
+}
+
+// New builds a Config from a gateway URL, deriving the matching WebSocket
+// endpoint. Useful for embedders that obtain the gateway URL from somewhere
+// other than the OPENCLAW_GATEWAY_URL environment variable.
+func New(gatewayURL string) (*Config, error) {
 	wsURL, err := deriveWSURL(gatewayURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid OPENCLAW_GATEWAY_URL: %w", err)
+		return nil, fmt.Errorf("invalid gateway URL: %w", err)
 	}
-
 	return &Config{
 		GatewayURL: gatewayURL,
 		WSURL:      wsURL,

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -1,0 +1,75 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Action is a discoverable, view-level command exposed by the active
+// view. The TUI auto-renders the bound key in the inline help line and
+// dispatches the keystroke through TriggerAction; embedders on other
+// platforms render the same list as native controls and trigger the
+// action by ID via Program.TriggerAction. Keeping both surfaces driven
+// by a single declaration in each view's Actions() method removes the
+// long-standing drift risk between the hand-written help string and
+// the actual key handler.
+type Action struct {
+	// ID is a stable, view-scoped identifier embedders use to invoke
+	// the action ("new-agent", "back", "retry"). Must be unique within
+	// a single view's action list.
+	ID string
+
+	// Label is the human-readable name embedders show next to the
+	// trigger ("New agent"). Should be a short verb phrase.
+	Label string
+
+	// Key is the single-character (or single-token) keystroke the TUI
+	// binds to the action ("n", "esc"). Embedders typically ignore it
+	// — they trigger by ID — but it is kept here so the TUI's auto-
+	// rendered help line reads "n: new agent" without the view having
+	// to repeat itself.
+	Key string
+}
+
+// TriggerActionMsg is emitted by Program.TriggerAction. AppModel routes
+// it to the active view's TriggerAction(id) so embedders can invoke a
+// view's commands without forging fake key events.
+type TriggerActionMsg struct {
+	ID string
+}
+
+// renderActionHints joins an action list into the inline-help format
+// each view used to hand-write ("  n: new agent · r: retry"). Returns
+// the empty string when no actions are present so the caller can decide
+// whether to render a help line at all.
+func renderActionHints(actions []Action) string {
+	if len(actions) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(actions))
+	for _, a := range actions {
+		if a.Key == "" || a.Label == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", a.Key, strings.ToLower(a.Label)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "  " + strings.Join(parts, " · ")
+}
+
+// actionsEqual reports whether two action lists are identical. AppModel
+// uses it to suppress redundant OnActionsChanged callbacks when the
+// recomputed list happens to match the previously-reported one.
+func actionsEqual(a, b []Action) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -75,11 +75,24 @@ func TestSessionsModel_Actions(t *testing.T) {
 }
 
 func TestConfigModel_Actions(t *testing.T) {
-	m := configModel{}
-	got := actionIDs(m.Actions())
-	want := []string{"back"}
-	if !equalStrings(got, want) {
-		t.Fatalf("ids=%v, want=%v", got, want)
+	cases := []struct {
+		name    string
+		items   []configItem
+		cursor  int
+		wantIDs []string
+	}{
+		{"empty (defensive)", nil, 0, []string{"back"}},
+		{"cursor on bool item", []configItem{{kind: configItemBool}}, 0, []string{"toggle", "back"}},
+		{"cursor on int item", []configItem{{kind: configItemBool}, {kind: configItemInt}}, 1, []string{"back"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := configModel{items: tc.items, cursor: tc.cursor}
+			got := actionIDs(m.Actions())
+			if !equalStrings(got, tc.wantIDs) {
+				t.Fatalf("ids=%v, want=%v", got, tc.wantIDs)
+			}
+		})
 	}
 }
 

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -1,0 +1,196 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestSelectModel_Actions(t *testing.T) {
+	cases := []struct {
+		name     string
+		subState selectSubState
+		loading  bool
+		err      error
+		wantIDs  []string
+	}{
+		{"list, ready", subStateList, false, nil, []string{"new-agent"}},
+		{"list, loading", subStateList, true, nil, nil},
+		{"list, error", subStateList, false, errors.New("boom"), []string{"retry"}},
+		{"create form exposes nothing", subStateCreate, false, nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := selectModel{subState: tc.subState, loading: tc.loading, err: tc.err}
+			got := actionIDs(m.Actions())
+			if !equalStrings(got, tc.wantIDs) {
+				t.Fatalf("ids=%v, want=%v", got, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func TestSelectModel_TriggerAction_NewAgent(t *testing.T) {
+	m := selectModel{subState: subStateList}
+	next, cmd := m.TriggerAction("new-agent")
+	if next.subState != subStateCreate {
+		t.Fatalf("expected create sub-state, got %v", next.subState)
+	}
+	if cmd == nil {
+		t.Fatal("expected an init cmd from initCreateForm")
+	}
+}
+
+func TestSelectModel_KeyDelegatesToTriggerAction(t *testing.T) {
+	// Regression: pressing 'n' on the agent list still opens the form
+	// even though the dispatch now goes through Actions().
+	m := selectModel{subState: subStateList}
+	next, _ := m.handleKey(tea.KeyPressMsg{Code: 'n'})
+	if next.subState != subStateCreate {
+		t.Fatalf("key 'n' should open create form via TriggerAction, got %v", next.subState)
+	}
+}
+
+func TestSessionsModel_Actions(t *testing.T) {
+	cases := []struct {
+		name    string
+		loading bool
+		err     error
+		wantIDs []string
+	}{
+		{"ready", false, nil, []string{"new-session", "back"}},
+		{"loading", true, nil, []string{"back"}},
+		{"error", false, errors.New("x"), []string{"back", "retry"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sessionsModel{loading: tc.loading, err: tc.err}
+			got := actionIDs(m.Actions())
+			if !equalStrings(got, tc.wantIDs) {
+				t.Fatalf("ids=%v, want=%v", got, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func TestConfigModel_Actions(t *testing.T) {
+	m := configModel{}
+	got := actionIDs(m.Actions())
+	want := []string{"back"}
+	if !equalStrings(got, want) {
+		t.Fatalf("ids=%v, want=%v", got, want)
+	}
+}
+
+func TestRenderActionHints(t *testing.T) {
+	got := renderActionHints([]Action{
+		{ID: "new-agent", Label: "New agent", Key: "n"},
+		{ID: "retry", Label: "Retry", Key: "r"},
+	})
+	want := "  n: new agent · r: retry"
+	if got != want {
+		t.Fatalf("hint=%q, want=%q", got, want)
+	}
+	if renderActionHints(nil) != "" {
+		t.Fatal("nil actions should render the empty string")
+	}
+}
+
+func TestActionsEqual(t *testing.T) {
+	a := []Action{{ID: "x", Label: "X", Key: "x"}}
+	b := []Action{{ID: "x", Label: "X", Key: "x"}}
+	if !actionsEqual(a, b) {
+		t.Fatal("identical lists should compare equal")
+	}
+	c := []Action{{ID: "x", Label: "X", Key: "y"}}
+	if actionsEqual(a, c) {
+		t.Fatal("different keys should not compare equal")
+	}
+	if actionsEqual(a, nil) {
+		t.Fatal("len mismatch should not compare equal")
+	}
+}
+
+func TestMaybeNotifyActions_FiresOnChange(t *testing.T) {
+	var got [][]string
+	m := AppModel{
+		state:            viewSelect,
+		onActionsChanged: func(as []Action) { got = append(got, actionIDs(as)) },
+	}
+
+	// First call always fires so embedders see the startup state.
+	next, cmd := m.maybeNotifyActions(nil)
+	runCmd(t, cmd)
+	if len(got) != 1 || !equalStrings(got[0], []string{"new-agent"}) {
+		t.Fatalf("initial fire: %v", got)
+	}
+	m = next.(AppModel)
+
+	// Same state — no refire.
+	next, cmd = m.maybeNotifyActions(nil)
+	runCmd(t, cmd)
+	if len(got) != 1 {
+		t.Fatalf("unchanged should not refire: %v", got)
+	}
+	m = next.(AppModel)
+
+	// Transition: error appears, retry action joins the list.
+	m.selectModel.err = errors.New("boom")
+	next, cmd = m.maybeNotifyActions(nil)
+	runCmd(t, cmd)
+	if len(got) != 2 || !equalStrings(got[1], []string{"retry"}) {
+		t.Fatalf("error transition: %v", got)
+	}
+	m = next.(AppModel)
+
+	// Move to sessions view — list changes again.
+	m.state = viewSessions
+	next, cmd = m.maybeNotifyActions(nil)
+	runCmd(t, cmd)
+	if len(got) != 3 || !equalStrings(got[2], []string{"new-session", "back"}) {
+		t.Fatalf("sessions transition: %v", got)
+	}
+}
+
+func TestMaybeNotifyActions_NoCallbackIsNoop(t *testing.T) {
+	m := AppModel{state: viewSelect}
+	_, cmd := m.maybeNotifyActions(nil)
+	if cmd != nil {
+		t.Fatalf("no callback should yield no notify cmd, got %T", cmd)
+	}
+}
+
+func TestAppModel_TriggerActionRoutesToActiveView(t *testing.T) {
+	m := AppModel{state: viewSelect}
+	next, cmd := m.TriggerAction("new-agent")
+	if next.selectModel.subState != subStateCreate {
+		t.Fatalf("expected create form via routed TriggerAction, got %v", next.selectModel.subState)
+	}
+	if cmd == nil {
+		t.Fatal("expected initCreateForm cmd to be returned")
+	}
+}
+
+func actionIDs(as []Action) []string {
+	if len(as) == 0 {
+		return nil
+	}
+	out := make([]string, len(as))
+	for i, a := range as {
+		out[i] = a.ID
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -2,9 +2,12 @@ package tui
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
 func TestSelectModel_Actions(t *testing.T) {
@@ -94,6 +97,52 @@ func TestConfigModel_Actions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHideActionHints_Suppresses verifies the inline help line is
+// emitted by default and omitted when the embedder has signalled that
+// it surfaces the same actions itself. We assert against the rendered
+// hint substring rather than the entire view so style changes elsewhere
+// don't make the test brittle.
+func TestHideActionHints_Suppresses(t *testing.T) {
+	t.Run("select", func(t *testing.T) {
+		shown := newSelectModel(nil, false)
+		shown.loading = false
+		hidden := newSelectModel(nil, true)
+		hidden.loading = false
+		if !strings.Contains(shown.View(), "n: new agent") {
+			t.Fatalf("expected hint with hideHints=false, got: %q", shown.View())
+		}
+		if strings.Contains(hidden.View(), "n: new agent") {
+			t.Fatalf("expected no hint with hideHints=true, got: %q", hidden.View())
+		}
+	})
+	t.Run("sessions", func(t *testing.T) {
+		shown := newSessionsModel(nil, "a", "A", "m", "k", false)
+		shown.loading = false
+		hidden := newSessionsModel(nil, "a", "A", "m", "k", true)
+		hidden.loading = false
+		if !strings.Contains(shown.View(), "esc: back") {
+			t.Fatalf("expected hint with hideHints=false, got: %q", shown.View())
+		}
+		if strings.Contains(hidden.View(), "esc: back") {
+			t.Fatalf("expected no hint with hideHints=true, got: %q", hidden.View())
+		}
+	})
+	t.Run("config", func(t *testing.T) {
+		prefs := config.DefaultPreferences()
+		shown := newConfigModel(prefs, false)
+		hidden := newConfigModel(prefs, true)
+		if !strings.Contains(shown.View(), "space: toggle") {
+			t.Fatalf("expected hint with hideHints=false, got: %q", shown.View())
+		}
+		if strings.Contains(hidden.View(), "space: toggle") {
+			t.Fatalf("expected no hint with hideHints=true, got: %q", hidden.View())
+		}
+		if strings.Contains(hidden.View(), "←/→: adjust") {
+			t.Fatalf("expected ←/→ adjust hint also suppressed, got: %q", hidden.View())
+		}
+	})
 }
 
 func TestRenderActionHints(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -30,6 +30,11 @@ type AppOptions struct {
 	// view's preferred input mode changes. See app.RunOptions for the
 	// full rationale; this is the unexported plumbing.
 	OnInputFocusChanged func(wantsInput bool)
+
+	// OnActionsChanged, if non-nil, is invoked whenever the active
+	// view's set of exposed Actions changes. See app.RunOptions for
+	// the full rationale; this is the unexported plumbing.
+	OnActionsChanged func(actions []Action)
 }
 
 // AppModel is the root bubbletea model.
@@ -49,6 +54,10 @@ type AppModel struct {
 	onInputFocusChanged func(bool)
 	lastWantsInput      bool
 	inputFocusReported  bool
+
+	onActionsChanged func([]Action)
+	lastActions      []Action
+	actionsReported  bool
 }
 
 // NewApp creates the root application model.
@@ -61,6 +70,7 @@ func NewApp(c *client.Client, opts AppOptions) AppModel {
 		hideInput:           opts.HideInputArea,
 		disableMouse:        opts.DisableMouse,
 		onInputFocusChanged: opts.OnInputFocusChanged,
+		onActionsChanged:    opts.OnActionsChanged,
 	}
 }
 
@@ -70,7 +80,76 @@ func (m AppModel) Init() tea.Cmd {
 
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	next, cmd := m.update(msg)
-	return next.maybeNotifyInputFocus(cmd)
+	nextModel, cmd := next.maybeNotifyInputFocus(cmd)
+	next = nextModel.(AppModel)
+	return next.maybeNotifyActions(cmd)
+}
+
+// Actions returns the discoverable, view-level commands the active
+// view currently exposes. AppModel re-publishes the slice on every
+// transition through OnActionsChanged so embedders can rebuild their
+// action UI without polling.
+func (m AppModel) Actions() []Action {
+	switch m.state {
+	case viewSelect:
+		return m.selectModel.Actions()
+	case viewSessions:
+		return m.sessionsModel.Actions()
+	case viewConfig:
+		return m.configModel.Actions()
+	}
+	return nil
+}
+
+// TriggerAction routes an embedder-issued action invocation to the
+// active view. Both keystrokes (handled inside each view's KeyPressMsg
+// switch) and external triggers (Program.TriggerAction) go through the
+// view's TriggerAction so the work lives in one place.
+func (m AppModel) TriggerAction(id string) (AppModel, tea.Cmd) {
+	switch m.state {
+	case viewSelect:
+		var cmd tea.Cmd
+		m.selectModel, cmd = m.selectModel.TriggerAction(id)
+		return m, cmd
+	case viewSessions:
+		var cmd tea.Cmd
+		m.sessionsModel, cmd = m.sessionsModel.TriggerAction(id)
+		return m, cmd
+	case viewConfig:
+		var cmd tea.Cmd
+		m.configModel, cmd = m.configModel.TriggerAction(id)
+		return m, cmd
+	}
+	return m, nil
+}
+
+// maybeNotifyActions invokes OnActionsChanged whenever the computed
+// actions slice differs from the last value reported. Mirrors
+// maybeNotifyInputFocus: the first call after Init always fires so
+// embedders see the startup list, and the callback runs from a tea.Cmd
+// so the bubbletea event loop is not blocked by embedder work.
+func (m AppModel) maybeNotifyActions(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if m.onActionsChanged == nil {
+		return m, cmd
+	}
+	actions := m.Actions()
+	if m.actionsReported && actionsEqual(actions, m.lastActions) {
+		return m, cmd
+	}
+	// Snapshot the slice so a downstream mutation by the next Update
+	// can't be observed retroactively through lastActions.
+	snapshot := append([]Action(nil), actions...)
+	m.lastActions = snapshot
+	m.actionsReported = true
+	cb := m.onActionsChanged
+	notify := func() tea.Msg {
+		cb(snapshot)
+		return nil
+	}
+	if cmd == nil {
+		return m, notify
+	}
+	return m, tea.Batch(cmd, notify)
 }
 
 // computeWantsInput reports whether the active view currently has a focused
@@ -192,6 +271,9 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
+
+	case TriggerActionMsg:
+		return m.TriggerAction(msg.ID)
 
 	case tea.KeyPressMsg:
 		switch msg.String() {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -24,6 +24,7 @@ const (
 // rationale.
 type AppOptions struct {
 	HideInputArea bool
+	DisableMouse  bool
 }
 
 // AppModel is the root bubbletea model.
@@ -38,16 +39,18 @@ type AppModel struct {
 	width         int
 	height        int
 	hideInput     bool
+	disableMouse  bool
 }
 
 // NewApp creates the root application model.
 func NewApp(c *client.Client, opts AppOptions) AppModel {
 	return AppModel{
-		state:       viewSelect,
-		selectModel: newSelectModel(c),
-		client:      c,
-		prefs:       config.LoadPreferences(),
-		hideInput:   opts.HideInputArea,
+		state:        viewSelect,
+		selectModel:  newSelectModel(c),
+		client:       c,
+		prefs:        config.LoadPreferences(),
+		hideInput:    opts.HideInputArea,
+		disableMouse: opts.DisableMouse,
 	}
 }
 
@@ -220,7 +223,9 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView("")
 	}
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeCellMotion
+	if !m.disableMouse {
+		v.MouseMode = tea.MouseModeCellMotion
+	}
 	v.KeyboardEnhancements.ReportEventTypes = true
 	return v
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,6 +18,14 @@ const (
 	viewConfig
 )
 
+// AppOptions configures an AppModel. Embedders that drive the program from
+// a platform-native input surface (so the in-TUI textarea would be
+// duplicate UI) set HideInputArea; see app.RunOptions for the full
+// rationale.
+type AppOptions struct {
+	HideInputArea bool
+}
+
 // AppModel is the root bubbletea model.
 type AppModel struct {
 	state         viewState
@@ -29,15 +37,17 @@ type AppModel struct {
 	prefs         config.Preferences
 	width         int
 	height        int
+	hideInput     bool
 }
 
 // NewApp creates the root application model.
-func NewApp(c *client.Client) AppModel {
+func NewApp(c *client.Client, opts AppOptions) AppModel {
 	return AppModel{
 		state:       viewSelect,
 		selectModel: newSelectModel(c),
 		client:      c,
 		prefs:       config.LoadPreferences(),
+		hideInput:   opts.HideInputArea,
 	}
 }
 
@@ -92,7 +102,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.sessionsModel.Init()
 
 	case sessionSelectedMsg:
-		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs)
+		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -103,7 +113,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sessionsModel.loading = false
 			return m, nil
 		}
-		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs)
+		m.chatModel = newChatModel(m.client, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -118,7 +128,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.state = viewSelect
 			return m, nil
 		}
-		m.chatModel = newChatModel(m.client, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs)
+		m.chatModel = newChatModel(m.client, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -25,6 +25,11 @@ const (
 type AppOptions struct {
 	HideInputArea bool
 	DisableMouse  bool
+
+	// OnInputFocusChanged, if non-nil, is invoked whenever the active
+	// view's preferred input mode changes. See app.RunOptions for the
+	// full rationale; this is the unexported plumbing.
+	OnInputFocusChanged func(wantsInput bool)
 }
 
 // AppModel is the root bubbletea model.
@@ -40,17 +45,22 @@ type AppModel struct {
 	height        int
 	hideInput     bool
 	disableMouse  bool
+
+	onInputFocusChanged func(bool)
+	lastWantsInput      bool
+	inputFocusReported  bool
 }
 
 // NewApp creates the root application model.
 func NewApp(c *client.Client, opts AppOptions) AppModel {
 	return AppModel{
-		state:        viewSelect,
-		selectModel:  newSelectModel(c),
-		client:       c,
-		prefs:        config.LoadPreferences(),
-		hideInput:    opts.HideInputArea,
-		disableMouse: opts.DisableMouse,
+		state:               viewSelect,
+		selectModel:         newSelectModel(c),
+		client:              c,
+		prefs:               config.LoadPreferences(),
+		hideInput:           opts.HideInputArea,
+		disableMouse:        opts.DisableMouse,
+		onInputFocusChanged: opts.OnInputFocusChanged,
 	}
 }
 
@@ -59,6 +69,53 @@ func (m AppModel) Init() tea.Cmd {
 }
 
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := m.update(msg)
+	return next.maybeNotifyInputFocus(cmd)
+}
+
+// computeWantsInput reports whether the active view currently has a focused
+// text-input widget that expects free-form typing (the chat textarea, the
+// new-agent form fields). Embedders use this signal to decide whether to
+// surface their on-screen keyboard. List- and viewport-only views (agent
+// list, sessions, config) return false: they only need the platform's
+// existing navigation affordances.
+func (m AppModel) computeWantsInput() bool {
+	switch m.state {
+	case viewChat:
+		return true
+	case viewSelect:
+		return m.selectModel.subState == subStateCreate
+	}
+	return false
+}
+
+// maybeNotifyInputFocus invokes the OnInputFocusChanged callback whenever
+// the computed input-focus state differs from the last value reported. The
+// first call after Init always fires so embedders see the startup state
+// without having to assume a default. The callback runs from a tea.Cmd so
+// the bubbletea event loop is not blocked by embedder work.
+func (m AppModel) maybeNotifyInputFocus(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if m.onInputFocusChanged == nil {
+		return m, cmd
+	}
+	wants := m.computeWantsInput()
+	if m.inputFocusReported && wants == m.lastWantsInput {
+		return m, cmd
+	}
+	m.lastWantsInput = wants
+	m.inputFocusReported = true
+	cb := m.onInputFocusChanged
+	notify := func() tea.Msg {
+		cb(wants)
+		return nil
+	}
+	if cmd == nil {
+		return m, notify
+	}
+	return m, tea.Batch(cmd, notify)
+}
+
+func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -23,8 +23,9 @@ const (
 // duplicate UI) set HideInputArea; see app.RunOptions for the full
 // rationale.
 type AppOptions struct {
-	HideInputArea bool
-	DisableMouse  bool
+	HideInputArea   bool
+	HideActionHints bool
+	DisableMouse    bool
 
 	// OnInputFocusChanged, if non-nil, is invoked whenever the active
 	// view's preferred input mode changes. See app.RunOptions for the
@@ -39,17 +40,18 @@ type AppOptions struct {
 
 // AppModel is the root bubbletea model.
 type AppModel struct {
-	state         viewState
-	selectModel   selectModel
-	chatModel     chatModel
-	sessionsModel sessionsModel
-	configModel   configModel
-	client        *client.Client
-	prefs         config.Preferences
-	width         int
-	height        int
-	hideInput     bool
-	disableMouse  bool
+	state           viewState
+	selectModel     selectModel
+	chatModel       chatModel
+	sessionsModel   sessionsModel
+	configModel     configModel
+	client          *client.Client
+	prefs           config.Preferences
+	width           int
+	height          int
+	hideInput       bool
+	hideActionHints bool
+	disableMouse    bool
 
 	onInputFocusChanged func(bool)
 	lastWantsInput      bool
@@ -64,10 +66,11 @@ type AppModel struct {
 func NewApp(c *client.Client, opts AppOptions) AppModel {
 	return AppModel{
 		state:               viewSelect,
-		selectModel:         newSelectModel(c),
+		selectModel:         newSelectModel(c, opts.HideActionHints),
 		client:              c,
 		prefs:               config.LoadPreferences(),
 		hideInput:           opts.HideInputArea,
+		hideActionHints:     opts.HideActionHints,
 		disableMouse:        opts.DisableMouse,
 		onInputFocusChanged: opts.OnInputFocusChanged,
 		onActionsChanged:    opts.OnActionsChanged,
@@ -231,7 +234,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		return m, nil
 
 	case showConfigMsg:
-		m.configModel = newConfigModel(m.prefs)
+		m.configModel = newConfigModel(m.prefs, m.hideActionHints)
 		m.configModel.setSize(m.width, m.height)
 		m.state = viewConfig
 		return m, nil
@@ -250,7 +253,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		return m, nil
 
 	case showSessionsMsg:
-		m.sessionsModel = newSessionsModel(m.client, msg.agentID, msg.agentName, msg.modelID, msg.mainKey)
+		m.sessionsModel = newSessionsModel(m.client, msg.agentID, msg.agentName, msg.modelID, msg.mainKey, m.hideActionHints)
 		m.sessionsModel.setSize(m.width, m.height)
 		m.state = viewSessions
 		return m, m.sessionsModel.Init()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -79,7 +79,22 @@ func (m AppModel) Init() tea.Cmd {
 }
 
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	prevState := m.state
 	next, cmd := m.update(msg)
+	if next.state != prevState {
+		// View transitions in an embedded terminal can leave stale cells
+		// from the previous view when an on-screen keyboard
+		// simultaneously toggles and resizes the embedder's grid
+		// mid-transition. Bubble Tea's incremental renderer assumes
+		// the host terminal preserves its grid across resizes; some
+		// embedded terminals don't after a rapid show/hide/show
+		// keyboard sequence (e.g. picker → create-form → picker →
+		// chat). Forcing a clear-screen on every viewState transition
+		// guarantees the next render starts from a known-empty grid.
+		// The CLI hardly notices — terminal emulators repaint a single
+		// CSI 2J in microseconds.
+		cmd = tea.Batch(cmd, tea.ClearScreen)
+	}
 	nextModel, cmd := next.maybeNotifyInputFocus(cmd)
 	next = nextModel.(AppModel)
 	return next.maybeNotifyActions(cmd)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,127 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestComputeWantsInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    viewState
+		subState selectSubState
+		want     bool
+	}{
+		{"select list — navigation only", viewSelect, subStateList, false},
+		{"select create-form — typing required", viewSelect, subStateCreate, true},
+		{"chat — textarea always focused", viewChat, subStateList, true},
+		{"sessions — list navigation", viewSessions, subStateList, false},
+		{"config — toggle navigation", viewConfig, subStateList, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := AppModel{state: tc.state}
+			m.selectModel.subState = tc.subState
+			if got := m.computeWantsInput(); got != tc.want {
+				t.Fatalf("wants=%v, got=%v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMaybeNotifyInputFocus_FiresOnChange(t *testing.T) {
+	var got []bool
+	m := AppModel{
+		state:               viewSelect,
+		onInputFocusChanged: func(b bool) { got = append(got, b) },
+	}
+
+	// First call must fire with the initial state so embedders need not
+	// assume a default.
+	_, cmd := m.maybeNotifyInputFocus(nil)
+	runCmd(t, cmd)
+	if len(got) != 1 || got[0] != false {
+		t.Fatalf("initial fire: got=%v", got)
+	}
+
+	// Mark reported as the previous call's returned model would have.
+	m.inputFocusReported = true
+	m.lastWantsInput = false
+
+	// No state change — callback must not fire again.
+	_, cmd = m.maybeNotifyInputFocus(nil)
+	runCmd(t, cmd)
+	if len(got) != 1 {
+		t.Fatalf("unchanged state should not refire: got=%v", got)
+	}
+
+	// Transition into chat — fire with true.
+	m.state = viewChat
+	_, cmd = m.maybeNotifyInputFocus(nil)
+	runCmd(t, cmd)
+	if len(got) != 2 || got[1] != true {
+		t.Fatalf("chat fire: got=%v", got)
+	}
+	m.lastWantsInput = true
+
+	// Transition into sessions — fire with false.
+	m.state = viewSessions
+	_, cmd = m.maybeNotifyInputFocus(nil)
+	runCmd(t, cmd)
+	if len(got) != 3 || got[2] != false {
+		t.Fatalf("sessions fire: got=%v", got)
+	}
+	m.lastWantsInput = false
+
+	// Enter the create-agent form from the agent list — fire with true.
+	m.state = viewSelect
+	m.selectModel.subState = subStateCreate
+	_, cmd = m.maybeNotifyInputFocus(nil)
+	runCmd(t, cmd)
+	if len(got) != 4 || got[3] != true {
+		t.Fatalf("create-form fire: got=%v", got)
+	}
+}
+
+func TestMaybeNotifyInputFocus_NoCallbackIsNoop(t *testing.T) {
+	m := AppModel{state: viewChat}
+	_, cmd := m.maybeNotifyInputFocus(nil)
+	if cmd != nil {
+		t.Fatalf("no callback should yield no notify cmd, got %T", cmd)
+	}
+}
+
+func TestMaybeNotifyInputFocus_PreservesIncomingCmd(t *testing.T) {
+	var got []bool
+	var inner bool
+	innerCmd := func() tea.Msg { inner = true; return nil }
+	m := AppModel{
+		state:               viewSelect,
+		onInputFocusChanged: func(b bool) { got = append(got, b) },
+	}
+	_, cmd := m.maybeNotifyInputFocus(innerCmd)
+	runCmd(t, cmd)
+	if !inner {
+		t.Fatal("inner cmd was dropped")
+	}
+	if len(got) != 1 || got[0] != false {
+		t.Fatalf("notify cmd did not fire: got=%v", got)
+	}
+}
+
+// runCmd drains a Cmd by invoking it and recursing into any BatchMsg it
+// returns. Tests use it to flush the focus-notify cmd produced by
+// maybeNotifyInputFocus alongside any inner cmd it was batched with.
+func runCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			runCmd(t, c)
+		}
+	}
+}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -714,7 +714,7 @@ func (m *chatModel) setSize(w, h int) {
 	borderH := 2
 	vpHeight := h - inputHeight - headerH - helpH - borderH - 2
 	if m.hideInput {
-		vpHeight = h - headerH - 2
+		vpHeight = h - headerH - helpH - 2
 	}
 
 	m.viewport.SetWidth(w)
@@ -756,14 +756,6 @@ func (m chatModel) View() string {
 		Width(m.width).
 		Render(title)
 
-	if m.hideInput {
-		return lipgloss.JoinVertical(
-			lipgloss.Left,
-			header,
-			m.viewport.View(),
-		)
-	}
-
 	borderStyle := inputBorderStyle
 	isRemoteExec := strings.HasPrefix(m.textarea.Value(), "!!")
 	isLocalExec := !isRemoteExec && strings.HasPrefix(m.textarea.Value(), "!")
@@ -772,9 +764,6 @@ func (m chatModel) View() string {
 	} else if isLocalExec {
 		borderStyle = localExecBorderStyle
 	}
-	input := borderStyle.
-		Width(m.width - 4).
-		Render(m.textarea.View())
 
 	var help string
 	if isRemoteExec {
@@ -785,6 +774,8 @@ func (m chatModel) View() string {
 		hint := m.slashCommandHint(m.textarea.Value())
 		if hint != "" {
 			help = helpStyle.Render(fmt.Sprintf(" %s%s — tab to complete", m.textarea.Value(), hint))
+		} else if m.hideInput {
+			help = helpStyle.Render(" /help: commands")
 		} else {
 			helpText := " enter: send | alt+enter: newline | /help: commands"
 			if n := len(m.pendingMessages); n > 0 {
@@ -793,6 +784,19 @@ func (m chatModel) View() string {
 			help = helpStyle.Render(helpText)
 		}
 	}
+
+	if m.hideInput {
+		return lipgloss.JoinVertical(
+			lipgloss.Left,
+			header,
+			m.viewport.View(),
+			help,
+		)
+	}
+
+	input := borderStyle.
+		Width(m.width - 4).
+		Render(m.textarea.View())
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -114,6 +114,7 @@ type chatModel struct {
 	historyLimit     int
 	thinkingLevel    string // current thinking level; "" means not set / using gateway default
 	connState        ConnStateMsg
+	hideInput        bool // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -152,7 +153,7 @@ func (m *chatModel) ensureSpinnerTicking() tea.Cmd {
 	return spinnerTickCmd()
 }
 
-func newChatModel(c *client.Client, sessionKey, agentID, agentName, modelID string, prefs config.Preferences) chatModel {
+func newChatModel(c *client.Client, sessionKey, agentID, agentName, modelID string, prefs config.Preferences, hideInput bool) chatModel {
 	ta := textarea.New()
 	ta.Placeholder = "Type a message..."
 	ta.Focus()
@@ -182,6 +183,7 @@ func newChatModel(c *client.Client, sessionKey, agentID, agentName, modelID stri
 		modelID:      modelID,
 		prefs:        prefs,
 		historyLimit: prefs.HistoryLimit,
+		hideInput:    hideInput,
 	}
 }
 
@@ -711,6 +713,9 @@ func (m *chatModel) setSize(w, h int) {
 	helpH := 1
 	borderH := 2
 	vpHeight := h - inputHeight - headerH - helpH - borderH - 2
+	if m.hideInput {
+		vpHeight = h - headerH - 2
+	}
 
 	m.viewport.SetWidth(w)
 	m.viewport.SetHeight(vpHeight)
@@ -750,6 +755,14 @@ func (m chatModel) View() string {
 	header := headerStyle.
 		Width(m.width).
 		Render(title)
+
+	if m.hideInput {
+		return lipgloss.JoinVertical(
+			lipgloss.Left,
+			header,
+			m.viewport.View(),
+		)
+	}
 
 	borderStyle := inputBorderStyle
 	isRemoteExec := strings.HasPrefix(m.textarea.Value(), "!!")

--- a/internal/tui/configview.go
+++ b/internal/tui/configview.go
@@ -93,9 +93,32 @@ func (m configModel) Update(msg tea.Msg) (configModel, tea.Cmd) {
 					return prefsUpdatedMsg{prefs: prefs}
 				}
 			}
-		case "esc":
-			return m, func() tea.Msg { return goBackFromConfigMsg{} }
+		default:
+			// Discoverable shortcuts route through TriggerAction so the
+			// help line and the keystroke share a single source of truth.
+			for _, a := range m.Actions() {
+				if a.Key == msg.String() {
+					return m.TriggerAction(a.ID)
+				}
+			}
 		}
+	}
+	return m, nil
+}
+
+// Actions returns the discoverable, view-level commands the config
+// view exposes. The space/←/→ controls are intentionally not actions —
+// they operate on the focused row, not the screen as a whole, and would
+// not translate cleanly into named buttons on mobile.
+func (m configModel) Actions() []Action {
+	return []Action{{ID: "back", Label: "Back", Key: "esc"}}
+}
+
+// TriggerAction invokes the named action.
+func (m configModel) TriggerAction(id string) (configModel, tea.Cmd) {
+	switch id {
+	case "back":
+		return m, func() tea.Msg { return goBackFromConfigMsg{} }
 	}
 	return m, nil
 }
@@ -138,7 +161,14 @@ func (m configModel) View() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("  space: toggle · ←/→: adjust · esc: back"))
+	// Item-level controls (space, ←/→) stay hand-rendered alongside the
+	// auto-rendered screen-level actions (back) so both surfaces are
+	// visible without forcing them into the actions abstraction.
+	hint := "  space: toggle · ←/→: adjust"
+	if h := renderActionHints(m.Actions()); h != "" {
+		hint += " ·" + strings.TrimPrefix(h, " ")
+	}
+	b.WriteString(helpStyle.Render(hint))
 
 	return b.String()
 }

--- a/internal/tui/configview.go
+++ b/internal/tui/configview.go
@@ -60,17 +60,6 @@ func (m configModel) Update(msg tea.Msg) (configModel, tea.Cmd) {
 			if m.cursor < len(m.items)-1 {
 				m.cursor++
 			}
-		case "space":
-			item := &m.items[m.cursor]
-			if item.kind == configItemBool {
-				item.checked = !item.checked
-				m.applyToPrefs()
-				prefs := m.prefs
-				return m, func() tea.Msg {
-					_ = config.SavePreferences(prefs)
-					return prefsUpdatedMsg{prefs: prefs}
-				}
-			}
 		case "left", "h":
 			item := &m.items[m.cursor]
 			if item.kind == configItemInt && item.value-item.step >= item.min {
@@ -107,16 +96,38 @@ func (m configModel) Update(msg tea.Msg) (configModel, tea.Cmd) {
 }
 
 // Actions returns the discoverable, view-level commands the config
-// view exposes. The space/←/→ controls are intentionally not actions —
-// they operate on the focused row, not the screen as a whole, and would
-// not translate cleanly into named buttons on mobile.
+// view exposes. `toggle` is only present when the focused row is a bool
+// item — flipping a checkbox is the only configurable operation that
+// translates cleanly into a single named button on embedders with a
+// native action surface. The ←/→ adjust controls remain inline (per-row
+// form controls, not screen commands), so they don't appear here.
 func (m configModel) Actions() []Action {
-	return []Action{{ID: "back", Label: "Back", Key: "esc"}}
+	actions := make([]Action, 0, 2)
+	if m.cursor >= 0 && m.cursor < len(m.items) && m.items[m.cursor].kind == configItemBool {
+		actions = append(actions, Action{ID: "toggle", Label: "Toggle", Key: "space"})
+	}
+	actions = append(actions, Action{ID: "back", Label: "Back", Key: "esc"})
+	return actions
 }
 
 // TriggerAction invokes the named action.
 func (m configModel) TriggerAction(id string) (configModel, tea.Cmd) {
 	switch id {
+	case "toggle":
+		if m.cursor < 0 || m.cursor >= len(m.items) {
+			return m, nil
+		}
+		item := &m.items[m.cursor]
+		if item.kind != configItemBool {
+			return m, nil
+		}
+		item.checked = !item.checked
+		m.applyToPrefs()
+		prefs := m.prefs
+		return m, func() tea.Msg {
+			_ = config.SavePreferences(prefs)
+			return prefsUpdatedMsg{prefs: prefs}
+		}
 	case "back":
 		return m, func() tea.Msg { return goBackFromConfigMsg{} }
 	}
@@ -161,12 +172,14 @@ func (m configModel) View() string {
 	}
 
 	b.WriteString("\n")
-	// Item-level controls (space, ←/→) stay hand-rendered alongside the
-	// auto-rendered screen-level actions (back) so both surfaces are
-	// visible without forcing them into the actions abstraction.
-	hint := "  space: toggle · ←/→: adjust"
-	if h := renderActionHints(m.Actions()); h != "" {
-		hint += " ·" + strings.TrimPrefix(h, " ")
+	// `toggle` and `back` come out of Actions(); ←/→ adjust stays
+	// hand-rendered as a per-row form control (it operates on whichever
+	// int item the cursor is on, not on the screen as a whole).
+	hint := renderActionHints(m.Actions())
+	if hint == "" {
+		hint = "  ←/→: adjust"
+	} else {
+		hint += " · ←/→: adjust"
 	}
 	b.WriteString(helpStyle.Render(hint))
 

--- a/internal/tui/configview.go
+++ b/internal/tui/configview.go
@@ -29,16 +29,18 @@ type configItem struct {
 }
 
 type configModel struct {
-	items  []configItem
-	cursor int
-	prefs  config.Preferences
-	width  int
-	height int
+	items     []configItem
+	cursor    int
+	prefs     config.Preferences
+	width     int
+	height    int
+	hideHints bool
 }
 
-func newConfigModel(prefs config.Preferences) configModel {
+func newConfigModel(prefs config.Preferences, hideHints bool) configModel {
 	return configModel{
-		prefs: prefs,
+		prefs:     prefs,
+		hideHints: hideHints,
 		items: []configItem{
 			{label: "Completion notification (terminal bell)", key: "completionBell", kind: configItemBool, checked: prefs.CompletionBell},
 			{label: "History limit (messages loaded per session)", key: "historyLimit", kind: configItemInt, value: prefs.HistoryLimit, min: 10, max: 500, step: 10},
@@ -171,17 +173,20 @@ func (m configModel) View() string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\n")
-	// `toggle` and `back` come out of Actions(); ←/→ adjust stays
-	// hand-rendered as a per-row form control (it operates on whichever
-	// int item the cursor is on, not on the screen as a whole).
-	hint := renderActionHints(m.Actions())
-	if hint == "" {
-		hint = "  ←/→: adjust"
-	} else {
-		hint += " · ←/→: adjust"
+	if !m.hideHints {
+		b.WriteString("\n")
+		// `toggle` and `back` come out of Actions(); ←/→ adjust stays
+		// hand-rendered as a per-row form control (it operates on
+		// whichever int item the cursor is on, not on the screen as a
+		// whole).
+		hint := renderActionHints(m.Actions())
+		if hint == "" {
+			hint = "  ←/→: adjust"
+		} else {
+			hint += " · ←/→: adjust"
+		}
+		b.WriteString(helpStyle.Render(hint))
 	}
-	b.WriteString(helpStyle.Render(hint))
 
 	return b.String()
 }

--- a/internal/tui/configview_test.go
+++ b/internal/tui/configview_test.go
@@ -11,7 +11,7 @@ import (
 
 func newTestConfigModel() configModel {
 	prefs := config.DefaultPreferences()
-	m := newConfigModel(prefs)
+	m := newConfigModel(prefs, false)
 	m.setSize(80, 30)
 	return m
 }
@@ -45,7 +45,7 @@ func TestConfigModel_View_CheckedByDefault(t *testing.T) {
 
 func TestConfigModel_View_UncheckedWhenDisabled(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: false}
-	m := newConfigModel(prefs)
+	m := newConfigModel(prefs, false)
 	view := m.View()
 	if !strings.Contains(view, "[ ]") {
 		t.Error("expected unchecked checkbox when CompletionBell is false")
@@ -75,7 +75,7 @@ func TestConfigModel_SpaceTogglesOff(t *testing.T) {
 
 func TestConfigModel_SpaceTogglesOn(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: false}
-	m := newConfigModel(prefs)
+	m := newConfigModel(prefs, false)
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: ' '})
 	if !m.items[0].checked {
@@ -168,7 +168,7 @@ func TestConfigModel_HistoryLimit_LeftDecreases(t *testing.T) {
 
 func TestConfigModel_HistoryLimit_RespectsMin(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: true, HistoryLimit: 10}
-	m := newConfigModel(prefs)
+	m := newConfigModel(prefs, false)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
@@ -182,7 +182,7 @@ func TestConfigModel_HistoryLimit_RespectsMin(t *testing.T) {
 
 func TestConfigModel_HistoryLimit_RespectsMax(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: true, HistoryLimit: 500}
-	m := newConfigModel(prefs)
+	m := newConfigModel(prefs, false)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyRight})

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewChatModel_DeleteWordBackwardBinding(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 
 	// ctrl+w should match DeleteWordBackward.
 	ctrlW := tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl}
@@ -34,7 +34,7 @@ func TestNewChatModel_DeleteWordBackwardBinding(t *testing.T) {
 }
 
 func TestNewChatModel_InsertNewlineBinding(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 
 	// Plain enter should NOT match InsertNewline.
 	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
@@ -50,7 +50,7 @@ func TestNewChatModel_InsertNewlineBinding(t *testing.T) {
 }
 
 func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -71,7 +71,7 @@ func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
 }
 
 func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -85,7 +85,7 @@ func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
 }
 
 func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -104,7 +104,7 @@ func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
 }
 
 func TestUpKey_RecallingOnlyMessageEmptiesQueue(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -122,7 +122,7 @@ func TestUpKey_RecallingOnlyMessageEmptiesQueue(t *testing.T) {
 }
 
 func TestUpKey_SuccessiveRecallsPopInLIFOOrder(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -154,7 +154,7 @@ func TestUpKey_SuccessiveRecallsPopInLIFOOrder(t *testing.T) {
 }
 
 func TestUpKey_RecallThenClearDiscardsMessage(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -173,7 +173,7 @@ func TestUpKey_RecallThenClearDiscardsMessage(t *testing.T) {
 }
 
 func TestUpKey_RecallEditAndRequeueWhileSending(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -201,7 +201,7 @@ func TestUpKey_RecallEditAndRequeueWhileSending(t *testing.T) {
 }
 
 func TestView_HelpShowsUpHintWhenQueued(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences())
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false)
 	m.viewport = viewport.New()
 	m.setSize(80, 30)
 	m.pendingMessages = []string{"one", "two"}

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -256,7 +256,7 @@ func TestRender_ChatView_RemoteExecModeHelpText(t *testing.T) {
 // newLoadedSelectAdapter returns a selectModelAdapter with agents already loaded.
 func newLoadedSelectAdapter(t *testing.T, agents ...protocol.AgentSummary) selectModelAdapter {
 	t.Helper()
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -293,7 +293,7 @@ func TestRender_SelectView_ShowsCreateHint(t *testing.T) {
 }
 
 func TestRender_SelectView_LoadingState(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.setSize(120, 40)
 	adapter := selectModelAdapter{inner: m}
 
@@ -317,7 +317,7 @@ func TestRender_SelectView_CreateFormLabels(t *testing.T) {
 }
 
 func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{err: errString("gateway unreachable")})
 	adapter := selectModelAdapter{inner: m}
@@ -352,7 +352,7 @@ func (a sessionsModelAdapter) View() tea.View {
 // newLoadedSessionsAdapter returns a sessionsModelAdapter with sessions already loaded.
 func newLoadedSessionsAdapter(t *testing.T, sessions ...sessionItem) sessionsModelAdapter {
 	t.Helper()
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key")
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false)
 	m.setSize(120, 40)
 	m, _ = m.Update(sessionsLoadedMsg{sessions: sessions})
 	return sessionsModelAdapter{inner: m}
@@ -382,7 +382,7 @@ func TestRender_SessionsView_ShowsCreateHint(t *testing.T) {
 }
 
 func TestRender_SessionsView_LoadingState(t *testing.T) {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key")
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false)
 	m.setSize(120, 40)
 	adapter := sessionsModelAdapter{inner: m}
 
@@ -402,7 +402,7 @@ func TestRender_SessionsView_EmptyState(t *testing.T) {
 }
 
 func TestRender_SessionsView_ErrorState(t *testing.T) {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key")
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false)
 	m.setSize(120, 40)
 	m, _ = m.Update(sessionsLoadedMsg{err: errString("network timeout")})
 	adapter := sessionsModelAdapter{inner: m}

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -74,7 +74,7 @@ func (a selectModelAdapter) View() tea.View {
 // rendering tests, wrapped in an adapter.
 func newRenderingChatModel(t *testing.T, agentName string) chatModelAdapter {
 	t.Helper()
-	m := newChatModel(nil, "session-key", "", agentName, "", config.DefaultPreferences())
+	m := newChatModel(nil, "session-key", "", agentName, "", config.DefaultPreferences(), false)
 	m.setSize(120, 40)
 	return chatModelAdapter{inner: m}
 }

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -325,7 +325,7 @@ func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
 	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
 	defer finishProgram(t, tm)
 
-	waitForContains(t, tm.Output(), "gateway unreachable", "'r' to retry")
+	waitForContains(t, tm.Output(), "gateway unreachable", "r: retry")
 }
 
 // sessionsModelAdapter wraps sessionsModel so it satisfies tea.Model for teatest.
@@ -410,7 +410,7 @@ func TestRender_SessionsView_ErrorState(t *testing.T) {
 	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
 	defer finishProgram(t, tm)
 
-	waitForContains(t, tm.Output(), "network timeout", "'r' to retry")
+	waitForContains(t, tm.Output(), "network timeout", "r: retry")
 }
 
 // errString is a tiny error helper so tests don't need to import "errors".

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -70,12 +70,13 @@ var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // selectModel is the agent selection view.
 type selectModel struct {
-	list     list.Model
-	client   *client.Client
-	loading  bool
-	err      error
-	mainKey  string
-	selected bool
+	list      list.Model
+	client    *client.Client
+	loading   bool
+	err       error
+	mainKey   string
+	selected  bool
+	hideHints bool
 
 	// Create-agent form state.
 	subState       selectSubState
@@ -95,18 +96,24 @@ type agentsLoadedMsg struct {
 	err    error
 }
 
-func newSelectModel(c *client.Client) selectModel {
+func newSelectModel(c *client.Client, hideHints bool) selectModel {
 	l := list.New(nil, agentDelegate{}, 0, 0)
 	l.Title = "Select an agent"
 	l.SetShowStatusBar(false)
-	l.SetShowHelp(true)
+	// The bubbles list widget renders its own keyboard-hint footer
+	// ("↑/k up · ↓/j down · q quit · ? more"). Embedders that surface
+	// actions through native controls suppress every hint line — those
+	// keys typically aren't reachable from the host's input surface
+	// anyway.
+	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
 
 	return selectModel{
-		list:    l,
-		client:  c,
-		loading: true,
+		list:      l,
+		client:    c,
+		loading:   true,
+		hideHints: hideHints,
 	}
 }
 
@@ -384,19 +391,30 @@ func (m selectModel) View() string {
 	if m.loading {
 		return "\n  Connecting to gateway...\n"
 	}
+	hints := m.renderHints()
 	if m.err != nil {
 		var b strings.Builder
 		b.WriteString("\n")
 		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
 		b.WriteString("\n\n")
-		b.WriteString(helpStyle.Render(renderActionHints(m.Actions())))
+		b.WriteString(hints)
 		b.WriteString("\n")
 		return b.String()
 	}
 	if m.subState == subStateCreate {
 		return m.viewCreateForm()
 	}
-	return m.list.View() + "\n" + helpStyle.Render(renderActionHints(m.Actions()))
+	return m.list.View() + "\n" + hints
+}
+
+// renderHints emits the inline action-hint help line, or the empty
+// string when the embedder has signalled (via HideActionHints) that it
+// will surface the same actions through native controls.
+func (m selectModel) renderHints() string {
+	if m.hideHints {
+		return ""
+	}
+	return helpStyle.Render(renderActionHints(m.Actions()))
 }
 
 func (m selectModel) viewCreateForm() string {

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -247,32 +247,71 @@ func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 		return m.handleCreateKey(msg)
 	}
 
-	// List sub-state keys.
-	switch msg.String() {
-	case "enter":
+	// Enter is intrinsic list navigation (select the highlighted item)
+	// rather than a discoverable view-level command, so it stays inline.
+	if msg.String() == "enter" {
 		if !m.loading && m.err == nil {
-			if item, ok := m.list.SelectedItem().(agentItem); ok {
+			if _, ok := m.list.SelectedItem().(agentItem); ok {
 				m.selected = true
-				_ = item
 				return m, nil
 			}
 		}
-	case "n":
-		if !m.loading && m.err == nil {
-			cmd := m.initCreateForm()
-			return m, cmd
-		}
-	case "r":
-		if m.err != nil {
-			m.loading = true
-			m.err = nil
-			return m, m.loadAgents()
+	}
+
+	// Discoverable shortcuts route through TriggerAction so the help
+	// line and the keystroke share a single source of truth (Actions()).
+	for _, a := range m.Actions() {
+		if a.Key == msg.String() {
+			return m.TriggerAction(a.ID)
 		}
 	}
 
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
 	return m, cmd
+}
+
+// Actions returns the discoverable, view-level commands the agent
+// picker currently exposes. The TUI auto-renders the help line from
+// this list and dispatches matching keystrokes through TriggerAction;
+// embedders render the same list as buttons.
+//
+// The create-agent sub-state has its own modal Tab/Enter/Esc
+// interactions and intentionally exposes no actions — those keys are
+// inherent form navigation, not discoverable commands.
+func (m selectModel) Actions() []Action {
+	if m.subState != subStateList {
+		return nil
+	}
+	var actions []Action
+	if !m.loading && m.err == nil {
+		actions = append(actions, Action{ID: "new-agent", Label: "New agent", Key: "n"})
+	}
+	if m.err != nil {
+		actions = append(actions, Action{ID: "retry", Label: "Retry", Key: "r"})
+	}
+	return actions
+}
+
+// TriggerAction invokes the named action. Both keystrokes (via
+// handleKey) and embedder calls (via Program.TriggerAction) reach the
+// same dispatcher so logic is not duplicated.
+func (m selectModel) TriggerAction(id string) (selectModel, tea.Cmd) {
+	switch id {
+	case "new-agent":
+		if m.loading || m.err != nil {
+			return m, nil
+		}
+		return m, m.initCreateForm()
+	case "retry":
+		if m.err == nil {
+			return m, nil
+		}
+		m.loading = true
+		m.err = nil
+		return m, m.loadAgents()
+	}
+	return m, nil
 }
 
 func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
@@ -350,14 +389,14 @@ func (m selectModel) View() string {
 		b.WriteString("\n")
 		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
 		b.WriteString("\n\n")
-		b.WriteString(helpStyle.Render("  Press 'r' to retry, 'q' to quit"))
+		b.WriteString(helpStyle.Render(renderActionHints(m.Actions())))
 		b.WriteString("\n")
 		return b.String()
 	}
 	if m.subState == subStateCreate {
 		return m.viewCreateForm()
 	}
-	return m.list.View() + "\n" + helpStyle.Render("  n: new agent")
+	return m.list.View() + "\n" + helpStyle.Render(renderActionHints(m.Actions()))
 }
 
 func (m selectModel) viewCreateForm() string {

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -39,7 +39,7 @@ func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -60,7 +60,7 @@ func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 
 	msg := agentsLoadedMsg{
 		err: fmt.Errorf("connection failed"),
@@ -77,7 +77,7 @@ func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormActivation(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	// Simulate agents loaded so the list is ready.
 	m.loading = false
 
@@ -89,7 +89,7 @@ func TestSelectModel_CreateFormActivation(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormCancel(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 	if m.subState != subStateCreate {
@@ -104,7 +104,7 @@ func TestSelectModel_CreateFormCancel(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormNotActivatedWhileLoading(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	// loading is true by default
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
@@ -157,7 +157,7 @@ func TestValidateName(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -180,7 +180,7 @@ func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -199,7 +199,7 @@ func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -222,7 +222,7 @@ func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedError(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -242,7 +242,7 @@ func TestSelectModel_AgentCreatedError(t *testing.T) {
 }
 
 func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
-	m := newSelectModel(nil)
+	m := newSelectModel(nil, false)
 	m.newAgentID = "new-agent"
 
 	m, _ = m.Update(agentsLoadedMsg{

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -263,6 +263,8 @@ func (m *sessionsModel) skipHeaders(dir int) {
 }
 
 func (m sessionsModel) handleKey(msg tea.KeyPressMsg) (sessionsModel, tea.Cmd) {
+	// Cursor navigation stays inline — these are intrinsic list controls,
+	// not discoverable view-level commands.
 	switch msg.String() {
 	case "up", "k":
 		m.list, _ = m.list.Update(msg)
@@ -287,8 +289,42 @@ func (m sessionsModel) handleKey(msg tea.KeyPressMsg) (sessionsModel, tea.Cmd) {
 				}
 			}
 		}
+	}
 
-	case "n":
+	// Discoverable shortcuts route through TriggerAction so the help
+	// line and the keystroke share a single source of truth (Actions()).
+	for _, a := range m.Actions() {
+		if a.Key == msg.String() {
+			return m.TriggerAction(a.ID)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// Actions returns the discoverable, view-level commands the session
+// browser currently exposes. Loading/error transitions are reflected
+// because the list is recomputed on every Update tick.
+func (m sessionsModel) Actions() []Action {
+	var actions []Action
+	if !m.loading && m.err == nil {
+		actions = append(actions, Action{ID: "new-session", Label: "New session", Key: "n"})
+	}
+	actions = append(actions, Action{ID: "back", Label: "Back", Key: "esc"})
+	if m.err != nil {
+		actions = append(actions, Action{ID: "retry", Label: "Retry", Key: "r"})
+	}
+	return actions
+}
+
+// TriggerAction invokes the named action. Both keystrokes (via
+// handleKey) and embedder calls (via Program.TriggerAction) reach the
+// same dispatcher.
+func (m sessionsModel) TriggerAction(id string) (sessionsModel, tea.Cmd) {
+	switch id {
+	case "new-session":
 		if m.loading || m.err != nil {
 			return m, nil
 		}
@@ -306,33 +342,30 @@ func (m sessionsModel) handleKey(msg tea.KeyPressMsg) (sessionsModel, tea.Cmd) {
 				err:        err,
 			}
 		}
-
-	case "esc":
+	case "back":
 		return m, func() tea.Msg { return goBackFromSessionsMsg{} }
-
-	case "r":
-		if m.err != nil {
-			m.loading = true
-			m.err = nil
-			return m, m.loadSessions()
+	case "retry":
+		if m.err == nil {
+			return m, nil
 		}
+		m.loading = true
+		m.err = nil
+		return m, m.loadSessions()
 	}
-
-	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
-	return m, cmd
+	return m, nil
 }
 
 func (m sessionsModel) View() string {
 	if m.loading {
 		return "\n  Loading sessions...\n"
 	}
+	hints := helpStyle.Render(renderActionHints(m.Actions()))
 	if m.err != nil {
 		var b strings.Builder
 		b.WriteString("\n")
 		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
 		b.WriteString("\n\n")
-		b.WriteString(helpStyle.Render("  Press 'r' to retry, Esc to go back"))
+		b.WriteString(hints)
 		b.WriteString("\n")
 		return b.String()
 	}
@@ -342,11 +375,11 @@ func (m sessionsModel) View() string {
 		b.WriteString(headerStyle.Render(" Sessions "))
 		b.WriteString("\n\n")
 		b.WriteString("  No sessions found.\n\n")
-		b.WriteString(helpStyle.Render("  n: new session | Esc: back"))
+		b.WriteString(hints)
 		b.WriteString("\n")
 		return b.String()
 	}
-	return m.list.View() + "\n" + helpStyle.Render("  n: new session | Esc: back")
+	return m.list.View() + "\n" + hints
 }
 
 func (m *sessionsModel) setSize(w, h int) {

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -99,13 +99,16 @@ type sessionsModel struct {
 	mainKey   string
 	loading   bool
 	err       error
+	hideHints bool
 }
 
-func newSessionsModel(c *client.Client, agentID, agentName, modelID, mainKey string) sessionsModel {
+func newSessionsModel(c *client.Client, agentID, agentName, modelID, mainKey string, hideHints bool) sessionsModel {
 	l := list.New(nil, sessionDelegate{}, 0, 0)
 	l.Title = "Sessions"
 	l.SetShowStatusBar(false)
-	l.SetShowHelp(true)
+	// Same rationale as selectModel: hide the list widget's keyboard
+	// footer when the embedder is rendering its own action surface.
+	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
 
@@ -117,6 +120,7 @@ func newSessionsModel(c *client.Client, agentID, agentName, modelID, mainKey str
 		modelID:   modelID,
 		mainKey:   mainKey,
 		loading:   true,
+		hideHints: hideHints,
 	}
 }
 
@@ -359,7 +363,10 @@ func (m sessionsModel) View() string {
 	if m.loading {
 		return "\n  Loading sessions...\n"
 	}
-	hints := helpStyle.Render(renderActionHints(m.Actions()))
+	hints := ""
+	if !m.hideHints {
+		hints = helpStyle.Render(renderActionHints(m.Actions()))
+	}
 	if m.err != nil {
 		var b strings.Builder
 		b.WriteString("\n")

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newTestSessionsModel() sessionsModel {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key")
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false)
 	m.setSize(120, 40)
 	return m
 }

--- a/main.go
+++ b/main.go
@@ -10,11 +10,9 @@ import (
 	"strings"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
-
+	"github.com/lucinate-ai/lucinate/app"
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
-	"github.com/lucinate-ai/lucinate/internal/tui"
 	"github.com/lucinate-ai/lucinate/internal/version"
 )
 
@@ -164,26 +162,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	app := tui.NewApp(c)
-	p := tea.NewProgram(app)
-
-	// Pump gateway events into the bubbletea program from a dedicated goroutine.
-	// This is more reliable than a cmd-chain that must be re-issued after each event.
-	go func() {
-		for ev := range c.Events() {
-			p.Send(tui.GatewayEventMsg(ev))
-		}
-	}()
-
-	// Watch the gateway connection and reconnect if it drops (e.g. gateway
-	// restart). The supervisor pushes state transitions to the TUI.
-	supervisorCtx, stopSupervisor := context.WithCancel(context.Background())
-	defer stopSupervisor()
-	go c.Supervise(supervisorCtx, func(s client.ConnState) {
-		p.Send(tui.ConnStateMsg{Status: s.Status, Attempt: s.Attempt, Err: s.Err})
-	})
-
-	if _, err := p.Run(); err != nil {
+	if err := app.Run(context.Background(), app.RunOptions{Client: c}); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Refactor the program lifecycle into a reusable `app` package and add the embedder hooks needed by native (non-CLI) clients.

## Summary

- Introduce an `IdentityStore` interface so identity persistence can be swapped out by embedders that don't have a writable home directory.
- Extract the bubbletea program lifecycle into `app.Run` / `app.New` + `app.Program`, with `Resize`, `Quit`, and `TriggerAction` hooks safe to call from any goroutine.
- Add `RunOptions` knobs that an embedded virtual terminal needs to render and behave correctly: `InitialCols` / `InitialRows`, `ColorProfile`, `HideInputArea`, `HideActionHints`, `DisableMouse`.
- Surface view-state to embedders via two callbacks: `OnInputFocusChanged(wantsInput)` so they can show/hide an on-screen keyboard only when the active view wants typing, and `OnActionsChanged([]Action)` so they can render each view's discoverable commands as native controls.
- Establish an `Action{ID, Label, Key}` abstraction that drives both the inline TUI help line and the embedder action list from a single declaration in each view, eliminating the long-standing drift between hand-written hint text and the actual key handler. Picker, sessions, and config views are migrated; config also exposes `toggle` as a screen action when the cursor is on a bool item.
- Wire the gateway connection supervisor into `Program.Run` so the reconnect / "lost connection" badge added in v0.21.0 keeps working transparently for any embedder.

## Implementation details

The `Program.Run` ownership boundary is the key design choice here. `Run` owns three goroutines for the duration of a session — events pump, connection supervisor, and a context-cancel watcher — so embedders only have to `New(opts)` and `Run(ctx)` without thinking about lifecycle.

`HideActionHints` is a separate flag from `HideInputArea` even though both default to true on native clients. Deriving it from `OnActionsChanged != nil` would conflate "I'm rendering actions natively" with "I'm consuming them for telemetry"; an explicit flag keeps the contract clear.

A `tea.ClearScreen` is now batched on every `viewState` transition. Bubble Tea's incremental renderer assumes the host terminal preserves its grid across resizes; embedded terminals don't always honour that after a rapid show/hide/show keyboard sequence, and a single `CSI 2J` per transition is cheaper than tracking which embedders need it.