### PR TITLE
feat(tui): list, inspect, and manage gateway cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Type these in the chat input. Tab autocompletes partial commands.
 | `/compact` | Compact session context (with confirmation) — OpenClaw only |
 | `/config` | Open preferences |
 | `/connections` | Switch backend connection |
+| `/crons` | List and manage gateway cron jobs (default: filter by current agent; `/crons all` shows global) — OpenClaw only |
 | `/model` | List available models |
 | `/model <name>` | Switch model (fuzzy match) |
 | `/reset` | Delete session and start fresh (with confirmation) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [authentication.md](authentication.md) | Device pairing, Ed25519 identity, gateway connection and token lifecycle |
 | [agents.md](agents.md) | Agent picker, auto-selection, agent creation |
 | [sessions.md](sessions.md) | Session lifecycle, session browser, compact/reset, message queueing |
+| [crons.md](crons.md) | Gateway cron browser: list/detail/form substates, capability gating, raw-patch edit semantics |
 | [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
 | [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |

--- a/docs/backend_openclaw.md
+++ b/docs/backend_openclaw.md
@@ -15,6 +15,7 @@ See [connections.md](connections.md) for the cross-backend connection lifecycle 
 | `SessionCompact`  | `/compact`                                |
 | `Thinking`        | `/think`                                  |
 | `SessionUsage`    | `/stats`                                  |
+| `Cron`            | `/crons` — see [crons.md](crons.md)       |
 | `AuthRecovery`    | `AuthRecoveryDeviceToken` — see below     |
 | `AgentWorkspace`  | Workspace field on the create-agent form  |
 
@@ -41,4 +42,4 @@ The check-and-mark is mutex-guarded so two concurrent sends on the same session 
 
 ## Pass-through methods
 
-`SessionsList`, `CreateSession`, `SessionDelete`, `ChatSend`, `ChatAbort`, `ChatHistory`, `ModelsList`, `SessionPatchModel`, and the capability-specific methods (`GatewayHealth`, `ExecRequest`, `ExecResolve`, `SessionCompact`, `SessionPatchThinking`, `SessionUsage`) all forward to the underlying client unchanged. The adapter exists to satisfy the `backend.Backend` interface, not to add behaviour.
+`SessionsList`, `CreateSession`, `SessionDelete`, `ChatSend`, `ChatAbort`, `ChatHistory`, `ModelsList`, `SessionPatchModel`, and the capability-specific methods (`GatewayHealth`, `ExecRequest`, `ExecResolve`, `SessionCompact`, `SessionPatchThinking`, `SessionUsage`, `CronsList`, `CronRuns`, `CronAdd`, `CronUpdate`, `CronUpdateRaw`, `CronRemove`, `CronRun`) all forward to the underlying client unchanged. The adapter exists to satisfy the `backend.Backend` interface, not to add behaviour.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,6 +18,8 @@ Unrecognised slash commands fall through to a skill-name lookup. If no skill mat
 | `/compact` | Compact the session context — see [sessions.md](sessions.md#compact-and-reset) — **OpenClaw only** |
 | `/config` | Open the preferences view by emitting `showConfigMsg{}` |
 | `/connections` | Open the connections picker mid-session, tearing down the active backend — see [connections.md](connections.md) |
+| `/crons` | Open the cron browser filtered to the current agent — see [crons.md](crons.md) — **OpenClaw only** |
+| `/crons all` | Open the cron browser unfiltered (jobs across all agents) — **OpenClaw only** |
 | `/exit`, `/quit` | Exit via `tea.Quit` |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
 | `/model` | List available models |

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -40,7 +40,7 @@ Legacy mode (`AppOptions.Backend != nil`, no `Store`) is for native-platform emb
 
 ## Capability negotiation
 
-`backend.Backend.Capabilities()` reports a `Capabilities` struct (`internal/backend/backend.go`); the TUI type-asserts against optional sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `DeviceTokenAuth`, `APIKeyAuth`) at the relevant call sites. OpenClaw implements all of them. OpenAI implements only `APIKeyAuth` — backend-only commands (`/status`, `/compact`, `/think`, `/stats`, `!!`) render a "not available on this connection" system message instead of erroring.
+`backend.Backend.Capabilities()` reports a `Capabilities` struct (`internal/backend/backend.go`); the TUI type-asserts against optional sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `CronBackend`, `DeviceTokenAuth`, `APIKeyAuth`) at the relevant call sites. OpenClaw implements all of them. OpenAI implements only `APIKeyAuth` — backend-only commands (`/status`, `/compact`, `/think`, `/stats`, `/crons`, `!!`) render a "not available on this connection" system message instead of erroring.
 
 ## Auth-recovery modals
 

--- a/docs/crons.md
+++ b/docs/crons.md
@@ -1,0 +1,85 @@
+# Cron jobs
+
+The cron browser (`internal/tui/crons.go`) lets users list, inspect, run, edit, create, and delete the gateway's scheduled jobs without leaving the TUI. Cron is gateway-side scheduling, not a lucinate concept — only backends that implement `backend.CronBackend` expose the view.
+
+## Entry points
+
+`/crons` and `/crons all` are the only entry points. The chat view's slash-command handler (`internal/tui/commands.go`) type-asserts the active backend against `backend.CronBackend`:
+
+- Assertion fails → `"/crons is not available on this connection"` system message, no view transition (same pattern as `/status`, `/compact`).
+- Assertion succeeds → `showCronsMsg{filterAgentID, filterLabel}` is emitted. With `/crons` the filter is the chat's current agent; `/crons all` clears the filter so jobs across every agent are listed.
+
+## Capability surface
+
+`backend.CronBackend` (`internal/backend/backend.go`) wraps six gateway RPCs:
+
+| Method | Wire call | Used for |
+|---|---|---|
+| `CronsList` | `cron.list` | List substate |
+| `CronRuns` | `cron.runs` | Run history in detail substate |
+| `CronAdd` | `cron.add` | Create form submit |
+| `CronUpdate` | `cron.update` (typed) | Toggle enable / disable |
+| `CronUpdateRaw` | `cron.update` (raw map) | Edit form submit — see [Raw-patch edit semantics](#raw-patch-edit-semantics) |
+| `CronRemove` | `cron.remove` | Confirm-delete substate |
+| `CronRun` | `cron.run` (`mode=force`) | Manual run-now |
+
+Capability is also reported as `Capabilities.Cron` so embedders can hide the entry up-front.
+
+## Substates
+
+`cronsModel` is a single view with four substates:
+
+| Substate | Purpose |
+|---|---|
+| `cronSubList` | Default — paginated, filtered job list |
+| `cronSubDetail` | Drill-down into a selected job + run history |
+| `cronSubForm` | Create or edit form |
+| `cronSubConfirmDelete` | y/n prompt before `CronRemove` fires |
+
+Each substate exposes its own discoverable actions through `Actions()`; `TriggerAction(id)` is the single dispatcher both keystrokes and embedder-issued `TriggerActionMsg`s flow through.
+
+## List substate
+
+The list view loads on `Init()` via `loadJobs()`, which calls `CronsList(Enabled: "all", SortBy: "nextRunAtMs", SortDir: "asc")`. The full slice is cached on the model so the agent-filter toggle (`a` key) can re-apply locally without a round-trip — server-side filtering is not exposed in `CronListParams`. Each row renders:
+
+- **Line 1**: bold name + dim relative-time chip (`in 8h`, `due`, `—`).
+- **Line 2**: chips for session target (`main`/`isolated`), wake mode (`now`/`heartbeat`), agent ID, and a status badge (`ok`/`error`/`disabled`/`idle`).
+
+`enter` opens detail; `r` refreshes; `n` opens the create form; `esc` emits `goBackFromCronsMsg{}` to return to chat.
+
+## Detail substate
+
+`enter` on the list emits a `loadRuns(jobID)` command alongside the substate transition; `cronRunsLoadedMsg` populates the run-history table (most recent 10 entries, formatted by `formatRunLogEntry`). Rendered fields:
+
+- Schedule (cron expression + timezone, or fallback for `at`/`every` kinds)
+- Description, Agent, Model (from `payload.Model`), Session target, Wake mode
+- Delivery (always shown — `none`, `announce (channel)`, or `webhook → URL`)
+- Next run, Last run (with status), Payload body
+- Run history table
+
+Actions: `R` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open the most recent run's session in chat (emits `sessionSelectedMsg{sessionKey, agentID}`), `r` refresh, `esc` back to list.
+
+## Form substate
+
+The create and edit form share `cronForm` and the `cronFormField` enum (12 fields, tab-ordered). To avoid a TUI form modelling every union the gateway protocol exposes (`CronSchedule.Kind` ∈ `at`/`every`/`cron`; `CronPayload.Kind` ∈ `systemEvent`/`agentTurn`), the form is **constrained to `cron` schedules and `agentTurn` payloads**. Editing a job whose existing kind is anything else loads the form in a refused state:
+
+> Edit not supported for schedule kind "every". Use the openclaw CLI.
+
+The save path is suppressed in this state — we surface the brittleness rather than silently round-trip a truncated representation.
+
+Tab/Shift+Tab navigates fields. Space toggles the cycle/checkbox controls (`sessionTarget`, `wakeMode`, `deliveryMode`, `enabled`). Inside the payload `textarea`, Enter inserts a newline; Ctrl+S (or Alt+Enter) saves from anywhere; Esc cancels and returns to whichever substate opened the form.
+
+### Raw-patch edit semantics
+
+The toggle action (`t` on detail) and the create-form submit use the typed `protocol.CronUpdateParams`/`CronAddParams`. The **edit-form submit goes through `CronUpdateRaw(jobID, patch map[string]any)` instead**, because every string field on `protocol.CronJobPatch` and `CronPayload` is tagged `json:",omitempty"` — once Go marshals an empty value, the field is dropped from the JSON, and the gateway can't distinguish "user cleared this field" from "user didn't touch this field" (it keeps the prior value). The map-based path emits empty strings verbatim (see `buildJobPatchMap`) so clearing model, description, or delivery actually persists. Toggle stays on the typed path because it only mutates a `*bool`, which doesn't have the omitempty problem.
+
+## Confirm-delete substate
+
+`x` on detail transitions to a y/n prompt. `y` calls `CronRemove(jobID)` and refreshes the list (returning to `cronSubList`). `n` or `esc` returns to detail without action.
+
+## Out of scope
+
+- Server-side cron filtering by agent (would need `agentId` added to `CronListParams` upstream).
+- Edit support for `at`/`every` schedules and `systemEvent` payloads.
+- Pagination of run history beyond the most recent 10 entries.
+- Live updates via cron-related gateway events — there is no streaming for cron state changes today, so the user must press `r` to refresh.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -181,6 +181,12 @@ type Capabilities struct {
 	// backends (OpenAI-compat) leave this false because Identity /
 	// Soul / Model carry the agent's configuration instead.
 	AgentWorkspace bool
+
+	// Cron indicates the backend implements CronBackend. The TUI
+	// gates the /crons command on this so backends without server-
+	// side scheduling print a clear "not available" message rather
+	// than crashing on a failed type assertion.
+	Cron bool
 }
 
 // AuthRecovery selects the auth-modal flow the connecting view runs
@@ -243,4 +249,17 @@ type DeviceTokenAuth interface {
 // backends when the upstream returns 401/403.
 type APIKeyAuth interface {
 	StoreAPIKey(key string) error
+}
+
+// CronBackend exposes the gateway cron API behind the /crons view.
+// Local-agent backends and OpenAI-compat backends omit this; the TUI
+// type-asserts and prints "not available on this connection" when the
+// assertion fails.
+type CronBackend interface {
+	CronsList(ctx context.Context, params protocol.CronListParams) (*protocol.CronListResult, error)
+	CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error)
+	CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error)
+	CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error
+	CronRemove(ctx context.Context, jobID string) error
+	CronRun(ctx context.Context, jobID string, force bool) error
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -260,6 +260,12 @@ type CronBackend interface {
 	CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error)
 	CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error)
 	CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error
+	// CronUpdateRaw is a low-level patch entry used by the edit form so
+	// cleared string fields actually round-trip — the typed CronJobPatch
+	// uses `omitempty` and would otherwise drop empty values before they
+	// reach the gateway. The toggle path stays on the typed CronUpdate
+	// because it only mutates a *bool field.
+	CronUpdateRaw(ctx context.Context, jobID string, patch map[string]any) error
 	CronRemove(ctx context.Context, jobID string) error
 	CronRun(ctx context.Context, jobID string, force bool) error
 }

--- a/internal/backend/openclaw/openclaw.go
+++ b/internal/backend/openclaw/openclaw.go
@@ -153,6 +153,7 @@ func (b *Backend) Capabilities() backend.Capabilities {
 		SessionUsage:   true,
 		AuthRecovery:   backend.AuthRecoveryDeviceToken,
 		AgentWorkspace: true,
+		Cron:           true,
 	}
 }
 
@@ -198,6 +199,32 @@ func (b *Backend) StoreToken(token string) error { return b.client.StoreToken(to
 func (b *Backend) ClearToken() error             { return b.client.ClearToken() }
 func (b *Backend) ResetIdentity() error          { return b.client.ResetIdentity() }
 
+// --- CronBackend ---
+
+func (b *Backend) CronsList(ctx context.Context, params protocol.CronListParams) (*protocol.CronListResult, error) {
+	return b.client.CronsList(ctx, params)
+}
+
+func (b *Backend) CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error) {
+	return b.client.CronRuns(ctx, params)
+}
+
+func (b *Backend) CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error) {
+	return b.client.CronAdd(ctx, params)
+}
+
+func (b *Backend) CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error {
+	return b.client.CronUpdate(ctx, params)
+}
+
+func (b *Backend) CronRemove(ctx context.Context, jobID string) error {
+	return b.client.CronRemove(ctx, jobID)
+}
+
+func (b *Backend) CronRun(ctx context.Context, jobID string, force bool) error {
+	return b.client.CronRun(ctx, jobID, force)
+}
+
 // Compile-time assertions that the wrapper implements every interface
 // it claims to.
 var (
@@ -208,4 +235,5 @@ var (
 	_ backend.ThinkingBackend = (*Backend)(nil)
 	_ backend.UsageBackend    = (*Backend)(nil)
 	_ backend.DeviceTokenAuth = (*Backend)(nil)
+	_ backend.CronBackend     = (*Backend)(nil)
 )

--- a/internal/backend/openclaw/openclaw.go
+++ b/internal/backend/openclaw/openclaw.go
@@ -217,6 +217,10 @@ func (b *Backend) CronUpdate(ctx context.Context, params protocol.CronUpdatePara
 	return b.client.CronUpdate(ctx, params)
 }
 
+func (b *Backend) CronUpdateRaw(ctx context.Context, jobID string, patch map[string]any) error {
+	return b.client.CronUpdateRaw(ctx, jobID, patch)
+}
+
 func (b *Backend) CronRemove(ctx context.Context, jobID string) error {
 	return b.client.CronRemove(ctx, jobID)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -424,6 +424,27 @@ func (c *Client) CronUpdate(ctx context.Context, params protocol.CronUpdateParam
 	return c.currentGW().CronUpdate(ctx, params)
 }
 
+// CronUpdateRaw updates an existing cron job using a raw patch map.
+// This bypasses the protocol.CronJobPatch struct so callers can express
+// "explicitly clear this string field" — the typed struct uses
+// `omitempty` on string fields, which makes an empty value
+// indistinguishable from "field not provided" once it hits the wire.
+// The form-edit flow uses this so clearing the model or description
+// fields actually persists.
+func (c *Client) CronUpdateRaw(ctx context.Context, jobID string, patch map[string]any) error {
+	resp, err := c.currentGW().Send(ctx, string(protocol.MethodCronUpdate), map[string]any{
+		"id":    jobID,
+		"patch": patch,
+	})
+	if err != nil {
+		return fmt.Errorf("cron update: %w", err)
+	}
+	if !resp.OK && resp.Error != nil {
+		return fmt.Errorf("cron update: %s: %s", resp.Error.Code, resp.Error.Message)
+	}
+	return nil
+}
+
 // CronRemove deletes a cron job.
 func (c *Client) CronRemove(ctx context.Context, jobID string) error {
 	return c.currentGW().CronRemove(ctx, protocol.CronRemoveParams{ID: jobID})

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -404,6 +404,41 @@ func (c *Client) StoreToken(token string) error {
 	return c.store.SaveDeviceToken(token)
 }
 
+// CronsList lists cron jobs on the gateway.
+func (c *Client) CronsList(ctx context.Context, params protocol.CronListParams) (*protocol.CronListResult, error) {
+	return c.currentGW().CronList(ctx, params)
+}
+
+// CronRuns retrieves the run history for a cron job (or all jobs).
+func (c *Client) CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error) {
+	return c.currentGW().CronRuns(ctx, params)
+}
+
+// CronAdd creates a new cron job.
+func (c *Client) CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error) {
+	return c.currentGW().CronAdd(ctx, params)
+}
+
+// CronUpdate updates an existing cron job.
+func (c *Client) CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error {
+	return c.currentGW().CronUpdate(ctx, params)
+}
+
+// CronRemove deletes a cron job.
+func (c *Client) CronRemove(ctx context.Context, jobID string) error {
+	return c.currentGW().CronRemove(ctx, protocol.CronRemoveParams{ID: jobID})
+}
+
+// CronRun manually triggers a cron job. When force is true, the job runs
+// regardless of its schedule; otherwise it only runs if currently due.
+func (c *Client) CronRun(ctx context.Context, jobID string, force bool) error {
+	mode := "due"
+	if force {
+		mode = "force"
+	}
+	return c.currentGW().CronRun(ctx, protocol.CronRunParams{ID: jobID, Mode: mode})
+}
+
 // GW returns the underlying gateway client (for direct RPC access).
 // May return nil if no connection has been established yet, or briefly
 // during a reconnect cycle.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -21,6 +21,7 @@ const (
 	viewChat
 	viewSessions
 	viewConfig
+	viewCrons
 )
 
 // BackendFactory builds an unconnected backend.Backend for a stored
@@ -83,6 +84,7 @@ type AppModel struct {
 	chatModel         chatModel
 	sessionsModel     sessionsModel
 	configModel       configModel
+	cronsModel        cronsModel
 	backend           backend.Backend
 	activeConn        *config.Connection // the connection backend belongs to; rendered in status bars
 	store             *config.Connections
@@ -200,6 +202,8 @@ func (m AppModel) Actions() []Action {
 		return m.sessionsModel.Actions()
 	case viewConfig:
 		return m.configModel.Actions()
+	case viewCrons:
+		return m.cronsModel.Actions()
 	}
 	return nil
 }
@@ -229,6 +233,10 @@ func (m AppModel) TriggerAction(id string) (AppModel, tea.Cmd) {
 	case viewConfig:
 		var cmd tea.Cmd
 		m.configModel, cmd = m.configModel.TriggerAction(id)
+		return m, cmd
+	case viewCrons:
+		var cmd tea.Cmd
+		m.cronsModel, cmd = m.cronsModel.TriggerAction(id)
 		return m, cmd
 	}
 	return m, nil
@@ -331,6 +339,8 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.sessionsModel.setSize(msg.Width, msg.Height)
 		case viewConfig:
 			m.configModel.setSize(msg.Width, msg.Height)
+		case viewCrons:
+			m.cronsModel.setSize(msg.Width, msg.Height)
 		}
 		return m, nil
 
@@ -413,6 +423,24 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case showCronsMsg:
+		cron, ok := m.backend.(backend.CronBackend)
+		if !ok {
+			// Capability missing — bounce silently. The /crons handler
+			// in commands.go renders the user-facing "not available"
+			// message before dispatching this msg, so reaching this
+			// branch implies a programming error elsewhere.
+			return m, nil
+		}
+		m.cronsModel = newCronsModel(cron, msg.filterAgentID, msg.filterLabel, m.hideActionHints, m.activeConn)
+		m.cronsModel.setSize(m.width, m.height)
+		m.state = viewCrons
+		return m, m.cronsModel.Init()
+
+	case goBackFromCronsMsg:
+		m.state = viewChat
+		return m, nil
+
 	case showSessionsMsg:
 		m.sessionsModel = newSessionsModel(m.backend, msg.agentID, msg.agentName, msg.modelID, msg.mainKey, m.hideActionHints, m.activeConn)
 		m.sessionsModel.setSize(m.width, m.height)
@@ -420,7 +448,11 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		return m, m.sessionsModel.Init()
 
 	case sessionSelectedMsg:
-		m.chatModel = newChatModel(m.backend, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn))
+		agentID := msg.agentID
+		if agentID == "" {
+			agentID = m.sessionsModel.agentID
+		}
+		m.chatModel = newChatModel(m.backend, msg.sessionKey, agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn))
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -530,6 +562,11 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case viewConfig:
 		var cmd tea.Cmd
 		m.configModel, cmd = m.configModel.Update(msg)
+		return m, cmd
+
+	case viewCrons:
+		var cmd tea.Cmd
+		m.cronsModel, cmd = m.cronsModel.Update(msg)
 		return m, cmd
 	}
 
@@ -683,6 +720,8 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView(m.sessionsModel.View())
 	case viewConfig:
 		v = tea.NewView(m.configModel.View())
+	case viewCrons:
+		v = tea.NewView(m.cronsModel.View())
 	default:
 		v = tea.NewView("")
 	}

--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -36,6 +36,18 @@ type fakeBackend struct {
 	storedAPIKey   string
 	clearedToken   bool
 	resetIdentity  bool
+
+	// Cron RPC seams — tests pre-seed jobs / runs / errors and read
+	// back the recorded calls through these fields.
+	cronJobs        []protocol.CronJob
+	cronRuns        []protocol.CronRunLogEntry
+	cronListErr     error
+	cronRunsErr     error
+	lastCronAdd     *protocol.CronAddParams
+	lastCronUpdate  *protocol.CronUpdateParams
+	lastCronRunID   string
+	lastCronRunForce bool
+	cronRemoved     []string
 }
 
 func newFakeBackend() *fakeBackend {
@@ -49,6 +61,7 @@ func newFakeBackend() *fakeBackend {
 			SessionUsage:   true,
 			AuthRecovery:   backend.AuthRecoveryDeviceToken,
 			AgentWorkspace: true,
+			Cron:           true,
 		},
 	}
 }
@@ -134,6 +147,45 @@ func (f *fakeBackend) ResetIdentity() error          { f.resetIdentity = true; r
 
 func (f *fakeBackend) StoreAPIKey(key string) error { f.storedAPIKey = key; return nil }
 
+// --- CronBackend ---
+
+func (f *fakeBackend) CronsList(ctx context.Context, params protocol.CronListParams) (*protocol.CronListResult, error) {
+	if f.cronListErr != nil {
+		return nil, f.cronListErr
+	}
+	return &protocol.CronListResult{Jobs: f.cronJobs, Total: len(f.cronJobs)}, nil
+}
+
+func (f *fakeBackend) CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error) {
+	if f.cronRunsErr != nil {
+		return nil, f.cronRunsErr
+	}
+	return &protocol.CronRunsResult{Entries: f.cronRuns, Total: len(f.cronRuns)}, nil
+}
+
+func (f *fakeBackend) CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error) {
+	p := params
+	f.lastCronAdd = &p
+	return json.RawMessage(`{"id":"new-job"}`), nil
+}
+
+func (f *fakeBackend) CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error {
+	p := params
+	f.lastCronUpdate = &p
+	return nil
+}
+
+func (f *fakeBackend) CronRemove(ctx context.Context, jobID string) error {
+	f.cronRemoved = append(f.cronRemoved, jobID)
+	return nil
+}
+
+func (f *fakeBackend) CronRun(ctx context.Context, jobID string, force bool) error {
+	f.lastCronRunID = jobID
+	f.lastCronRunForce = force
+	return nil
+}
+
 // Compile-time assertions.
 var (
 	_ backend.Backend         = (*fakeBackend)(nil)
@@ -144,4 +196,5 @@ var (
 	_ backend.UsageBackend    = (*fakeBackend)(nil)
 	_ backend.DeviceTokenAuth = (*fakeBackend)(nil)
 	_ backend.APIKeyAuth      = (*fakeBackend)(nil)
+	_ backend.CronBackend     = (*fakeBackend)(nil)
 )

--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -43,11 +43,13 @@ type fakeBackend struct {
 	cronRuns        []protocol.CronRunLogEntry
 	cronListErr     error
 	cronRunsErr     error
-	lastCronAdd     *protocol.CronAddParams
-	lastCronUpdate  *protocol.CronUpdateParams
-	lastCronRunID   string
-	lastCronRunForce bool
-	cronRemoved     []string
+	lastCronAdd       *protocol.CronAddParams
+	lastCronUpdate    *protocol.CronUpdateParams
+	lastCronUpdateRaw map[string]any
+	lastCronUpdateID  string
+	lastCronRunID     string
+	lastCronRunForce  bool
+	cronRemoved       []string
 }
 
 func newFakeBackend() *fakeBackend {
@@ -172,6 +174,12 @@ func (f *fakeBackend) CronAdd(ctx context.Context, params protocol.CronAddParams
 func (f *fakeBackend) CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error {
 	p := params
 	f.lastCronUpdate = &p
+	return nil
+}
+
+func (f *fakeBackend) CronUpdateRaw(ctx context.Context, jobID string, patch map[string]any) error {
+	f.lastCronUpdateID = jobID
+	f.lastCronUpdateRaw = patch
 	return nil
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -21,7 +21,7 @@ type pendingConfirmation struct {
 }
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/agents", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -132,6 +132,24 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, func() tea.Msg { return showConfigMsg{} }
 	case "/connections":
 		return true, func() tea.Msg { return showConnectionsMsg{} }
+	case "/crons", "/crons all":
+		if _, ok := m.backend.(backend.CronBackend); !ok {
+			m.messages = append(m.messages, chatMessage{
+				role:   "system",
+				errMsg: "/crons is not available on this connection",
+			})
+			m.updateViewport()
+			return true, nil
+		}
+		filterAgentID := m.agentID
+		filterLabel := m.agentName
+		if command == "/crons all" {
+			filterAgentID = ""
+			filterLabel = "all agents"
+		}
+		return true, func() tea.Msg {
+			return showCronsMsg{filterAgentID: filterAgentID, filterLabel: filterLabel}
+		}
 	case "/sessions":
 		agentID := m.agentID
 		agentName := m.agentName
@@ -146,7 +164,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -1,0 +1,1330 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/a3tai/openclaw-go/protocol"
+	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// cronItem wraps a CronJob for the bubbles list.
+type cronItem struct {
+	job protocol.CronJob
+}
+
+func (i cronItem) FilterValue() string {
+	if i.job.Name != "" {
+		return i.job.Name
+	}
+	return i.job.ID
+}
+
+// cronDelegate renders each cron job as two lines: a bold name (with the
+// next-run relative time) and a row of status chips (session target,
+// wake mode, agent, last-run badge).
+type cronDelegate struct{}
+
+func (d cronDelegate) Height() int                             { return 2 }
+func (d cronDelegate) Spacing() int                            { return 1 }
+func (d cronDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d cronDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	i, ok := item.(cronItem)
+	if !ok {
+		return
+	}
+	name := i.job.Name
+	if name == "" {
+		name = i.job.ID
+	}
+	relative := relativeNextRun(i.job.State.NextRunAtMs)
+
+	var titleLine string
+	if index == m.Index() {
+		titleLine = lipgloss.NewStyle().Foreground(accent).Bold(true).
+			Render(fmt.Sprintf("> %s", name))
+	} else {
+		titleLine = fmt.Sprintf("  %s", name)
+	}
+	if relative != "" {
+		titleLine += "  " + lipgloss.NewStyle().Foreground(subtle).Render(relative)
+	}
+
+	chips := []string{
+		chipStyle.Render(orDash(i.job.SessionTarget)),
+		chipStyle.Render(wakeModeLabel(i.job.WakeMode)),
+	}
+	if i.job.AgentID != "" {
+		chips = append(chips, chipStyle.Render("agent "+i.job.AgentID))
+	}
+	chips = append(chips, statusChip(i.job))
+
+	subtitle := "  " + strings.Join(chips, " ")
+	fmt.Fprint(w, titleLine+"\n"+subtitle)
+}
+
+// chipStyle is a neutral background tag used for sessionTarget / wake /
+// agent chips on each list row.
+var chipStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("#FFFFFF")).
+	Background(lipgloss.Color("#3A3A3A")).
+	Padding(0, 1)
+
+// cronStatusOKStyle is the green badge for last-run==ok.
+var cronStatusOKStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("#0A2A0A")).
+	Background(lipgloss.Color("#5BC85B")).
+	Bold(true).
+	Padding(0, 1)
+
+// cronStatusErrStyle is the red badge for last-run==error.
+var cronStatusErrStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("#FFFFFF")).
+	Background(errClr).
+	Bold(true).
+	Padding(0, 1)
+
+// cronStatusDisabledStyle is the dim badge for disabled jobs.
+var cronStatusDisabledStyle = lipgloss.NewStyle().
+	Foreground(subtle).
+	Background(lipgloss.Color("#2A2A2A")).
+	Padding(0, 1)
+
+func statusChip(job protocol.CronJob) string {
+	if !job.Enabled {
+		return cronStatusDisabledStyle.Render("disabled")
+	}
+	switch job.State.LastStatus {
+	case "ok":
+		return cronStatusOKStyle.Render("ok")
+	case "error":
+		return cronStatusErrStyle.Render("error")
+	case "skipped":
+		return chipStyle.Render("skipped")
+	}
+	return chipStyle.Render("idle")
+}
+
+func wakeModeLabel(m string) string {
+	switch m {
+	case "now":
+		return "now"
+	case "next-heartbeat":
+		return "heartbeat"
+	}
+	return orDash(m)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// relativeNextRun renders a "in 8h", "in 23m", "now" or "—" label for
+// the next scheduled run. Past times render as "due".
+func relativeNextRun(nextMs *int64) string {
+	if nextMs == nil || *nextMs == 0 {
+		return "—"
+	}
+	delta := time.Duration(*nextMs-time.Now().UnixMilli()) * time.Millisecond
+	if delta <= 0 {
+		return "due"
+	}
+	if delta < time.Minute {
+		return "in <1m"
+	}
+	if delta < time.Hour {
+		return fmt.Sprintf("in %dm", int(delta.Minutes()))
+	}
+	if delta < 24*time.Hour {
+		return fmt.Sprintf("in %dh", int(delta.Hours()))
+	}
+	return fmt.Sprintf("in %dd", int(delta.Hours()/24))
+}
+
+// cronSubState selects which sub-view the model is rendering.
+type cronSubState int
+
+const (
+	cronSubList cronSubState = iota
+	cronSubDetail
+	cronSubForm
+	cronSubConfirmDelete
+)
+
+// cronFormField identifies a field on the create/edit form. The order
+// here is the tab order rendered in the form view.
+type cronFormField int
+
+const (
+	formName cronFormField = iota
+	formDescription
+	formCronExpr
+	formTimezone
+	formAgentID
+	formSessionTarget
+	formWakeMode
+	formPayloadText
+	formEnabled
+	formFieldCount
+)
+
+// cronForm carries the in-progress create/edit-job form state. The form
+// only supports the cron-style schedule kind and the agentTurn payload
+// kind to avoid the brittleness of a TUI form modelling the union types
+// the gateway exposes; jobs of other kinds open as read-only with a
+// banner pointing the user to the gateway CLI.
+type cronForm struct {
+	mode      string // "create" or "edit"
+	editingID string // job ID being edited; "" in create mode
+
+	name        textinput.Model
+	description textinput.Model
+	cronExpr    textinput.Model
+	timezone    textinput.Model
+	agentID     textinput.Model
+	payloadText textarea.Model
+
+	sessionTarget string // "main" or "isolated"
+	wakeMode      string // "next-heartbeat" or "now"
+	enabled       bool
+
+	focused      cronFormField
+	saving       bool
+	err          error
+	unsupported  string // non-empty when the existing job's kind cannot be edited; rendered as a banner
+}
+
+// cronsModel is the cron browser view.
+type cronsModel struct {
+	list   list.Model
+	cron   backend.CronBackend
+	subset cronSubState
+
+	// Filter state.
+	filterAgentID string
+	filterLabel   string
+	showAllAgents bool
+	jobs          []protocol.CronJob // unfiltered cache, refreshed by loadJobs
+
+	// List loading.
+	loading bool
+	err     error
+
+	// Detail substate.
+	selectedID  string
+	runs        []protocol.CronRunLogEntry
+	runsLoading bool
+	runsErr     error
+
+	// Form substate.
+	form cronForm
+
+	// Confirm-delete substate.
+	pendingDeleteID   string
+	pendingDeleteName string
+
+	hideHints  bool
+	activeConn *config.Connection
+	width      int
+	height     int
+}
+
+func newCronsModel(cron backend.CronBackend, filterAgentID, filterLabel string, hideHints bool, activeConn *config.Connection) cronsModel {
+	l := list.New(nil, cronDelegate{}, 0, 0)
+	l.Title = "Cron"
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(!hideHints)
+	l.Styles.Title = headerStyle
+	l.SetFilteringEnabled(false)
+
+	return cronsModel{
+		list:          l,
+		cron:          cron,
+		subset:        cronSubList,
+		filterAgentID: filterAgentID,
+		filterLabel:   filterLabel,
+		loading:       true,
+		hideHints:     hideHints,
+		activeConn:    activeConn,
+	}
+}
+
+func (m cronsModel) Init() tea.Cmd { return m.loadJobs() }
+
+func (m *cronsModel) setSize(w, h int) {
+	m.width = w
+	m.height = h
+	m.list.SetSize(w, h-2)
+	if m.subset == cronSubForm {
+		m.sizePayloadTextarea()
+	}
+}
+
+// loadJobs fetches the full cron-job list from the gateway. We cache
+// the unfiltered slice so the agent-filter toggle can re-render
+// without a round-trip.
+func (m cronsModel) loadJobs() tea.Cmd {
+	cron := m.cron
+	return func() tea.Msg {
+		result, err := cron.CronsList(context.Background(), protocol.CronListParams{
+			Enabled: "all",
+			SortBy:  "nextRunAtMs",
+			SortDir: "asc",
+		})
+		if err != nil {
+			return cronsLoadedMsg{err: err}
+		}
+		return cronsLoadedMsg{jobs: result.Jobs}
+	}
+}
+
+// loadRuns fetches the run history for a single cron job. The server
+// caps the entry count; we additionally render only the most recent 10
+// in the detail view.
+func (m cronsModel) loadRuns(jobID string) tea.Cmd {
+	cron := m.cron
+	limit := 10
+	return func() tea.Msg {
+		result, err := cron.CronRuns(context.Background(), protocol.CronRunsParams{
+			Scope:   "job",
+			ID:      jobID,
+			Limit:   &limit,
+			SortDir: "desc",
+		})
+		if err != nil {
+			return cronRunsLoadedMsg{jobID: jobID, err: err}
+		}
+		return cronRunsLoadedMsg{jobID: jobID, entries: result.Entries}
+	}
+}
+
+// applyFilter rebuilds the list items from the cached jobs slice
+// using the current filter state. Kept as a separate step so the agent-
+// toggle action doesn't have to re-fetch.
+func (m *cronsModel) applyFilter() {
+	want := m.filterAgentID
+	if m.showAllAgents {
+		want = ""
+	}
+	filtered := make([]protocol.CronJob, 0, len(m.jobs))
+	for _, j := range m.jobs {
+		if want != "" && j.AgentID != want {
+			continue
+		}
+		filtered = append(filtered, j)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		ai, bj := filtered[i].State.NextRunAtMs, filtered[j].State.NextRunAtMs
+		switch {
+		case ai != nil && bj != nil:
+			return *ai < *bj
+		case ai != nil:
+			return true
+		case bj != nil:
+			return false
+		default:
+			return filtered[i].Name < filtered[j].Name
+		}
+	})
+	items := make([]list.Item, len(filtered))
+	for i, j := range filtered {
+		items[i] = cronItem{job: j}
+	}
+	m.list.SetItems(items)
+}
+
+// findJob returns the cached job by ID, plus a bool indicator. Used by
+// the detail / form / delete substates which keep only the ID across
+// substate transitions.
+func (m cronsModel) findJob(id string) (protocol.CronJob, bool) {
+	for _, j := range m.jobs {
+		if j.ID == id {
+			return j, true
+		}
+	}
+	return protocol.CronJob{}, false
+}
+
+func (m cronsModel) Update(msg tea.Msg) (cronsModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case cronsLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.err = nil
+		m.jobs = msg.jobs
+		m.applyFilter()
+		return m, nil
+
+	case cronRunsLoadedMsg:
+		if msg.jobID != m.selectedID {
+			return m, nil
+		}
+		m.runsLoading = false
+		if msg.err != nil {
+			m.runsErr = msg.err
+			return m, nil
+		}
+		m.runsErr = nil
+		m.runs = msg.entries
+		return m, nil
+
+	case cronJobToggledMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		// Reload to pick up the new state and any next-run shift.
+		m.loading = true
+		return m, m.loadJobs()
+
+	case cronJobRanMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.runsLoading = true
+		var refreshRuns tea.Cmd
+		if m.selectedID != "" {
+			refreshRuns = m.loadRuns(m.selectedID)
+		}
+		m.loading = true
+		return m, tea.Batch(m.loadJobs(), refreshRuns)
+
+	case cronJobSavedMsg:
+		if msg.err != nil {
+			m.form.err = msg.err
+			m.form.saving = false
+			return m, nil
+		}
+		// Return to the list and refresh.
+		m.subset = cronSubList
+		m.form = cronForm{}
+		m.loading = true
+		return m, m.loadJobs()
+
+	case cronJobRemovedMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.subset = cronSubList
+		m.selectedID = ""
+		m.runs = nil
+		m.loading = true
+		return m, m.loadJobs()
+
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	}
+
+	if m.subset == cronSubList {
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m cronsModel) handleKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
+	switch m.subset {
+	case cronSubList:
+		return m.handleListKey(msg)
+	case cronSubDetail:
+		return m.handleDetailKey(msg)
+	case cronSubForm:
+		return m.handleFormKey(msg)
+	case cronSubConfirmDelete:
+		return m.handleConfirmKey(msg)
+	}
+	return m, nil
+}
+
+func (m cronsModel) handleListKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k", "down", "j":
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
+	case "enter":
+		if m.loading || m.err != nil {
+			return m, nil
+		}
+		item, ok := m.list.SelectedItem().(cronItem)
+		if !ok {
+			return m, nil
+		}
+		m.selectedID = item.job.ID
+		m.subset = cronSubDetail
+		m.runs = nil
+		m.runsErr = nil
+		m.runsLoading = true
+		return m, m.loadRuns(item.job.ID)
+	}
+	for _, a := range m.Actions() {
+		if a.Key == msg.String() {
+			return m.TriggerAction(a.ID)
+		}
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m cronsModel) handleDetailKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
+	for _, a := range m.Actions() {
+		if a.Key == msg.String() {
+			return m.TriggerAction(a.ID)
+		}
+	}
+	return m, nil
+}
+
+func (m cronsModel) handleConfirmKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
+	switch strings.ToLower(msg.String()) {
+	case "y":
+		jobID := m.pendingDeleteID
+		cron := m.cron
+		m.pendingDeleteID = ""
+		m.pendingDeleteName = ""
+		m.subset = cronSubList
+		return m, func() tea.Msg {
+			err := cron.CronRemove(context.Background(), jobID)
+			return cronJobRemovedMsg{jobID: jobID, err: err}
+		}
+	case "n", "esc":
+		m.pendingDeleteID = ""
+		m.pendingDeleteName = ""
+		m.subset = cronSubDetail
+		return m, nil
+	}
+	return m, nil
+}
+
+// -----------------------------------------------------------------------------
+// Actions / TriggerAction
+// -----------------------------------------------------------------------------
+
+func (m cronsModel) Actions() []Action {
+	switch m.subset {
+	case cronSubList:
+		return m.listActions()
+	case cronSubDetail:
+		return m.detailActions()
+	case cronSubForm:
+		// The form's tab/enter/esc are intrinsic form controls, not
+		// discoverable view-level commands, so they don't appear here.
+		return nil
+	case cronSubConfirmDelete:
+		return []Action{
+			{ID: "confirm-delete", Label: "Delete", Key: "y"},
+			{ID: "cancel-delete", Label: "Cancel", Key: "n"},
+		}
+	}
+	return nil
+}
+
+func (m cronsModel) listActions() []Action {
+	var actions []Action
+	if !m.loading && m.err == nil {
+		actions = append(actions, Action{ID: "new", Label: "New job", Key: "n"})
+	}
+	if m.filterAgentID != "" {
+		label := "Show all agents"
+		if m.showAllAgents {
+			label = "Filter by agent"
+		}
+		actions = append(actions, Action{ID: "toggle-agent-filter", Label: label, Key: "a"})
+	}
+	actions = append(actions, Action{ID: "refresh", Label: "Refresh", Key: "r"})
+	actions = append(actions, Action{ID: "back", Label: "Back", Key: "esc"})
+	if m.err != nil {
+		actions = append(actions, Action{ID: "retry", Label: "Retry", Key: "R"})
+	}
+	return actions
+}
+
+func (m cronsModel) detailActions() []Action {
+	job, ok := m.findJob(m.selectedID)
+	var actions []Action
+	if ok {
+		actions = append(actions, Action{ID: "run", Label: "Run now", Key: "R"})
+		toggleLabel := "Disable"
+		if !job.Enabled {
+			toggleLabel = "Enable"
+		}
+		actions = append(actions, Action{ID: "toggle", Label: toggleLabel, Key: "t"})
+		actions = append(actions, Action{ID: "edit", Label: "Edit", Key: "e"})
+		actions = append(actions, Action{ID: "delete", Label: "Delete", Key: "x"})
+		if transcriptKey := bestTranscriptSessionKey(job, m.runs); transcriptKey != "" {
+			actions = append(actions, Action{ID: "transcript", Label: "Transcript", Key: "T"})
+		}
+	}
+	actions = append(actions, Action{ID: "refresh", Label: "Refresh", Key: "r"})
+	actions = append(actions, Action{ID: "back", Label: "Back", Key: "esc"})
+	return actions
+}
+
+func (m cronsModel) TriggerAction(id string) (cronsModel, tea.Cmd) {
+	switch id {
+	case "back":
+		return m.actionBack()
+	case "refresh":
+		return m.actionRefresh()
+	case "retry":
+		if m.err == nil {
+			return m, nil
+		}
+		m.loading = true
+		m.err = nil
+		return m, m.loadJobs()
+	case "toggle-agent-filter":
+		m.showAllAgents = !m.showAllAgents
+		m.applyFilter()
+		return m, nil
+	case "new":
+		m.form = newCreateForm()
+		m.sizePayloadTextarea()
+		m.subset = cronSubForm
+		return m, m.form.name.Focus()
+	case "run":
+		return m.actionRun()
+	case "toggle":
+		return m.actionToggle()
+	case "edit":
+		return m.actionEdit()
+	case "delete":
+		return m.actionDelete()
+	case "transcript":
+		return m.actionTranscript()
+	case "confirm-delete":
+		return m.handleConfirmKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	case "cancel-delete":
+		return m.handleConfirmKey(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	}
+	return m, nil
+}
+
+func (m cronsModel) actionBack() (cronsModel, tea.Cmd) {
+	switch m.subset {
+	case cronSubList:
+		return m, func() tea.Msg { return goBackFromCronsMsg{} }
+	case cronSubDetail:
+		m.subset = cronSubList
+		return m, nil
+	case cronSubForm:
+		// Form esc returns to whichever substate opened it.
+		if m.form.editingID != "" {
+			m.subset = cronSubDetail
+		} else {
+			m.subset = cronSubList
+		}
+		m.form = cronForm{}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m cronsModel) actionRefresh() (cronsModel, tea.Cmd) {
+	switch m.subset {
+	case cronSubList:
+		m.loading = true
+		return m, m.loadJobs()
+	case cronSubDetail:
+		if m.selectedID == "" {
+			return m, nil
+		}
+		m.runsLoading = true
+		m.loading = true
+		return m, tea.Batch(m.loadJobs(), m.loadRuns(m.selectedID))
+	}
+	return m, nil
+}
+
+func (m cronsModel) actionRun() (cronsModel, tea.Cmd) {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return m, nil
+	}
+	cron := m.cron
+	id := job.ID
+	return m, func() tea.Msg {
+		err := cron.CronRun(context.Background(), id, true)
+		return cronJobRanMsg{err: err}
+	}
+}
+
+func (m cronsModel) actionToggle() (cronsModel, tea.Cmd) {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return m, nil
+	}
+	cron := m.cron
+	newEnabled := !job.Enabled
+	id := job.ID
+	return m, func() tea.Msg {
+		err := cron.CronUpdate(context.Background(), protocol.CronUpdateParams{
+			ID: id,
+			Patch: protocol.CronJobPatch{
+				Enabled: &newEnabled,
+			},
+		})
+		return cronJobToggledMsg{jobID: id, enabled: newEnabled, err: err}
+	}
+}
+
+func (m cronsModel) actionEdit() (cronsModel, tea.Cmd) {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return m, nil
+	}
+	form, err := newEditForm(job)
+	if err != "" {
+		// Render the form anyway so the user sees the explanation; the
+		// save action is suppressed while the unsupported banner is up.
+		form.unsupported = err
+	}
+	m.form = form
+	m.sizePayloadTextarea()
+	m.subset = cronSubForm
+	return m, m.form.name.Focus()
+}
+
+// sizePayloadTextarea applies the current view width to the payload
+// textarea. Called whenever the form is (re)constructed because each
+// new form has a fresh textarea.Model with default sizing.
+func (m *cronsModel) sizePayloadTextarea() {
+	w := m.width - 6
+	if w < 20 {
+		w = 20
+	}
+	m.form.payloadText.SetWidth(w)
+}
+
+func (m cronsModel) actionDelete() (cronsModel, tea.Cmd) {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return m, nil
+	}
+	m.pendingDeleteID = job.ID
+	m.pendingDeleteName = displayJobName(job)
+	m.subset = cronSubConfirmDelete
+	return m, nil
+}
+
+func (m cronsModel) actionTranscript() (cronsModel, tea.Cmd) {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return m, nil
+	}
+	sessionKey := bestTranscriptSessionKey(job, m.runs)
+	if sessionKey == "" {
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		return sessionSelectedMsg{
+			sessionKey: sessionKey,
+			agentID:    job.AgentID,
+			agentName:  job.AgentID, // best-effort label; the chat header re-resolves on first event
+		}
+	}
+}
+
+// bestTranscriptSessionKey returns the most useful session key for the
+// "view transcript" action — the most recent run with one wins;
+// otherwise the job's stored sessionKey if any.
+func bestTranscriptSessionKey(job protocol.CronJob, runs []protocol.CronRunLogEntry) string {
+	for _, r := range runs {
+		if r.SessionKey != "" {
+			return r.SessionKey
+		}
+	}
+	return job.SessionKey
+}
+
+// -----------------------------------------------------------------------------
+// Form
+// -----------------------------------------------------------------------------
+
+func newCreateForm() cronForm {
+	f := cronForm{
+		mode:          "create",
+		sessionTarget: "isolated",
+		wakeMode:      "next-heartbeat",
+		enabled:       true,
+		focused:       formName,
+	}
+	f.name = textinput.New()
+	f.name.CharLimit = 80
+	f.description = textinput.New()
+	f.description.CharLimit = 200
+	f.cronExpr = textinput.New()
+	f.cronExpr.Placeholder = "0 8 * * *"
+	f.cronExpr.CharLimit = 64
+	f.timezone = textinput.New()
+	f.timezone.Placeholder = "Europe/London"
+	f.timezone.CharLimit = 64
+	f.agentID = textinput.New()
+	f.agentID.CharLimit = 64
+	f.payloadText = textarea.New()
+	f.payloadText.CharLimit = 4000
+	f.payloadText.SetHeight(6)
+	f.payloadText.ShowLineNumbers = false
+	f.payloadText.Prompt = ""
+	f.payloadText.Placeholder = "Read /home/pete/projects/cron-jobs/example.md and follow the instructions."
+	return f
+}
+
+// newEditForm pre-populates a form from an existing job. If the job's
+// schedule or payload kind is one the TUI form does not model, the
+// returned banner string is non-empty and the caller should disable the
+// save path.
+func newEditForm(job protocol.CronJob) (cronForm, string) {
+	f := newCreateForm()
+	f.mode = "edit"
+	f.editingID = job.ID
+	f.name.SetValue(job.Name)
+	f.description.SetValue(job.Description)
+	f.cronExpr.SetValue(job.Schedule.Expr)
+	f.timezone.SetValue(job.Schedule.Tz)
+	f.agentID.SetValue(job.AgentID)
+	f.payloadText.SetValue(job.Payload.Text)
+	if f.payloadText.Value() == "" {
+		f.payloadText.SetValue(job.Payload.Message)
+	}
+	if job.SessionTarget != "" {
+		f.sessionTarget = job.SessionTarget
+	}
+	if job.WakeMode != "" {
+		f.wakeMode = job.WakeMode
+	}
+	f.enabled = job.Enabled
+
+	var unsupported string
+	if job.Schedule.Kind != "" && job.Schedule.Kind != "cron" {
+		unsupported = fmt.Sprintf("Edit not supported for schedule kind %q. Use the openclaw CLI.", job.Schedule.Kind)
+	}
+	if job.Payload.Kind != "" && job.Payload.Kind != "agentTurn" && unsupported == "" {
+		unsupported = fmt.Sprintf("Edit not supported for payload kind %q. Use the openclaw CLI.", job.Payload.Kind)
+	}
+	return f, unsupported
+}
+
+func (m cronsModel) handleFormKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
+	if m.form.saving {
+		return m, nil
+	}
+	switch msg.String() {
+	case "esc":
+		return m.actionBack()
+	case "tab":
+		m.form.advanceFocus(+1)
+		return m, m.form.refocus()
+	case "shift+tab":
+		m.form.advanceFocus(-1)
+		return m, m.form.refocus()
+	case "enter":
+		// In the payload textarea, Enter inserts a newline; submission
+		// uses Ctrl+S (or Alt+Enter) so multi-line bodies are easy.
+		if m.form.focused == formPayloadText {
+			var cmd tea.Cmd
+			m.form.payloadText, cmd = m.form.payloadText.Update(msg)
+			return m, cmd
+		}
+		return m.submitForm()
+	case "ctrl+s", "alt+enter":
+		return m.submitForm()
+	case "space", " ":
+		// Toggle controls are bound to space when focused. Text fields
+		// and the payload textarea fall through to receive the literal
+		// space character.
+		switch m.form.focused {
+		case formSessionTarget:
+			if m.form.sessionTarget == "main" {
+				m.form.sessionTarget = "isolated"
+			} else {
+				m.form.sessionTarget = "main"
+			}
+			return m, nil
+		case formWakeMode:
+			if m.form.wakeMode == "now" {
+				m.form.wakeMode = "next-heartbeat"
+			} else {
+				m.form.wakeMode = "now"
+			}
+			return m, nil
+		case formEnabled:
+			m.form.enabled = !m.form.enabled
+			return m, nil
+		}
+	}
+	// Forward to the payload textarea or whichever textinput is focused.
+	if m.form.focused == formPayloadText {
+		var cmd tea.Cmd
+		m.form.payloadText, cmd = m.form.payloadText.Update(msg)
+		return m, cmd
+	}
+	field := m.form.activeInput()
+	if field == nil {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	*field, cmd = field.Update(msg)
+	return m, cmd
+}
+
+// activeInput returns a pointer to the textinput currently focused, or
+// nil if the focus is on the payload textarea (handled separately) or
+// a non-text control (toggles / checkbox).
+func (f *cronForm) activeInput() *textinput.Model {
+	switch f.focused {
+	case formName:
+		return &f.name
+	case formDescription:
+		return &f.description
+	case formCronExpr:
+		return &f.cronExpr
+	case formTimezone:
+		return &f.timezone
+	case formAgentID:
+		return &f.agentID
+	}
+	return nil
+}
+
+// advanceFocus moves the focus marker by dir (+1 forward, -1 back),
+// wrapping around the field list.
+func (f *cronForm) advanceFocus(dir int) {
+	next := int(f.focused) + dir
+	if next < 0 {
+		next = int(formFieldCount) - 1
+	}
+	if next >= int(formFieldCount) {
+		next = 0
+	}
+	f.focused = cronFormField(next)
+}
+
+// refocus reapplies bubbletea focus to the active text input (and
+// blurs the others). Returns the focus tea.Cmd so the cursor blinks.
+func (f *cronForm) refocus() tea.Cmd {
+	f.name.Blur()
+	f.description.Blur()
+	f.cronExpr.Blur()
+	f.timezone.Blur()
+	f.agentID.Blur()
+	f.payloadText.Blur()
+	if f.focused == formPayloadText {
+		return f.payloadText.Focus()
+	}
+	if input := f.activeInput(); input != nil {
+		return input.Focus()
+	}
+	return nil
+}
+
+func (m cronsModel) submitForm() (cronsModel, tea.Cmd) {
+	if m.form.unsupported != "" {
+		// User must back out and use the CLI; we refuse to save a
+		// truncated representation rather than silently mutate the job.
+		return m, nil
+	}
+	if m.form.name.Value() == "" {
+		m.form.err = fmt.Errorf("name is required")
+		return m, nil
+	}
+	if m.form.cronExpr.Value() == "" {
+		m.form.err = fmt.Errorf("cron expression is required")
+		return m, nil
+	}
+	m.form.err = nil
+	m.form.saving = true
+	cron := m.cron
+	form := m.form
+
+	if form.mode == "edit" {
+		patch := buildJobPatch(form)
+		jobID := form.editingID
+		return m, func() tea.Msg {
+			err := cron.CronUpdate(context.Background(), protocol.CronUpdateParams{
+				ID:    jobID,
+				Patch: patch,
+			})
+			return cronJobSavedMsg{jobID: jobID, err: err}
+		}
+	}
+
+	params := buildAddParams(form)
+	return m, func() tea.Msg {
+		_, err := cron.CronAdd(context.Background(), params)
+		return cronJobSavedMsg{err: err}
+	}
+}
+
+func buildAddParams(f cronForm) protocol.CronAddParams {
+	params := protocol.CronAddParams{
+		Name:          f.name.Value(),
+		Description:   f.description.Value(),
+		SessionTarget: f.sessionTarget,
+		WakeMode:      f.wakeMode,
+		Schedule: protocol.CronSchedule{
+			Kind: "cron",
+			Expr: f.cronExpr.Value(),
+			Tz:   f.timezone.Value(),
+		},
+		Payload: protocol.CronPayload{
+			Kind: "agentTurn",
+			Text: f.payloadText.Value(),
+		},
+	}
+	if v := f.agentID.Value(); v != "" {
+		params.AgentID = &v
+	}
+	enabled := f.enabled
+	params.Enabled = &enabled
+	return params
+}
+
+func buildJobPatch(f cronForm) protocol.CronJobPatch {
+	patch := protocol.CronJobPatch{
+		Name:          f.name.Value(),
+		Description:   f.description.Value(),
+		SessionTarget: f.sessionTarget,
+		WakeMode:      f.wakeMode,
+		Schedule: &protocol.CronSchedule{
+			Kind: "cron",
+			Expr: f.cronExpr.Value(),
+			Tz:   f.timezone.Value(),
+		},
+		Payload: &protocol.CronPayload{
+			Kind: "agentTurn",
+			Text: f.payloadText.Value(),
+		},
+	}
+	if v := f.agentID.Value(); v != "" {
+		patch.AgentID = &v
+	}
+	enabled := f.enabled
+	patch.Enabled = &enabled
+	return patch
+}
+
+// -----------------------------------------------------------------------------
+// View
+// -----------------------------------------------------------------------------
+
+func (m cronsModel) View() string {
+	banner := renderConnectionBanner(m.activeConn)
+	switch m.subset {
+	case cronSubList:
+		return banner + m.viewList()
+	case cronSubDetail:
+		return banner + m.viewDetail()
+	case cronSubForm:
+		return banner + m.viewForm()
+	case cronSubConfirmDelete:
+		return banner + m.viewConfirm()
+	}
+	return banner
+}
+
+func (m cronsModel) viewList() string {
+	if m.loading {
+		return "\n  Loading cron jobs...\n"
+	}
+	hints := ""
+	if !m.hideHints {
+		hints = helpStyle.Render(renderActionHints(m.Actions()))
+	}
+	if m.err != nil {
+		var b strings.Builder
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
+		b.WriteString("\n\n")
+		b.WriteString(hints)
+		b.WriteString("\n")
+		return b.String()
+	}
+	header := headerStyle.Render(" Cron — " + m.headerLabel() + " ")
+	if len(m.list.Items()) == 0 {
+		var b strings.Builder
+		b.WriteString("\n")
+		b.WriteString(header)
+		b.WriteString("\n\n")
+		b.WriteString("  No cron jobs found.\n\n")
+		b.WriteString(hints)
+		b.WriteString("\n")
+		return b.String()
+	}
+	return m.list.View() + "\n" + hints
+}
+
+func (m cronsModel) headerLabel() string {
+	if m.showAllAgents || m.filterAgentID == "" {
+		return "all agents"
+	}
+	if m.filterLabel != "" {
+		return m.filterLabel
+	}
+	return m.filterAgentID
+}
+
+func (m cronsModel) viewDetail() string {
+	job, ok := m.findJob(m.selectedID)
+	if !ok {
+		return "\n  Job no longer available.\n"
+	}
+	hints := ""
+	if !m.hideHints {
+		hints = helpStyle.Render(renderActionHints(m.Actions()))
+	}
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(headerStyle.Render(" Cron · " + displayJobName(job) + " "))
+	if !job.Enabled {
+		b.WriteString("  ")
+		b.WriteString(cronStatusDisabledStyle.Render("disabled"))
+	}
+	b.WriteString("\n\n")
+
+	rows := [][2]string{
+		{"Schedule", formatSchedule(job.Schedule)},
+		{"Description", orDash(job.Description)},
+		{"Agent", orDash(job.AgentID)},
+		{"Session", orDash(job.SessionTarget)},
+		{"Wake", wakeModeLabel(job.WakeMode)},
+		{"Next run", formatAbsTime(job.State.NextRunAtMs)},
+		{"Last run", formatLastRun(job.State)},
+	}
+	for _, r := range rows {
+		b.WriteString(fmt.Sprintf("  %-12s  %s\n", r[0], r[1]))
+	}
+	if delivery := formatDelivery(job.Delivery); delivery != "" {
+		b.WriteString(fmt.Sprintf("  %-12s  %s\n", "Delivery", delivery))
+	}
+	b.WriteString("\n")
+	b.WriteString("  Payload:\n")
+	payload := job.Payload.Text
+	if payload == "" {
+		payload = job.Payload.Message
+	}
+	if payload == "" {
+		payload = "—"
+	}
+	for _, line := range strings.Split(payload, "\n") {
+		b.WriteString("    " + line + "\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(headerStyle.Render(" Run history "))
+	b.WriteString("\n")
+	switch {
+	case m.runsLoading:
+		b.WriteString("  Loading...\n")
+	case m.runsErr != nil:
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.runsErr)))
+		b.WriteString("\n")
+	case len(m.runs) == 0:
+		b.WriteString("  No run log entries yet.\n")
+	default:
+		for _, r := range m.runs {
+			b.WriteString("  " + formatRunLogEntry(r) + "\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(hints)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (m cronsModel) viewForm() string {
+	var b strings.Builder
+	b.WriteString("\n")
+	title := " New cron job "
+	if m.form.mode == "edit" {
+		title = " Edit cron job "
+	}
+	b.WriteString(headerStyle.Render(title))
+	b.WriteString("\n\n")
+
+	if m.form.unsupported != "" {
+		b.WriteString(errorStyle.Render("  " + m.form.unsupported))
+		b.WriteString("\n\n")
+	}
+
+	rows := []struct {
+		label string
+		field cronFormField
+		view  string
+	}{
+		{"Name", formName, m.form.name.View()},
+		{"Description", formDescription, m.form.description.View()},
+		{"Cron expression", formCronExpr, m.form.cronExpr.View()},
+		{"Timezone", formTimezone, m.form.timezone.View()},
+		{"Agent ID (optional)", formAgentID, m.form.agentID.View()},
+		{"Session target", formSessionTarget, toggleView(m.form.sessionTarget, "main", "isolated")},
+		{"Wake mode", formWakeMode, toggleView(m.form.wakeMode, "next-heartbeat", "now")},
+		{"Payload (agent turn text)", formPayloadText, m.form.payloadText.View()},
+		{"Enabled", formEnabled, checkboxView(m.form.enabled)},
+	}
+	for _, r := range rows {
+		marker := "  "
+		if r.field == m.form.focused {
+			marker = lipgloss.NewStyle().Foreground(accent).Bold(true).Render("> ")
+		}
+		b.WriteString(marker + r.label + "\n")
+		b.WriteString("    " + r.view + "\n\n")
+	}
+
+	if m.form.err != nil {
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.form.err)))
+		b.WriteString("\n\n")
+	}
+	if m.form.saving {
+		b.WriteString(statusStyle.Render("  Saving..."))
+		b.WriteString("\n")
+	} else {
+		hint := "  Tab/Shift+Tab: navigate | Space: toggle | Enter: save (newline in payload) | Ctrl+S: save anywhere | Esc: cancel"
+		b.WriteString(helpStyle.Render(hint))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (m cronsModel) viewConfirm() string {
+	var b strings.Builder
+	b.WriteString("\n\n")
+	b.WriteString(headerStyle.Render(" Delete cron job "))
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("  Delete %q? This cannot be undone.\n\n", m.pendingDeleteName))
+	b.WriteString(helpStyle.Render("  y: confirm  ·  n / esc: cancel"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// -----------------------------------------------------------------------------
+// Formatting helpers
+// -----------------------------------------------------------------------------
+
+func displayJobName(job protocol.CronJob) string {
+	if job.Name != "" {
+		return job.Name
+	}
+	return job.ID
+}
+
+func toggleView(current, opt1, opt2 string) string {
+	render := func(label string) string {
+		if label == current {
+			return lipgloss.NewStyle().Foreground(accent).Bold(true).Render("[" + label + "]")
+		}
+		return statusStyle.Render(" " + label + " ")
+	}
+	return render(opt1) + " " + render(opt2)
+}
+
+func checkboxView(checked bool) string {
+	box := "[ ]"
+	if checked {
+		box = "[x]"
+	}
+	return box + " enabled"
+}
+
+func formatSchedule(s protocol.CronSchedule) string {
+	switch s.Kind {
+	case "cron":
+		out := "cron " + s.Expr
+		if s.Tz != "" {
+			out += " (" + s.Tz + ")"
+		}
+		return out
+	case "every":
+		if s.EveryMs != nil {
+			return "every " + formatDuration(int64(*s.EveryMs))
+		}
+		return "every —"
+	case "at":
+		return "at " + s.At
+	}
+	return orDash(s.Kind)
+}
+
+func formatAbsTime(ms *int64) string {
+	if ms == nil || *ms == 0 {
+		return "—"
+	}
+	t := time.UnixMilli(*ms).Local()
+	return t.Format("02 Jan 2006 15:04:05")
+}
+
+func formatLastRun(s protocol.CronJobState) string {
+	if s.LastRunAtMs == nil || *s.LastRunAtMs == 0 {
+		return "—"
+	}
+	t := time.UnixMilli(*s.LastRunAtMs).Local().Format("02 Jan 2006 15:04:05")
+	if s.LastStatus != "" {
+		return t + " · " + s.LastStatus
+	}
+	return t
+}
+
+func formatDelivery(d *protocol.CronDelivery) string {
+	if d == nil || d.Mode == "" {
+		return ""
+	}
+	out := d.Mode
+	if d.Channel != "" {
+		out += " (" + d.Channel + ")"
+	}
+	if d.To != "" {
+		out += " → " + d.To
+	}
+	return out
+}
+
+func formatRunLogEntry(r protocol.CronRunLogEntry) string {
+	when := "—"
+	if r.RunAtMs != nil {
+		when = time.UnixMilli(*r.RunAtMs).Local().Format("02 Jan 15:04:05")
+	}
+	parts := []string{when}
+	if r.Status != "" {
+		parts = append(parts, r.Status)
+	}
+	if r.DurationMs != nil {
+		parts = append(parts, formatDuration(*r.DurationMs))
+	}
+	if r.Summary != "" {
+		summary := r.Summary
+		if len(summary) > 60 {
+			summary = summary[:57] + "..."
+		}
+		parts = append(parts, summary)
+	} else if r.Error != "" {
+		errMsg := r.Error
+		if len(errMsg) > 60 {
+			errMsg = errMsg[:57] + "..."
+		}
+		parts = append(parts, errMsg)
+	}
+	return strings.Join(parts, " · ")
+}

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -1011,13 +1011,10 @@ func (m cronsModel) submitForm() (cronsModel, tea.Cmd) {
 	form := m.form
 
 	if form.mode == "edit" {
-		patch := buildJobPatch(form)
+		patch := buildJobPatchMap(form)
 		jobID := form.editingID
 		return m, func() tea.Msg {
-			err := cron.CronUpdate(context.Background(), protocol.CronUpdateParams{
-				ID:    jobID,
-				Patch: patch,
-			})
+			err := cron.CronUpdateRaw(context.Background(), jobID, patch)
 			return cronJobSavedMsg{jobID: jobID, err: err}
 		}
 	}
@@ -1055,29 +1052,41 @@ func buildAddParams(f cronForm) protocol.CronAddParams {
 	return params
 }
 
-func buildJobPatch(f cronForm) protocol.CronJobPatch {
-	patch := protocol.CronJobPatch{
-		Name:          f.name.Value(),
-		Description:   f.description.Value(),
-		SessionTarget: f.sessionTarget,
-		WakeMode:      f.wakeMode,
-		Schedule: &protocol.CronSchedule{
-			Kind: "cron",
-			Expr: f.cronExpr.Value(),
-			Tz:   f.timezone.Value(),
+// buildJobPatchMap renders the form as a wire-level map for
+// CronUpdateRaw. We avoid the typed CronJobPatch here because every
+// string field on it is `omitempty` — once Go marshals the struct,
+// "" becomes indistinguishable from "not provided", and the gateway
+// silently retains the prior value. Sending a literal map preserves
+// the user's intent to clear a field.
+func buildJobPatchMap(f cronForm) map[string]any {
+	patch := map[string]any{
+		"name":          f.name.Value(),
+		"description":   f.description.Value(),
+		"sessionTarget": f.sessionTarget,
+		"wakeMode":      f.wakeMode,
+		"schedule": map[string]any{
+			"kind": "cron",
+			"expr": f.cronExpr.Value(),
+			"tz":   f.timezone.Value(),
 		},
-		Payload: &protocol.CronPayload{
-			Kind:  "agentTurn",
-			Text:  f.payloadText.Value(),
-			Model: f.model.Value(),
+		"payload": map[string]any{
+			"kind":  "agentTurn",
+			"text":  f.payloadText.Value(),
+			"model": f.model.Value(),
 		},
-		Delivery: buildDelivery(f),
+		"agentId": f.agentID.Value(),
+		"enabled": f.enabled,
 	}
-	if v := f.agentID.Value(); v != "" {
-		patch.AgentID = &v
+	if d := buildDelivery(f); d != nil {
+		patch["delivery"] = map[string]any{
+			"mode":    d.Mode,
+			"channel": d.Channel,
+			"to":      d.To,
+		}
+	} else {
+		// mode=none clears delivery on the wire too.
+		patch["delivery"] = map[string]any{"mode": "none"}
 	}
-	enabled := f.enabled
-	patch.Enabled = &enabled
 	return patch
 }
 

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -176,12 +176,35 @@ const (
 	formCronExpr
 	formTimezone
 	formAgentID
+	formModel
 	formSessionTarget
 	formWakeMode
 	formPayloadText
+	formDeliveryMode
+	formDeliveryTarget
 	formEnabled
 	formFieldCount
 )
+
+// deliveryModes is the cycle order for the delivery-mode toggle in the
+// form. "none" leaves the gateway silent after a run; "announce" posts
+// to a channel (Slack/Telegram/...); "webhook" POSTs to an external URL.
+var deliveryModes = []string{"none", "announce", "webhook"}
+
+// cycleString advances current to the next entry in opts (wrapping to
+// the start), returning the new value. Used by multi-state toggles in
+// the cron form.
+func cycleString(opts []string, current string) string {
+	for i, o := range opts {
+		if o == current {
+			return opts[(i+1)%len(opts)]
+		}
+	}
+	if len(opts) > 0 {
+		return opts[0]
+	}
+	return current
+}
 
 // cronForm carries the in-progress create/edit-job form state. The form
 // only supports the cron-style schedule kind and the agentTurn payload
@@ -192,15 +215,18 @@ type cronForm struct {
 	mode      string // "create" or "edit"
 	editingID string // job ID being edited; "" in create mode
 
-	name        textinput.Model
-	description textinput.Model
-	cronExpr    textinput.Model
-	timezone    textinput.Model
-	agentID     textinput.Model
-	payloadText textarea.Model
+	name           textinput.Model
+	description    textinput.Model
+	cronExpr       textinput.Model
+	timezone       textinput.Model
+	agentID        textinput.Model
+	model          textinput.Model
+	payloadText    textarea.Model
+	deliveryTarget textinput.Model // channel for announce, URL for webhook
 
 	sessionTarget string // "main" or "isolated"
 	wakeMode      string // "next-heartbeat" or "now"
+	deliveryMode  string // "none", "announce", "webhook"
 	enabled       bool
 
 	focused      cronFormField
@@ -768,6 +794,7 @@ func newCreateForm() cronForm {
 		mode:          "create",
 		sessionTarget: "isolated",
 		wakeMode:      "next-heartbeat",
+		deliveryMode:  "none",
 		enabled:       true,
 		focused:       formName,
 	}
@@ -783,12 +810,17 @@ func newCreateForm() cronForm {
 	f.timezone.CharLimit = 64
 	f.agentID = textinput.New()
 	f.agentID.CharLimit = 64
+	f.model = textinput.New()
+	f.model.Placeholder = "leave blank to use the agent default"
+	f.model.CharLimit = 128
 	f.payloadText = textarea.New()
 	f.payloadText.CharLimit = 4000
 	f.payloadText.SetHeight(6)
 	f.payloadText.ShowLineNumbers = false
 	f.payloadText.Prompt = ""
 	f.payloadText.Placeholder = "Read /home/pete/projects/cron-jobs/example.md and follow the instructions."
+	f.deliveryTarget = textinput.New()
+	f.deliveryTarget.CharLimit = 256
 	return f
 }
 
@@ -805,6 +837,7 @@ func newEditForm(job protocol.CronJob) (cronForm, string) {
 	f.cronExpr.SetValue(job.Schedule.Expr)
 	f.timezone.SetValue(job.Schedule.Tz)
 	f.agentID.SetValue(job.AgentID)
+	f.model.SetValue(job.Payload.Model)
 	f.payloadText.SetValue(job.Payload.Text)
 	if f.payloadText.Value() == "" {
 		f.payloadText.SetValue(job.Payload.Message)
@@ -814,6 +847,15 @@ func newEditForm(job protocol.CronJob) (cronForm, string) {
 	}
 	if job.WakeMode != "" {
 		f.wakeMode = job.WakeMode
+	}
+	if job.Delivery != nil && job.Delivery.Mode != "" {
+		f.deliveryMode = job.Delivery.Mode
+		switch job.Delivery.Mode {
+		case "webhook":
+			f.deliveryTarget.SetValue(job.Delivery.To)
+		default:
+			f.deliveryTarget.SetValue(job.Delivery.Channel)
+		}
 	}
 	f.enabled = job.Enabled
 
@@ -870,6 +912,9 @@ func (m cronsModel) handleFormKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
 				m.form.wakeMode = "now"
 			}
 			return m, nil
+		case formDeliveryMode:
+			m.form.deliveryMode = cycleString(deliveryModes, m.form.deliveryMode)
+			return m, nil
 		case formEnabled:
 			m.form.enabled = !m.form.enabled
 			return m, nil
@@ -905,6 +950,10 @@ func (f *cronForm) activeInput() *textinput.Model {
 		return &f.timezone
 	case formAgentID:
 		return &f.agentID
+	case formModel:
+		return &f.model
+	case formDeliveryTarget:
+		return &f.deliveryTarget
 	}
 	return nil
 }
@@ -930,6 +979,8 @@ func (f *cronForm) refocus() tea.Cmd {
 	f.cronExpr.Blur()
 	f.timezone.Blur()
 	f.agentID.Blur()
+	f.model.Blur()
+	f.deliveryTarget.Blur()
 	f.payloadText.Blur()
 	if f.focused == formPayloadText {
 		return f.payloadText.Focus()
@@ -990,9 +1041,11 @@ func buildAddParams(f cronForm) protocol.CronAddParams {
 			Tz:   f.timezone.Value(),
 		},
 		Payload: protocol.CronPayload{
-			Kind: "agentTurn",
-			Text: f.payloadText.Value(),
+			Kind:  "agentTurn",
+			Text:  f.payloadText.Value(),
+			Model: f.model.Value(),
 		},
+		Delivery: buildDelivery(f),
 	}
 	if v := f.agentID.Value(); v != "" {
 		params.AgentID = &v
@@ -1014,9 +1067,11 @@ func buildJobPatch(f cronForm) protocol.CronJobPatch {
 			Tz:   f.timezone.Value(),
 		},
 		Payload: &protocol.CronPayload{
-			Kind: "agentTurn",
-			Text: f.payloadText.Value(),
+			Kind:  "agentTurn",
+			Text:  f.payloadText.Value(),
+			Model: f.model.Value(),
 		},
+		Delivery: buildDelivery(f),
 	}
 	if v := f.agentID.Value(); v != "" {
 		patch.AgentID = &v
@@ -1024,6 +1079,25 @@ func buildJobPatch(f cronForm) protocol.CronJobPatch {
 	enabled := f.enabled
 	patch.Enabled = &enabled
 	return patch
+}
+
+// buildDelivery turns the form's deliveryMode + deliveryTarget into a
+// *CronDelivery, or nil when the user picked "none". For "announce" the
+// target is the channel; for "webhook" it's the destination URL.
+func buildDelivery(f cronForm) *protocol.CronDelivery {
+	switch f.deliveryMode {
+	case "announce":
+		return &protocol.CronDelivery{
+			Mode:    "announce",
+			Channel: f.deliveryTarget.Value(),
+		}
+	case "webhook":
+		return &protocol.CronDelivery{
+			Mode: "webhook",
+			To:   f.deliveryTarget.Value(),
+		}
+	}
+	return nil
 }
 
 // -----------------------------------------------------------------------------
@@ -1108,16 +1182,15 @@ func (m cronsModel) viewDetail() string {
 		{"Schedule", formatSchedule(job.Schedule)},
 		{"Description", orDash(job.Description)},
 		{"Agent", orDash(job.AgentID)},
+		{"Model", orDash(job.Payload.Model)},
 		{"Session", orDash(job.SessionTarget)},
 		{"Wake", wakeModeLabel(job.WakeMode)},
+		{"Delivery", formatDeliveryOrNone(job.Delivery)},
 		{"Next run", formatAbsTime(job.State.NextRunAtMs)},
 		{"Last run", formatLastRun(job.State)},
 	}
 	for _, r := range rows {
 		b.WriteString(fmt.Sprintf("  %-12s  %s\n", r[0], r[1]))
-	}
-	if delivery := formatDelivery(job.Delivery); delivery != "" {
-		b.WriteString(fmt.Sprintf("  %-12s  %s\n", "Delivery", delivery))
 	}
 	b.WriteString("\n")
 	b.WriteString("  Payload:\n")
@@ -1180,9 +1253,12 @@ func (m cronsModel) viewForm() string {
 		{"Cron expression", formCronExpr, m.form.cronExpr.View()},
 		{"Timezone", formTimezone, m.form.timezone.View()},
 		{"Agent ID (optional)", formAgentID, m.form.agentID.View()},
+		{"Model (optional)", formModel, m.form.model.View()},
 		{"Session target", formSessionTarget, toggleView(m.form.sessionTarget, "main", "isolated")},
 		{"Wake mode", formWakeMode, toggleView(m.form.wakeMode, "next-heartbeat", "now")},
 		{"Payload (agent turn text)", formPayloadText, m.form.payloadText.View()},
+		{"Delivery mode", formDeliveryMode, cycleView(deliveryModes, m.form.deliveryMode)},
+		{deliveryTargetLabel(m.form.deliveryMode), formDeliveryTarget, m.form.deliveryTarget.View()},
 		{"Enabled", formEnabled, checkboxView(m.form.enabled)},
 	}
 	for _, r := range rows {
@@ -1239,6 +1315,34 @@ func toggleView(current, opt1, opt2 string) string {
 		return statusStyle.Render(" " + label + " ")
 	}
 	return render(opt1) + " " + render(opt2)
+}
+
+// cycleView is toggleView for an N-state field (the delivery-mode
+// cycle). The current option is highlighted; non-active options are
+// rendered dim.
+func cycleView(opts []string, current string) string {
+	parts := make([]string, len(opts))
+	for i, o := range opts {
+		if o == current {
+			parts[i] = lipgloss.NewStyle().Foreground(accent).Bold(true).Render("[" + o + "]")
+		} else {
+			parts[i] = statusStyle.Render(" " + o + " ")
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// deliveryTargetLabel returns the input label that matches the current
+// delivery mode. "none" still shows the field but disabled-looking so
+// the layout stays stable as the user cycles modes.
+func deliveryTargetLabel(mode string) string {
+	switch mode {
+	case "announce":
+		return "Channel (e.g. slack:#alerts)"
+	case "webhook":
+		return "Webhook URL"
+	}
+	return "Delivery target (unused while mode=none)"
 }
 
 func checkboxView(checked bool) string {
@@ -1299,6 +1403,16 @@ func formatDelivery(d *protocol.CronDelivery) string {
 		out += " → " + d.To
 	}
 	return out
+}
+
+// formatDeliveryOrNone returns "none" instead of an empty string when
+// the job has no delivery configured, so the detail view's row layout
+// stays consistent.
+func formatDeliveryOrNone(d *protocol.CronDelivery) string {
+	if s := formatDelivery(d); s != "" {
+		return s
+	}
+	return "none"
 }
 
 func formatRunLogEntry(r protocol.CronRunLogEntry) string {

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -242,6 +242,86 @@ func TestCronsForm_BuildDelivery_NoneReturnsNil(t *testing.T) {
 	}
 }
 
+func TestCronsForm_BuildJobPatchMap_ClearsModelAndDescription(t *testing.T) {
+	f := newCreateForm()
+	f.editingID = "job-1"
+	f.mode = "edit"
+	f.name.SetValue("Renamed")
+	// description and model are intentionally left empty to simulate
+	// the user clearing them in the edit form.
+	f.cronExpr.SetValue("0 9 * * *")
+	f.timezone.SetValue("UTC")
+	f.agentID.SetValue("agent-1")
+	f.payloadText.SetValue("Do thing.")
+	f.sessionTarget = "isolated"
+	f.wakeMode = "now"
+	f.deliveryMode = "none"
+	f.enabled = true
+
+	patch := buildJobPatchMap(f)
+
+	if got := patch["description"]; got != "" {
+		t.Errorf("expected description to be present and empty, got %#v", got)
+	}
+	payload, ok := patch["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected payload map, got %T", patch["payload"])
+	}
+	if got, ok := payload["model"]; !ok {
+		t.Errorf("expected payload.model key to be present in patch")
+	} else if got != "" {
+		t.Errorf("expected payload.model='', got %#v", got)
+	}
+	delivery, ok := patch["delivery"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected delivery map, got %T", patch["delivery"])
+	}
+	if delivery["mode"] != "none" {
+		t.Errorf("expected delivery.mode=none, got %#v", delivery["mode"])
+	}
+}
+
+func TestCronsForm_EditSubmitUsesRawUpdate(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	jobs := []protocol.CronJob{{
+		ID:            "job-1",
+		Name:          "Old name",
+		AgentID:       "agent-1",
+		Enabled:       true,
+		SessionTarget: "isolated",
+		WakeMode:      "now",
+		Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "0 9 * * *"},
+		Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "old text", Model: "haiku-4-5"},
+	}}
+	m, _ = m.Update(cronsLoadedMsg{jobs: jobs})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})  // open detail
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'e', Text: "e"}) // open edit form
+	if m.subset != cronSubForm {
+		t.Fatalf("expected form substate, got %v", m.subset)
+	}
+	// Clear the model value, simulating the user emptying the field.
+	m.form.model.SetValue("")
+
+	_, cmd := m.submitForm()
+	if cmd == nil {
+		t.Fatal("expected a save cmd")
+	}
+	cmd()
+
+	if fake.lastCronUpdateID != "job-1" {
+		t.Errorf("lastCronUpdateID: %q", fake.lastCronUpdateID)
+	}
+	payload, ok := fake.lastCronUpdateRaw["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected payload map in raw patch, got %T", fake.lastCronUpdateRaw["payload"])
+	}
+	if model, present := payload["model"]; !present {
+		t.Errorf("expected payload.model key on the wire even when empty")
+	} else if model != "" {
+		t.Errorf("expected payload.model=\"\", got %#v", model)
+	}
+}
+
 func TestCronsForm_PrePopulatesModelAndDelivery(t *testing.T) {
 	job := protocol.CronJob{
 		ID:            "job-1",

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -190,9 +190,12 @@ func TestCronsForm_BuildsCronAddParams(t *testing.T) {
 	f.cronExpr.SetValue("0 9 * * *")
 	f.timezone.SetValue("Europe/London")
 	f.agentID.SetValue("agent-1")
+	f.model.SetValue("claude-opus-4-7")
 	f.payloadText.SetValue("Please generate today's report.")
 	f.sessionTarget = "main"
 	f.wakeMode = "now"
+	f.deliveryMode = "announce"
+	f.deliveryTarget.SetValue("slack:#alerts")
 	f.enabled = true
 
 	params := buildAddParams(f)
@@ -205,6 +208,9 @@ func TestCronsForm_BuildsCronAddParams(t *testing.T) {
 	if params.Payload.Kind != "agentTurn" || params.Payload.Text != "Please generate today's report." {
 		t.Errorf("Payload: %+v", params.Payload)
 	}
+	if params.Payload.Model != "claude-opus-4-7" {
+		t.Errorf("Payload.Model: %q", params.Payload.Model)
+	}
 	if params.SessionTarget != "main" || params.WakeMode != "now" {
 		t.Errorf("SessionTarget/WakeMode: %q/%q", params.SessionTarget, params.WakeMode)
 	}
@@ -213,6 +219,52 @@ func TestCronsForm_BuildsCronAddParams(t *testing.T) {
 	}
 	if params.Enabled == nil || !*params.Enabled {
 		t.Errorf("Enabled: %+v", params.Enabled)
+	}
+	if params.Delivery == nil || params.Delivery.Mode != "announce" || params.Delivery.Channel != "slack:#alerts" {
+		t.Errorf("Delivery: %+v", params.Delivery)
+	}
+}
+
+func TestCronsForm_BuildDelivery_Webhook(t *testing.T) {
+	f := newCreateForm()
+	f.deliveryMode = "webhook"
+	f.deliveryTarget.SetValue("https://example.com/hook")
+	d := buildDelivery(f)
+	if d == nil || d.Mode != "webhook" || d.To != "https://example.com/hook" {
+		t.Errorf("expected webhook delivery, got %+v", d)
+	}
+}
+
+func TestCronsForm_BuildDelivery_NoneReturnsNil(t *testing.T) {
+	f := newCreateForm()
+	if d := buildDelivery(f); d != nil {
+		t.Errorf("expected nil for mode=none, got %+v", d)
+	}
+}
+
+func TestCronsForm_PrePopulatesModelAndDelivery(t *testing.T) {
+	job := protocol.CronJob{
+		ID:            "job-1",
+		Name:          "Foo",
+		Enabled:       true,
+		SessionTarget: "isolated",
+		WakeMode:      "now",
+		Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "0 9 * * *"},
+		Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "hi", Model: "haiku-4-5"},
+		Delivery:      &protocol.CronDelivery{Mode: "announce", Channel: "slack:#general"},
+	}
+	form, banner := newEditForm(job)
+	if banner != "" {
+		t.Fatalf("unexpected unsupported banner: %q", banner)
+	}
+	if got := form.model.Value(); got != "haiku-4-5" {
+		t.Errorf("model: %q", got)
+	}
+	if form.deliveryMode != "announce" {
+		t.Errorf("deliveryMode: %q", form.deliveryMode)
+	}
+	if got := form.deliveryTarget.Value(); got != "slack:#general" {
+		t.Errorf("deliveryTarget: %q", got)
 	}
 }
 

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -1,0 +1,284 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+	tea "charm.land/bubbletea/v2"
+)
+
+func newTestCronsModel(t *testing.T) (cronsModel, *fakeBackend) {
+	t.Helper()
+	fake := newFakeBackend()
+	m := newCronsModel(fake, "agent-1", "Scout", false, nil)
+	m.setSize(120, 40)
+	return m, fake
+}
+
+func sampleJobs() []protocol.CronJob {
+	enabled := true
+	return []protocol.CronJob{
+		{
+			ID:            "job-1",
+			Name:          "Daily report",
+			AgentID:       "agent-1",
+			Enabled:       enabled,
+			SessionTarget: "isolated",
+			WakeMode:      "now",
+			Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "0 9 * * *", Tz: "UTC"},
+			Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "Generate report."},
+		},
+		{
+			ID:            "job-2",
+			Name:          "Other agent thing",
+			AgentID:       "agent-2",
+			Enabled:       enabled,
+			SessionTarget: "main",
+			WakeMode:      "next-heartbeat",
+			Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "*/15 * * * *"},
+			Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "Tick."},
+		},
+	}
+}
+
+func TestCronsLoadedMsg_PopulatesList(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	if m.loading {
+		t.Error("expected loading=false after cronsLoadedMsg")
+	}
+	// filter is agent-1 by default → only job-1 should be shown.
+	if got := len(m.list.Items()); got != 1 {
+		t.Fatalf("expected 1 item after filtering, got %d", got)
+	}
+	item, ok := m.list.SelectedItem().(cronItem)
+	if !ok || item.job.ID != "job-1" {
+		t.Errorf("expected job-1 to be selected, got %+v", m.list.SelectedItem())
+	}
+}
+
+func TestCronsLoadedMsg_Error(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{err: errString("gateway down")})
+	if m.err == nil {
+		t.Error("expected err to be set")
+	}
+	if m.loading {
+		t.Error("expected loading=false even on error")
+	}
+}
+
+func TestCronsKey_A_TogglesAllAgentsFilter(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	if got := len(m.list.Items()); got != 1 {
+		t.Fatalf("expected filtered list to start with 1 item, got %d", got)
+	}
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if got := len(m.list.Items()); got != 2 {
+		t.Errorf("expected 2 items after toggling all-agents, got %d", got)
+	}
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if got := len(m.list.Items()); got != 1 {
+		t.Errorf("expected back to 1 item after toggling off, got %d", got)
+	}
+}
+
+func TestCronsKey_Enter_OpensDetail(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.subset != cronSubDetail {
+		t.Fatalf("expected substate=detail, got %v", m.subset)
+	}
+	if m.selectedID != "job-1" {
+		t.Errorf("expected selectedID=job-1, got %q", m.selectedID)
+	}
+	if cmd == nil {
+		t.Fatal("expected a runs-load command from enter")
+	}
+	msg := cmd()
+	if _, ok := msg.(cronRunsLoadedMsg); !ok {
+		t.Errorf("expected cronRunsLoadedMsg, got %T", msg)
+	}
+}
+
+func TestCronsKey_Esc_FromList_GoesBack(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected a cmd from esc on list")
+	}
+	if _, ok := cmd().(goBackFromCronsMsg); !ok {
+		t.Errorf("expected goBackFromCronsMsg, got %T", cmd())
+	}
+}
+
+func TestCronsKey_Esc_FromDetail_ReturnsToList(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.subset != cronSubDetail {
+		t.Fatal("setup: expected detail substate")
+	}
+	m, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.subset != cronSubList {
+		t.Errorf("expected substate=list after esc from detail, got %v", m.subset)
+	}
+	if cmd != nil {
+		// esc inside the detail view shouldn't escape to the parent.
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(goBackFromCronsMsg); ok {
+				t.Errorf("esc from detail should not bubble to goBackFromCronsMsg, got %T", msg)
+			}
+		}
+	}
+}
+
+func TestCronsKey_T_TogglesEnabled(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: 't', Text: "t"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from toggle")
+	}
+	msg := cmd()
+	tm, ok := msg.(cronJobToggledMsg)
+	if !ok {
+		t.Fatalf("expected cronJobToggledMsg, got %T", msg)
+	}
+	if tm.jobID != "job-1" {
+		t.Errorf("expected jobID=job-1, got %q", tm.jobID)
+	}
+	if tm.enabled != false {
+		t.Errorf("expected enabled flipped to false, got %v", tm.enabled)
+	}
+	if fake.lastCronUpdate == nil {
+		t.Fatal("expected CronUpdate to be invoked")
+	}
+	if fake.lastCronUpdate.Patch.Enabled == nil || *fake.lastCronUpdate.Patch.Enabled {
+		t.Errorf("expected patch.Enabled=false, got %+v", fake.lastCronUpdate.Patch.Enabled)
+	}
+}
+
+func TestCronsForm_RefusesUnsupportedScheduleKind(t *testing.T) {
+	job := protocol.CronJob{
+		ID:            "weird",
+		Name:          "Weird",
+		AgentID:       "agent-1",
+		Enabled:       true,
+		SessionTarget: "isolated",
+		WakeMode:      "now",
+		Schedule:      protocol.CronSchedule{Kind: "every"},
+		Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "X"},
+	}
+	form, banner := newEditForm(job)
+	if banner == "" {
+		t.Fatal("expected unsupported banner for schedule.kind=every")
+	}
+	if form.editingID != "weird" {
+		t.Errorf("expected editingID=weird, got %q", form.editingID)
+	}
+}
+
+func TestCronsForm_BuildsCronAddParams(t *testing.T) {
+	f := newCreateForm()
+	f.name.SetValue("Daily report")
+	f.description.SetValue("Generate a report")
+	f.cronExpr.SetValue("0 9 * * *")
+	f.timezone.SetValue("Europe/London")
+	f.agentID.SetValue("agent-1")
+	f.payloadText.SetValue("Please generate today's report.")
+	f.sessionTarget = "main"
+	f.wakeMode = "now"
+	f.enabled = true
+
+	params := buildAddParams(f)
+	if params.Name != "Daily report" {
+		t.Errorf("Name: %q", params.Name)
+	}
+	if params.Schedule.Kind != "cron" || params.Schedule.Expr != "0 9 * * *" || params.Schedule.Tz != "Europe/London" {
+		t.Errorf("Schedule: %+v", params.Schedule)
+	}
+	if params.Payload.Kind != "agentTurn" || params.Payload.Text != "Please generate today's report." {
+		t.Errorf("Payload: %+v", params.Payload)
+	}
+	if params.SessionTarget != "main" || params.WakeMode != "now" {
+		t.Errorf("SessionTarget/WakeMode: %q/%q", params.SessionTarget, params.WakeMode)
+	}
+	if params.AgentID == nil || *params.AgentID != "agent-1" {
+		t.Errorf("AgentID: %+v", params.AgentID)
+	}
+	if params.Enabled == nil || !*params.Enabled {
+		t.Errorf("Enabled: %+v", params.Enabled)
+	}
+}
+
+func TestCronsConfirmDelete_YesDispatchesRemove(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if m.subset != cronSubConfirmDelete {
+		t.Fatalf("expected confirm substate, got %v", m.subset)
+	}
+	if m.pendingDeleteID != "job-1" {
+		t.Errorf("pendingDeleteID: %q", m.pendingDeleteID)
+	}
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from y")
+	}
+	msg := cmd()
+	if rm, ok := msg.(cronJobRemovedMsg); !ok {
+		t.Errorf("expected cronJobRemovedMsg, got %T", msg)
+	} else if rm.jobID != "job-1" {
+		t.Errorf("expected removed jobID=job-1, got %q", rm.jobID)
+	}
+	if len(fake.cronRemoved) != 1 || fake.cronRemoved[0] != "job-1" {
+		t.Errorf("expected fake.cronRemoved=[job-1], got %+v", fake.cronRemoved)
+	}
+}
+
+func TestCronsConfirmDelete_NoCancels(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	if m.subset != cronSubDetail {
+		t.Errorf("expected return to detail after n, got %v", m.subset)
+	}
+	if m.pendingDeleteID != "" {
+		t.Errorf("expected pendingDeleteID cleared, got %q", m.pendingDeleteID)
+	}
+}
+
+func TestCronsTranscript_PicksMostRecentRunSession(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	jobs := sampleJobs()
+	m, _ = m.Update(cronsLoadedMsg{jobs: jobs})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	// Seed runs as if loadRuns completed.
+	m, _ = m.Update(cronRunsLoadedMsg{
+		jobID:   "job-1",
+		entries: []protocol.CronRunLogEntry{{SessionKey: "agent-1:cron:job-1:run-42"}},
+	})
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: 'T', Text: "T"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from T")
+	}
+	msg := cmd()
+	sel, ok := msg.(sessionSelectedMsg)
+	if !ok {
+		t.Fatalf("expected sessionSelectedMsg, got %T", msg)
+	}
+	if sel.sessionKey != "agent-1:cron:job-1:run-42" {
+		t.Errorf("sessionKey: %q", sel.sessionKey)
+	}
+	if sel.agentID != "agent-1" {
+		t.Errorf("agentID: %q", sel.agentID)
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -124,9 +124,14 @@ type showSessionsMsg struct {
 	mainKey   string
 }
 
-// sessionSelectedMsg is returned when the user picks a session to restore.
+// sessionSelectedMsg is returned when the user picks a session to
+// restore. Most senders (the session browser) leave agentID empty and
+// the AppModel falls back to the session view's known agentID;
+// crossviews like the cron browser populate it explicitly so the chat
+// model is constructed with the right agent context.
 type sessionSelectedMsg struct {
 	sessionKey string
+	agentID    string
 	agentName  string
 	modelID    string
 }
@@ -245,4 +250,49 @@ type ConnStateMsg struct {
 	Status  client.ConnStatus
 	Attempt int
 	Err     error
+}
+
+// showCronsMsg signals the AppModel to switch to the cron browser.
+// filterAgentID empty means "show jobs across all agents".
+type showCronsMsg struct {
+	filterAgentID string
+	filterLabel   string // "all agents" or the agent's name; rendered in the header
+}
+
+// goBackFromCronsMsg signals the AppModel to return from the cron view.
+type goBackFromCronsMsg struct{}
+
+// cronsLoadedMsg is returned when the cron job list is fetched.
+type cronsLoadedMsg struct {
+	jobs []protocol.CronJob
+	err  error
+}
+
+// cronRunsLoadedMsg is returned when run history for a specific job is fetched.
+type cronRunsLoadedMsg struct {
+	jobID   string
+	entries []protocol.CronRunLogEntry
+	err     error
+}
+
+// cronJobToggledMsg is returned after flipping a job's enabled flag.
+type cronJobToggledMsg struct {
+	jobID   string
+	enabled bool
+	err     error
+}
+
+// cronJobRanMsg is returned after a manual run-now request completes.
+type cronJobRanMsg struct{ err error }
+
+// cronJobSavedMsg is returned after creating or updating a cron job.
+type cronJobSavedMsg struct {
+	jobID string
+	err   error
+}
+
+// cronJobRemovedMsg is returned after deleting a cron job.
+type cronJobRemovedMsg struct {
+	jobID string
+	err   error
 }


### PR DESCRIPTION
Add a `/crons` view to lucinate so users can browse, inspect, and manage Gateway cron jobs without leaving the TUI.

## Summary
- New `/crons` slash command opens a cron browser, defaulting to jobs for the current chat's agent (`/crons all` shows global). Capability-gated via a new `backend.CronBackend` sub-interface — backends without server-side scheduling print "not available on this connection" rather than crashing.
- List view shows job name, next-run relative time, session target / wake mode / agent / status badge per row.
- Detail view shows schedule, description, agent, model, session, wake, delivery, next/last run, payload body, and recent run history.
- Actions on a selected job: run-now, toggle enable/disable, edit, delete (with confirmation), open the most recent run's transcript in chat.
- Create/edit form covers name, description, cron expression, timezone, agent, model, session target, wake mode, payload (multi-line textarea), delivery mode (none/announce/webhook) + target, and enabled flag. Refuses to load jobs whose schedule or payload kind isn't `cron`/`agentTurn` rather than silently truncating.
- Resolves issue #71.

## Implementation details
- The form-edit submit path uses a new `CronUpdateRaw(jobID, patch map[string]any)` rather than the typed `protocol.CronJobPatch`. The typed struct marks every string field with `omitempty`, which strips empty values before they hit the wire and makes the gateway treat "field cleared" identically to "field absent" (it kept the prior value). The map-based patch sends empty strings verbatim so clearing the model, description, or delivery actually persists. The toggle-enabled path stays on the typed `CronUpdate` because it only mutates a `*bool`.
- Skill-style coverage rather than UX-only tests: 16 unit tests cover list filtering, agent-filter toggle, navigation, toggle, run-now, create-vs-edit form submission, raw-patch keys for cleared fields, delete confirmation, and transcript routing.