### PR TITLE
feat(tui): show last-message timestamp on the history separator

### DIFF
--- a/internal/backend/openai/backend.go
+++ b/internal/backend/openai/backend.go
@@ -402,8 +402,9 @@ func (b *Backend) ChatHistory(ctx context.Context, sessionKey string, limit int)
 		Text string `json:"text"`
 	}
 	type historyMsg struct {
-		Role    string  `json:"role"`
-		Content []block `json:"content"`
+		Role      string  `json:"role"`
+		Content   []block `json:"content"`
+		Timestamp int64   `json:"timestamp,omitempty"`
 	}
 	out := struct {
 		Messages []historyMsg `json:"messages"`
@@ -412,9 +413,14 @@ func (b *Backend) ChatHistory(ctx context.Context, sessionKey string, limit int)
 		if msg.Role == "system" {
 			continue
 		}
+		var ts int64
+		if !msg.Time.IsZero() {
+			ts = msg.Time.UnixMilli()
+		}
 		out.Messages = append(out.Messages, historyMsg{
-			Role:    msg.Role,
-			Content: []block{{Type: "text", Text: msg.Content}},
+			Role:      msg.Role,
+			Content:   []block{{Type: "text", Text: msg.Content}},
+			Timestamp: ts,
 		})
 	}
 	return json.Marshal(out)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -256,7 +256,8 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case historyLoadedMsg:
 		if msg.err == nil && len(msg.messages) > 0 {
-			hist := append(msg.messages, chatMessage{role: "separator"})
+			lastTs := lastTimestampMs(msg.messages)
+			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
 			m.messages = append(hist, m.messages...)
 			m.updateViewport()
 		}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -17,8 +17,9 @@ type historyResponse struct {
 }
 
 type historyMessage struct {
-	Role    string             `json:"role"`
-	Content []chatContentBlock `json:"content"`
+	Role      string             `json:"role"`
+	Content   []chatContentBlock `json:"content"`
+	Timestamp int64              `json:"timestamp,omitempty"` // unix millis, when present
 }
 
 func (m chatModel) loadHistory() tea.Cmd {
@@ -88,7 +89,7 @@ func fetchHistory(b backend.Backend, sessionKey string, renderer *glamour.TermRe
 				rendered = true
 			}
 		}
-		msgs = append(msgs, chatMessage{role: role, content: text, raw: raw, thinking: thinking, rendered: rendered})
+		msgs = append(msgs, chatMessage{role: role, content: text, raw: raw, thinking: thinking, rendered: rendered, timestampMs: hm.Timestamp})
 	}
 	return msgs, nil
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -17,7 +17,8 @@ type chatMessage struct {
 	streaming     bool
 	awaitingDelta bool // true for the pre-response spinner placeholder, before any delta arrives
 	errMsg        string
-	rendered      bool // true if content has been glamour-rendered (contains ANSI codes)
+	rendered      bool  // true if content has been glamour-rendered (contains ANSI codes)
+	timestampMs   int64 // unix millis; only used by "separator" rows to label resume time
 }
 
 // sessionStats holds token usage stats for display.

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"github.com/olekukonko/tablewriter"
@@ -18,8 +19,7 @@ func (m *chatModel) updateViewport() {
 		}
 		switch msg.role {
 		case "separator":
-			sep := strings.Repeat("─", contentWidth)
-			b.WriteString(statusStyle.Render(sep))
+			b.WriteString(statusStyle.Render(buildSeparator(contentWidth, formatSeparatorLabel(msg.timestampMs, time.Now()))))
 
 		case "user":
 			prefixIndent, wrapWidth := m.writePrefix(&b, userPrefixStyle, "You")
@@ -285,6 +285,60 @@ func stripLeadingSpacesPerLine(s string) string {
 		lines[i] = sb.String()
 	}
 	return strings.Join(lines, "\n")
+}
+
+// lastTimestampMs returns the timestamp of the last message in msgs that
+// carries one, or 0 if none do. Used to label the resume-point separator.
+func lastTimestampMs(msgs []chatMessage) int64 {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].timestampMs > 0 {
+			return msgs[i].timestampMs
+		}
+	}
+	return 0
+}
+
+// formatSeparatorLabel renders a timestamp suffix for the history separator.
+// Returns "" when the timestamp is missing so older backends fall back to a
+// plain rule.
+func formatSeparatorLabel(ms int64, now time.Time) string {
+	if ms <= 0 {
+		return ""
+	}
+	t := time.UnixMilli(ms).In(now.Location())
+	if sameYMD(t, now) {
+		return t.Format("15:04")
+	}
+	if sameYMD(t, now.AddDate(0, 0, -1)) {
+		return "Yesterday " + t.Format("15:04")
+	}
+	if t.Year() == now.Year() {
+		return t.Format("2 Jan 15:04")
+	}
+	return t.Format("2 Jan 2006 15:04")
+}
+
+func sameYMD(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// buildSeparator returns a horizontal rule of the given width with an optional
+// centred label. The total visible width always equals width.
+func buildSeparator(width int, label string) string {
+	if width <= 0 {
+		return ""
+	}
+	if label == "" {
+		return strings.Repeat("─", width)
+	}
+	decorated := " " + label + " "
+	if len(decorated) >= width {
+		return strings.Repeat("─", width)
+	}
+	pad := (width - len(decorated)) / 2
+	return strings.Repeat("─", pad) + decorated + strings.Repeat("─", width-pad-len(decorated))
 }
 
 // isTableLine returns true if the line appears to be part of a rendered table.

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/bubbles/v2/viewport"
 	"github.com/charmbracelet/x/ansi"
@@ -323,6 +324,71 @@ func TestStripLeadingSpacesPerLine(t *testing.T) {
 				t.Errorf("stripLeadingSpacesPerLine(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatSeparatorLabel(t *testing.T) {
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		ts   time.Time
+		zero bool // pass ms=0 instead of ts
+		want string
+	}{
+		{"missing", time.Time{}, true, ""},
+		{"today", time.Date(2026, 4, 29, 8, 30, 0, 0, time.UTC), false, "08:30"},
+		{"yesterday", time.Date(2026, 4, 28, 22, 5, 0, 0, time.UTC), false, "Yesterday 22:05"},
+		{"earlier_this_year", time.Date(2026, 1, 12, 14, 0, 0, 0, time.UTC), false, "12 Jan 14:00"},
+		{"prior_year", time.Date(2025, 12, 31, 23, 59, 0, 0, time.UTC), false, "31 Dec 2025 23:59"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ms int64
+			if !tt.zero {
+				ms = tt.ts.UnixMilli()
+			}
+			got := formatSeparatorLabel(ms, now)
+			if got != tt.want {
+				t.Errorf("formatSeparatorLabel(%s) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSeparator(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		label string
+		want  string
+	}{
+		{"plain", 10, "", "──────────"},
+		{"centred_label", 13, "08:30", "─── 08:30 ───"},
+		{"odd_padding", 12, "08:30", "── 08:30 ───"},
+		{"label_too_wide", 5, "08:30", "─────"},
+		{"zero_width", 0, "08:30", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSeparator(tt.width, tt.label)
+			if got != tt.want {
+				t.Errorf("buildSeparator(%d, %q) = %q, want %q", tt.width, tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLastTimestampMs(t *testing.T) {
+	msgs := []chatMessage{
+		{role: "user", timestampMs: 100},
+		{role: "assistant", timestampMs: 200},
+		{role: "user"},
+	}
+	if got := lastTimestampMs(msgs); got != 200 {
+		t.Errorf("lastTimestampMs() = %d, want 200", got)
+	}
+	if got := lastTimestampMs(nil); got != 0 {
+		t.Errorf("lastTimestampMs(nil) = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
Add a timestamp indicator on the horizontal rule that marks the resume point when opening an existing chat session, so users can see when they last interacted.

## Summary
- Read the `timestamp` field already returned per message by the gateway's `chat.history` (Unix millis) and pass it through the TUI's history loader.
- Stamp the resume-point separator with the most recent message's timestamp when history is loaded.
- Render the separator as a centred label: `15:04` (today), `Yesterday HH:MM`, `2 Jan HH:MM` (this year), or `2 Jan 2006 HH:MM` (older). Falls back to a plain rule when no timestamp is available, so older transcripts and backends without timestamps still render.
- Include `timestamp` in the OpenAI backend's synthetic history JSON for parity, sourced from the existing per-message `Time` field.
- Unit tests cover the label formatter, the centred-rule builder, and the last-timestamp helper.