### PR TITLE
refactor: surface a connection-managed embedder API for non-CLI hosts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -172,6 +172,22 @@ type RunOptions struct {
 	// accordingly. The CLI leaves it nil — its inline help is the
 	// surface that matters there.
 	OnActionsChanged func(actions []Action)
+
+	// OnFocusedFieldChanged, if non-nil, is invoked whenever the
+	// active view's focused text-input changes — Tab/Shift-Tab inside
+	// a multi-field form, or entry into a view that lands focus on a
+	// different field. The string is the new field's current value
+	// at the moment of transition (empty for a fresh field; pre-fill
+	// in Edit mode), so embedders driving an external input surface
+	// (a SwiftUI TextField on iOS, say) can hydrate it to match the
+	// TUI state without inventing their own per-field bookkeeping.
+	//
+	// The callback does not fire on every keystroke — only on field
+	// transitions, dedup'd by field identity — so embedders are safe
+	// to use it as a source of truth without rate-limiting. It runs
+	// from a tea.Cmd goroutine, so embedders that touch UI on a main
+	// thread should trampoline accordingly. The CLI leaves it nil.
+	OnFocusedFieldChanged func(value string)
 }
 
 // Program wraps a Bubble Tea program with the lucinate model and the
@@ -252,15 +268,16 @@ func New(opts RunOptions) (*Program, error) {
 	}
 
 	tuiOpts := tui.AppOptions{
-		HideInputArea:        opts.HideInputArea,
-		HideActionHints:      opts.HideActionHints,
-		DisableMouse:         opts.DisableMouse,
-		OnInputFocusChanged:  opts.OnInputFocusChanged,
-		OnActionsChanged:     opts.OnActionsChanged,
-		Store:                opts.Store,
-		Initial:              opts.Initial,
-		BackendFactory:       opts.BackendFactory,
-		OnConnectionsChanged: opts.OnConnectionsChanged,
+		HideInputArea:         opts.HideInputArea,
+		HideActionHints:       opts.HideActionHints,
+		DisableMouse:          opts.DisableMouse,
+		OnInputFocusChanged:   opts.OnInputFocusChanged,
+		OnActionsChanged:      opts.OnActionsChanged,
+		OnFocusedFieldChanged: opts.OnFocusedFieldChanged,
+		Store:                 opts.Store,
+		Initial:               opts.Initial,
+		BackendFactory:        opts.BackendFactory,
+		OnConnectionsChanged:  opts.OnConnectionsChanged,
 	}
 	if mode == modeManaged {
 		// Blocking send is fine: OnBackendChanged is invoked from a

--- a/app/app.go
+++ b/app/app.go
@@ -179,8 +179,9 @@ type RunOptions struct {
 	// different field. The string is the new field's current value
 	// at the moment of transition (empty for a fresh field; pre-fill
 	// in Edit mode), so embedders driving an external input surface
-	// (a SwiftUI TextField on iOS, say) can hydrate it to match the
-	// TUI state without inventing their own per-field bookkeeping.
+	// (a native-platform host's text field, say) can hydrate it to
+	// match the TUI state without inventing their own per-field
+	// bookkeeping.
 	//
 	// The callback does not fire on every keystroke — only on field
 	// transitions, dedup'd by field identity — so embedders are safe

--- a/app/external.go
+++ b/app/external.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/a3tai/openclaw-go/identity"
 
+	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
 	"github.com/lucinate-ai/lucinate/internal/tui"
@@ -29,6 +30,57 @@ type Identity = identity.Identity
 // obtain one from Connect and pass it to RunOptions.Client. The only method
 // they need to call directly is Close.
 type Client = client.Client
+
+// Backend is the chat-service abstraction the TUI consumes. Values of
+// this type are produced by a BackendFactory and passed to
+// RunOptions.Backend (single-connection mode) or returned from the
+// factory the TUI calls itself (managed mode).
+type Backend = backend.Backend
+
+// Connection is a saved chat-service target. The picker in managed
+// mode adds, edits, and deletes Connections in the surrounding store.
+type Connection = config.Connection
+
+// Connections is the on-disk persistence shape for the connection
+// store: a list of Connection plus the ID to auto-pick at startup.
+type Connections = config.Connections
+
+// ConnectionType identifies the protocol/backend a Connection points
+// at. Use the ConnTypeOpenClaw / ConnTypeOpenAI constants.
+type ConnectionType = config.ConnectionType
+
+// ConnectionFields is the input shape Connections.Add and Update take.
+// Only the fields relevant to the chosen Type need to be populated.
+type ConnectionFields = config.ConnectionFields
+
+// EntryConnection is the resolved startup decision returned from
+// ResolveEntryConnection: either an explicit Connection to use, or a
+// directive to drop the user into the picker.
+type EntryConnection = config.EntryConnection
+
+// Connection-type constants re-exported so embedders can build
+// Connection values without importing internal/config.
+const (
+	ConnTypeOpenClaw = config.ConnTypeOpenClaw
+	ConnTypeOpenAI   = config.ConnTypeOpenAI
+)
+
+// LoadConnections reads the connection store from
+// ~/.lucinate/connections.json, returning an empty store on first run
+// or when the file is missing or unreadable.
+func LoadConnections() Connections { return config.LoadConnections() }
+
+// SaveConnections writes the connection store to disk atomically. The
+// CLI calls this from the OnConnectionsChanged callback so a successful
+// connect persists; embedders that own persistence elsewhere can skip
+// it.
+func SaveConnections(c Connections) error { return config.SaveConnections(c) }
+
+// ResolveEntryConnection runs the startup decision tree (env vars,
+// stored DefaultID, single-entry auto-pick, picker fallback) against
+// the on-disk store. Embedders that don't honour env vars and want
+// pure on-disk behaviour can call LoadConnections directly.
+func ResolveEntryConnection() EntryConnection { return config.ResolveEntryConnection() }
 
 // Connect builds a gateway client for the given URL, hooks it up to the
 // supplied IdentityStore, and performs the connect handshake. The returned

--- a/app/external.go
+++ b/app/external.go
@@ -65,9 +65,27 @@ const (
 	ConnTypeOpenAI   = config.ConnTypeOpenAI
 )
 
-// LoadConnections reads the connection store from
-// ~/.lucinate/connections.json, returning an empty store on first run
-// or when the file is missing or unreadable.
+// DataDirEnvVar is the environment variable that overrides the
+// default lucinate state directory (where connections, secrets,
+// identity, and agents live). Embedders whose host platform doesn't
+// expose a writable user home directory — typically native-platform
+// hosts whose process inherits a read-only bundle path from
+// os.UserHomeDir() — set this before invoking app.New / app.Run;
+// pointing at a writable sandboxed location keeps every persistence
+// path inside the host's data container.
+const DataDirEnvVar = config.DataDirEnvVar
+
+// DataDir returns the resolved root directory used for all on-disk
+// lucinate state. Resolution: LUCINATE_DATA_DIR if set, else
+// <UserHomeDir>/.lucinate. Embedders typically don't need to call
+// this — every persistence helper goes through it transparently —
+// but it is exposed so embedders can surface the location to the
+// user (e.g. "your data lives at …").
+func DataDir() (string, error) { return config.DataDir() }
+
+// LoadConnections reads the connection store from the lucinate
+// data dir's connections.json, returning an empty store on first
+// run or when the file is missing or unreadable.
 func LoadConnections() Connections { return config.LoadConnections() }
 
 // SaveConnections writes the connection store to disk atomically. The

--- a/app/factory.go
+++ b/app/factory.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	openaiBackend "github.com/lucinate-ai/lucinate/internal/backend/openai"
+	openclawBackend "github.com/lucinate-ai/lucinate/internal/backend/openclaw"
+	"github.com/lucinate-ai/lucinate/internal/client"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// secretAwareOpenAIBackend layers persistence onto the OpenAI backend's
+// auth-modal StoreAPIKey so the next launch reuses the key without re-
+// prompting. The concrete *openai.Backend's StoreAPIKey only updates
+// the in-memory copy.
+type secretAwareOpenAIBackend struct {
+	*openaiBackend.Backend
+	connID string
+}
+
+// StoreAPIKey persists the key under the connection ID in the secrets
+// store and updates the backend's in-memory copy.
+func (s *secretAwareOpenAIBackend) StoreAPIKey(key string) error {
+	if err := config.SetAPIKey(s.connID, key); err != nil {
+		return fmt.Errorf("persist api key: %w", err)
+	}
+	return s.Backend.StoreAPIKey(key)
+}
+
+// DefaultBackendFactory builds an unconnected backend for a stored
+// connection by dispatching on Connection.Type. Auth resolution mirrors
+// the CLI: API keys are read from the per-connection secrets store and
+// fall back to LUCINATE_OPENAI_API_KEY when the store is empty. The TUI
+// calls Connect on the returned backend itself so it can route auth
+// errors into the modal recovery flows.
+//
+// Embedders pass this directly via RunOptions.BackendFactory unless
+// they need to register additional ConnectionTypes or substitute a
+// different secrets store, in which case they wrap or replace it.
+func DefaultBackendFactory(conn *Connection) (Backend, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("connection is nil")
+	}
+	// User-configured WebSocket / HTTP handshake deadline applied to
+	// every (re)dial so slow backends don't trip the SDK's default.
+	prefs := config.LoadPreferences()
+	connectTimeout := time.Duration(prefs.ConnectTimeoutSeconds) * time.Second
+	switch conn.Type {
+	case ConnTypeOpenClaw:
+		cfg, err := config.FromConnection(conn)
+		if err != nil {
+			return nil, err
+		}
+		c, err := client.New(cfg)
+		if err != nil {
+			return nil, err
+		}
+		c.SetConnectTimeout(connectTimeout)
+		return openclawBackend.New(c), nil
+	case ConnTypeOpenAI:
+		apiKey := config.GetAPIKey(conn.ID)
+		if env := os.Getenv("LUCINATE_OPENAI_API_KEY"); env != "" && apiKey == "" {
+			apiKey = env
+		}
+		b, err := openaiBackend.New(openaiBackend.Options{
+			ConnectionID:   conn.ID,
+			BaseURL:        conn.URL,
+			APIKey:         apiKey,
+			DefaultModel:   conn.DefaultModel,
+			ConnectTimeout: connectTimeout,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &secretAwareOpenAIBackend{Backend: b, connID: conn.ID}, nil
+	default:
+		return nil, fmt.Errorf("unsupported connection type: %q", conn.Type)
+	}
+}

--- a/app/factory_test.go
+++ b/app/factory_test.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"context"
@@ -11,14 +11,14 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
-// TestSecretAwareBackend_StoreAPIKeyPersistsToDisk verifies the
-// disk-write side effect of the wrapper used in main.go: when the
-// auth-modal resolution stores a key, it lands in the secrets file so
-// the next launch picks it up via config.GetAPIKey without
-// re-prompting. The connecting-view tests cover the TUI plumbing
-// against an in-memory fake; this test covers the production wrapper
-// end-to-end against a real OpenAI backend.
-func TestSecretAwareBackend_StoreAPIKeyPersistsToDisk(t *testing.T) {
+// TestSecretAwareOpenAIBackend_StoreAPIKeyPersistsToDisk verifies the
+// disk-write side effect of the wrapper DefaultBackendFactory uses:
+// when the auth-modal resolution stores a key, it lands in the
+// secrets file so the next launch picks it up via config.GetAPIKey
+// without re-prompting. The connecting-view tests cover the TUI
+// plumbing against an in-memory fake; this test covers the
+// production wrapper end-to-end against a real OpenAI backend.
+func TestSecretAwareOpenAIBackend_StoreAPIKeyPersistsToDisk(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +35,7 @@ func TestSecretAwareBackend_StoreAPIKeyPersistsToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openai.New: %v", err)
 	}
-	wrapper := &secretAwareBackend{Backend: inner, connID: connID}
+	wrapper := &secretAwareOpenAIBackend{Backend: inner, connID: connID}
 
 	if got := config.GetAPIKey(connID); got != "" {
 		t.Fatalf("precondition: expected no stored key, got %q", got)
@@ -65,11 +65,12 @@ func TestSecretAwareBackend_StoreAPIKeyPersistsToDisk(t *testing.T) {
 	}
 }
 
-// TestSecretAwareBackend_StoreAPIKeyClear verifies the empty-key path
-// removes the entry from disk so users can fully unset a stored key
-// (e.g. by submitting an empty value at the modal — currently the TUI
-// does not expose this but the contract is worth pinning).
-func TestSecretAwareBackend_StoreAPIKeyClear(t *testing.T) {
+// TestSecretAwareOpenAIBackend_StoreAPIKeyClear verifies the empty-
+// key path removes the entry from disk so users can fully unset a
+// stored key (e.g. by submitting an empty value at the modal —
+// currently the TUI does not expose this but the contract is worth
+// pinning).
+func TestSecretAwareOpenAIBackend_StoreAPIKeyClear(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +88,7 @@ func TestSecretAwareBackend_StoreAPIKeyClear(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openai.New: %v", err)
 	}
-	wrapper := &secretAwareBackend{Backend: inner, connID: connID}
+	wrapper := &secretAwareOpenAIBackend{Backend: inner, connID: connID}
 
 	if err := wrapper.StoreAPIKey("on-disk"); err != nil {
 		t.Fatalf("StoreAPIKey: %v", err)

--- a/internal/backend/openai/agents.go
+++ b/internal/backend/openai/agents.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
 // AgentMeta is the shape persisted to agent.json. Identity / soul /
@@ -56,17 +58,18 @@ type AgentStore struct {
 	root string
 }
 
-// NewAgentStore returns a Store rooted under ~/.lucinate/agents/<connID>/.
-// The directory is created lazily on first write.
+// NewAgentStore returns a Store rooted under
+// <data-dir>/agents/<connID>/. The directory is created lazily on
+// first write.
 func NewAgentStore(connID string) (*AgentStore, error) {
 	if connID == "" {
 		return nil, fmt.Errorf("connection id is required")
 	}
-	home, err := os.UserHomeDir()
+	dataDir, err := config.DataDir()
 	if err != nil {
-		return nil, fmt.Errorf("user home dir: %w", err)
+		return nil, fmt.Errorf("data dir: %w", err)
 	}
-	root := filepath.Join(home, ".lucinate", "agents", connID)
+	root := filepath.Join(dataDir, "agents", connID)
 	return &AgentStore{root: root}, nil
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -91,13 +90,14 @@ func NewWithIdentityStore(cfg *config.Config, store IdentityStore) *Client {
 	}
 }
 
-// identityDirForEndpoint returns a per-endpoint identity directory under
-// ~/.lucinate/identity/<host_port>/.  This keeps keys and device tokens
-// isolated per gateway so switching endpoints doesn't overwrite them.
+// identityDirForEndpoint returns a per-endpoint identity directory
+// under <data-dir>/identity/<host_port>/. This keeps keys and device
+// tokens isolated per gateway so switching endpoints doesn't
+// overwrite them.
 func identityDirForEndpoint(gatewayURL string) (string, error) {
-	home, err := os.UserHomeDir()
+	root, err := config.DataDir()
 	if err != nil {
-		return "", fmt.Errorf("user home dir: %w", err)
+		return "", fmt.Errorf("data dir: %w", err)
 	}
 
 	u, err := url.Parse(gatewayURL)
@@ -110,7 +110,7 @@ func identityDirForEndpoint(gatewayURL string) (string, error) {
 		return "", fmt.Errorf("gateway URL has no host: %s", gatewayURL)
 	}
 
-	return filepath.Join(home, ".lucinate", "identity", key), nil
+	return filepath.Join(root, "identity", key), nil
 }
 
 // sanitiseHost converts a host or host:port into a filesystem-safe directory

--- a/internal/config/connections.go
+++ b/internal/config/connections.go
@@ -65,13 +65,13 @@ type Connections struct {
 
 // ConnectionsPath returns the path to the connections file, creating
 // the parent directory if necessary. The file lives alongside
-// preferences under ~/.lucinate/.
+// preferences under the lucinate data dir (LUCINATE_DATA_DIR or
+// ~/.lucinate).
 func ConnectionsPath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := DataDir()
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, ".lucinate")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}

--- a/internal/config/datadir.go
+++ b/internal/config/datadir.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DataDirEnvVar is the environment variable that overrides the
+// default lucinate state directory. Embedders whose host platform
+// doesn't expose a writable user home directory — typically
+// native-platform hosts whose process inherits a read-only bundle
+// path from os.UserHomeDir() — set this to a writable sandboxed
+// location before the program starts. The CLI leaves it unset and
+// falls back to the platform's home directory.
+const DataDirEnvVar = "LUCINATE_DATA_DIR"
+
+// DataDir returns the root directory for all on-disk lucinate state
+// (connections, secrets, identity, agents, preferences, skill cache).
+// Resolution order:
+//
+//  1. The LUCINATE_DATA_DIR environment variable, if set and non-empty.
+//  2. <user-home>/.lucinate.
+//
+// The returned path is not created here — each caller is responsible
+// for provisioning the subdirectory layout it needs (with whatever
+// permission mode the data warrants).
+func DataDir() (string, error) {
+	if override := os.Getenv(DataDirEnvVar); override != "" {
+		return override, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".lucinate"), nil
+}

--- a/internal/config/preferences.go
+++ b/internal/config/preferences.go
@@ -35,11 +35,10 @@ func DefaultPreferences() Preferences {
 // PreferencesPath returns the path to the preferences file,
 // creating the parent directory if necessary.
 func PreferencesPath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := DataDir()
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, ".lucinate")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -25,11 +25,11 @@ type Secrets struct {
 // SecretsPath returns the on-disk location, creating the parent
 // directory if needed.
 func SecretsPath() (string, error) {
-	home, err := os.UserHomeDir()
+	root, err := DataDir()
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, ".lucinate", "secrets")
+	dir := filepath.Join(root, "secrets")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -79,8 +79,8 @@ type AppOptions struct {
 	// form, or entry into a new view that lands focus on a different
 	// field). The string is the new field's current value at the
 	// moment of transition, so embedders driving an external input
-	// surface (e.g. a SwiftUI TextField on iOS) can hydrate it to
-	// match. See app.RunOptions for the full rationale.
+	// surface (a native-platform host's text field, say) can hydrate
+	// it to match. See app.RunOptions for the full rationale.
 	OnFocusedFieldChanged func(value string)
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -73,6 +73,15 @@ type AppOptions struct {
 	// view's set of exposed Actions changes. See app.RunOptions for
 	// the full rationale; this is the unexported plumbing.
 	OnActionsChanged func(actions []Action)
+
+	// OnFocusedFieldChanged, if non-nil, is invoked whenever the
+	// active view's focused text-input changes (Tab/Shift-Tab inside a
+	// form, or entry into a new view that lands focus on a different
+	// field). The string is the new field's current value at the
+	// moment of transition, so embedders driving an external input
+	// surface (e.g. a SwiftUI TextField on iOS) can hydrate it to
+	// match. See app.RunOptions for the full rationale.
+	OnFocusedFieldChanged func(value string)
 }
 
 // AppModel is the root bubbletea model.
@@ -106,6 +115,10 @@ type AppModel struct {
 	onActionsChanged func([]Action)
 	lastActions      []Action
 	actionsReported  bool
+
+	onFocusedFieldChanged func(string)
+	lastFocusedFieldKey   string
+	focusedFieldReported  bool
 }
 
 // NewApp creates the root application model.
@@ -130,6 +143,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		managed:              managed,
 		onInputFocusChanged:  opts.OnInputFocusChanged,
 		onActionsChanged:     opts.OnActionsChanged,
+		onFocusedFieldChanged: opts.OnFocusedFieldChanged,
 	}
 
 	switch {
@@ -183,7 +197,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	nextModel, cmd := next.maybeNotifyInputFocus(cmd)
 	next = nextModel.(AppModel)
-	return next.maybeNotifyActions(cmd)
+	nextModel, cmd = next.maybeNotifyActions(cmd)
+	next = nextModel.(AppModel)
+	return next.maybeNotifyFocusedField(cmd)
 }
 
 // Actions returns the discoverable, view-level commands the active
@@ -309,6 +325,51 @@ func (m AppModel) maybeNotifyInputFocus(cmd tea.Cmd) (tea.Model, tea.Cmd) {
 	cb := m.onInputFocusChanged
 	notify := func() tea.Msg {
 		cb(wants)
+		return nil
+	}
+	if cmd == nil {
+		return m, notify
+	}
+	return m, tea.Batch(cmd, notify)
+}
+
+// computeFocusedField returns a pair (identityKey, currentValue) for
+// the active view's focused text input. The identityKey changes only
+// when the FIELD changes (not when its value mutates from a user
+// keystroke), so dedup against it fires the callback on transitions
+// without spamming on every typed character. The currentValue is read
+// at notification time so embedders see the field's pre-fill in Edit
+// mode and the empty initial state on Add.
+func (m AppModel) computeFocusedField() (key, value string) {
+	switch m.state {
+	case viewConnections:
+		return m.connectionsModel.focusedFieldIdentity()
+	}
+	// Other views (chat, agent picker, sessions, config, connecting)
+	// either have no field-level focus or only ever expose one input;
+	// embedders that need single-input hydration can still observe
+	// OnInputFocusChanged for view-level transitions.
+	return "", ""
+}
+
+// maybeNotifyFocusedField invokes OnFocusedFieldChanged when the
+// focused-field identity changes. Mirrors maybeNotifyInputFocus /
+// maybeNotifyActions: the first post-Init call always fires so the
+// embedder sees the starting state, and the callback runs from a
+// tea.Cmd to keep the event loop responsive.
+func (m AppModel) maybeNotifyFocusedField(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if m.onFocusedFieldChanged == nil {
+		return m, cmd
+	}
+	key, value := m.computeFocusedField()
+	if m.focusedFieldReported && key == m.lastFocusedFieldKey {
+		return m, cmd
+	}
+	m.lastFocusedFieldKey = key
+	m.focusedFieldReported = true
+	cb := m.onFocusedFieldChanged
+	notify := func() tea.Msg {
+		cb(value)
 		return nil
 	}
 	if cmd == nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -173,12 +173,13 @@ func TestAppModel_TabAdvancesFocusInConnectionsForm(t *testing.T) {
 	if m.connectionsModel.subState != subStateConnForm {
 		t.Fatalf("expected form sub-state, got %v", m.connectionsModel.subState)
 	}
-	if got := m.connectionsModel.currentField(); got != formFieldType {
-		t.Fatalf("expected initial focus on type radio, got %v", got)
+	if got := m.connectionsModel.currentField(); got != formFieldName {
+		t.Fatalf("expected initial focus on name input, got %v", got)
 	}
 
-	// One Tab advances to name, two to URL — through AppModel.Update.
-	for _, want := range []formField{formFieldName, formFieldURL} {
+	// One Tab advances to URL, two to the type radio — through
+	// AppModel.Update.
+	for _, want := range []formField{formFieldURL, formFieldType} {
 		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 		m = updated.(AppModel)
 		if got := m.connectionsModel.currentField(); got != want {

--- a/internal/tui/connections.go
+++ b/internal/tui/connections.go
@@ -305,7 +305,6 @@ func (m *connectionsModel) enterFormForNew() {
 	m.editingID = ""
 	m.formErr = ""
 	m.formPreset = presetOpenClaw
-	m.focusedField = 0
 
 	m.nameInput = textinput.New()
 	m.nameInput.Placeholder = "home pi"
@@ -319,6 +318,14 @@ func (m *connectionsModel) enterFormForNew() {
 	m.modelInput.CharLimit = 128
 
 	m.applyPresetDefaults(presetOpenClaw)
+
+	// Start focus on Name. The type radio sits at index 0 of
+	// formFields() in Add mode, but landing focus there silently
+	// swallows typed characters (updateForm has no case for
+	// formFieldType — left/right cycle the radio in handleFormKey,
+	// while Bubbles textinputs aren't reached). Users who want to
+	// switch protocol can shift-tab back to the radio.
+	m.focusedField = m.indexOfField(formFieldName)
 }
 
 func (m *connectionsModel) enterFormForEdit(conn config.Connection) {
@@ -402,6 +409,48 @@ func (m connectionsModel) currentField() formField {
 		return formFieldName
 	}
 	return fields[m.focusedField]
+}
+
+// indexOfField returns the focus-order position of the given field
+// in the current form layout, or 0 if the field is not present.
+// formFields() varies by mode (Add includes the type radio; Edit
+// drops it) and by preset (model is OpenAI-only), so callers that
+// want to land focus on a named field compute its index this way.
+func (m connectionsModel) indexOfField(target formField) int {
+	for i, f := range m.formFields() {
+		if f == target {
+			return i
+		}
+	}
+	return 0
+}
+
+// focusedFieldIdentity returns a (key, value) pair identifying the
+// active form input. The key changes only when the focused field
+// itself changes (e.g. Tab from name → url), not when its value
+// mutates from typing — host hydration of an external input surface
+// should track field transitions, not keystrokes. The value is the
+// field's current contents at the moment of the call. When the form
+// isn't open or the focused position is on the type radio (which has
+// no string value), key and value are empty so the host clears its
+// surface.
+func (m connectionsModel) focusedFieldIdentity() (string, string) {
+	if m.subState != subStateConnForm {
+		return "", ""
+	}
+	scope := "connections.add"
+	if m.editingID != "" {
+		scope = "connections.edit." + m.editingID
+	}
+	switch m.currentField() {
+	case formFieldName:
+		return scope + ".name", m.nameInput.Value()
+	case formFieldURL:
+		return scope + ".url", m.urlInput.Value()
+	case formFieldModel:
+		return scope + ".model", m.modelInput.Value()
+	}
+	return "", ""
 }
 
 func (m connectionsModel) handleFormKey(msg tea.KeyPressMsg) (connectionsModel, tea.Cmd) {

--- a/internal/tui/connections_test.go
+++ b/internal/tui/connections_test.go
@@ -21,6 +21,18 @@ func newSeededStore(t *testing.T) *config.Connections {
 	return store
 }
 
+// focusTypeRadio walks the form's focus order until the type radio
+// is selected. The new-connection form lands focus on Name so plain
+// typing produces visible input; tests that exercise preset cycling
+// (Left/Right is the radio's own affordance, gated on the radio
+// being the active field) shift-tab back to it explicitly.
+func focusTypeRadio(m connectionsModel) connectionsModel {
+	for m.currentField() != formFieldType {
+		m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	}
+	return m
+}
+
 func TestConnectionsModel_RendersEmptyState(t *testing.T) {
 	m := newConnectionsModel(&config.Connections{}, false)
 	out := m.View()
@@ -171,6 +183,7 @@ func TestConnectionsModel_TypeCycleUpdatesPreset(t *testing.T) {
 	store := &config.Connections{}
 	m := newConnectionsModel(store, false)
 	m, _ = m.TriggerAction("new-connection")
+	m = focusTypeRadio(m)
 
 	if m.formPreset != presetOpenClaw {
 		t.Fatalf("expected initial preset OpenClaw, got %v", m.formPreset)
@@ -213,6 +226,7 @@ func TestConnectionsModel_OllamaPresetPersistsAsOpenAI(t *testing.T) {
 	store := &config.Connections{}
 	m := newConnectionsModel(store, false)
 	m, _ = m.TriggerAction("new-connection")
+	m = focusTypeRadio(m)
 
 	// OpenClaw → OpenAI → Ollama.
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -248,6 +262,7 @@ func TestConnectionsModel_OpenAITabOrderIncludesModel(t *testing.T) {
 	store := &config.Connections{}
 	m := newConnectionsModel(store, false)
 	m, _ = m.TriggerAction("new-connection")
+	m = focusTypeRadio(m)
 
 	// Switch to OpenAI so the model field joins the tab order.
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -288,6 +303,7 @@ func TestConnectionsModel_NewOpenAIConnectionPersistsModel(t *testing.T) {
 	store := &config.Connections{}
 	m := newConnectionsModel(store, false)
 	m, _ = m.TriggerAction("new-connection")
+	m = focusTypeRadio(m)
 
 	// Switch type to OpenAI.
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -327,6 +343,7 @@ func TestConnectionsModel_NewFormRendersOnlyRelevantFields(t *testing.T) {
 	}
 
 	// Switch to OpenAI: model field appears, URL relabels.
+	m = focusTypeRadio(m)
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyRight})
 	out = m.viewForm()
 	if !strings.Contains(out, "Default model") {
@@ -345,24 +362,28 @@ func TestConnectionsModel_TabAdvancesFocus(t *testing.T) {
 	m := newConnectionsModel(store, false)
 	m, _ = m.TriggerAction("new-connection")
 
-	// New form starts focused on the type radio (index 0).
-	if m.focusedField != 0 || m.currentField() != formFieldType {
-		t.Fatalf("expected initial focus on type, got field=%v idx=%d", m.currentField(), m.focusedField)
+	// New form lands focus on Name so the host's first keystroke
+	// produces visible input. The type radio is at index 0 of
+	// formFields() but accepting plain characters there is a no-op
+	// (updateForm has no case for formFieldType, and left/right are
+	// the radio's own affordance), so initial focus skips past it.
+	if m.currentField() != formFieldName {
+		t.Fatalf("expected initial focus on name, got field=%v idx=%d", m.currentField(), m.focusedField)
 	}
 
-	// Tab advances through type → name → url; for OpenClaw there is
-	// no model field so the next Tab wraps back to type.
+	// Tab advances through name → url → type and wraps; for
+	// OpenClaw there is no model field.
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.currentField() != formFieldName {
+	if m.currentField() != formFieldURL {
 		t.Errorf("after first tab: %v", m.currentField())
 	}
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.currentField() != formFieldURL {
+	if m.currentField() != formFieldType {
 		t.Errorf("after second tab: %v", m.currentField())
 	}
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.currentField() != formFieldType {
-		t.Errorf("expected wrap back to type, got %v", m.currentField())
+	if m.currentField() != formFieldName {
+		t.Errorf("expected wrap back to name, got %v", m.currentField())
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,80 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/lucinate-ai/lucinate/app"
-	"github.com/lucinate-ai/lucinate/internal/backend"
-	openaiBackend "github.com/lucinate-ai/lucinate/internal/backend/openai"
-	openclawBackend "github.com/lucinate-ai/lucinate/internal/backend/openclaw"
-	"github.com/lucinate-ai/lucinate/internal/client"
-	"github.com/lucinate-ai/lucinate/internal/config"
 	"github.com/lucinate-ai/lucinate/internal/version"
 )
-
-// secretAwareBackend wraps an OpenAI backend and persists the API
-// key to disk whenever the auth-modal resolution stores one. The
-// concrete *openai.Backend's StoreAPIKey only updates the in-memory
-// copy; this wrapper layers the disk write on top so the next launch
-// reuses the key without re-prompting.
-type secretAwareBackend struct {
-	*openaiBackend.Backend
-	connID string
-}
-
-// StoreAPIKey persists the key for the connection and updates the
-// backend's in-memory copy.
-func (s *secretAwareBackend) StoreAPIKey(key string) error {
-	if err := config.SetAPIKey(s.connID, key); err != nil {
-		return fmt.Errorf("persist api key: %w", err)
-	}
-	return s.Backend.StoreAPIKey(key)
-}
-
-// backendFactory builds an unconnected backend for a stored
-// connection. Dispatches on Connection.Type so future backend types
-// can plug in here. The TUI calls Connect itself so it can route
-// auth errors into modal recovery flows.
-func backendFactory(conn *config.Connection) (backend.Backend, error) {
-	if conn == nil {
-		return nil, fmt.Errorf("connection is nil")
-	}
-	switch conn.Type {
-	case config.ConnTypeOpenClaw:
-		cfg, err := config.FromConnection(conn)
-		if err != nil {
-			return nil, err
-		}
-		c, err := client.New(cfg)
-		if err != nil {
-			return nil, err
-		}
-		// Apply the user-configured WebSocket handshake deadline to
-		// every (re)dial so slow backends don't trip the SDK's default.
-		prefs := config.LoadPreferences()
-		c.SetConnectTimeout(time.Duration(prefs.ConnectTimeoutSeconds) * time.Second)
-		return openclawBackend.New(c), nil
-	case config.ConnTypeOpenAI:
-		apiKey := config.GetAPIKey(conn.ID)
-		if env := os.Getenv("LUCINATE_OPENAI_API_KEY"); env != "" && apiKey == "" {
-			apiKey = env
-		}
-		prefs := config.LoadPreferences()
-		b, err := openaiBackend.New(openaiBackend.Options{
-			ConnectionID:   conn.ID,
-			BaseURL:        conn.URL,
-			APIKey:         apiKey,
-			DefaultModel:   conn.DefaultModel,
-			ConnectTimeout: time.Duration(prefs.ConnectTimeoutSeconds) * time.Second,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return &secretAwareBackend{Backend: b, connID: conn.ID}, nil
-	default:
-		return nil, fmt.Errorf("unsupported connection type: %q", conn.Type)
-	}
-}
 
 func main() {
 	fs := flag.NewFlagSet("lucinate", flag.ExitOnError)
@@ -91,14 +21,14 @@ func main() {
 		return
 	}
 
-	entry := config.ResolveEntryConnection()
+	entry := app.ResolveEntryConnection()
 
 	if err := app.Run(context.Background(), app.RunOptions{
 		Store:          &entry.Store,
 		Initial:        entry.Connection,
-		BackendFactory: backendFactory,
-		OnConnectionsChanged: func(c config.Connections) {
-			if err := config.SaveConnections(c); err != nil {
+		BackendFactory: app.DefaultBackendFactory,
+		OnConnectionsChanged: func(c app.Connections) {
+			if err := app.SaveConnections(c); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to save connections: %v\n", err)
 			}
 		},


### PR DESCRIPTION
Expose the connections store and default backend factory so non-CLI hosts can drive lucinate in managed mode without reimplementing the OpenClaw / OpenAI dispatch.

## Summary

- Add public type aliases (`Backend`, `Connection`, `Connections`, `ConnectionType`, `ConnectionFields`, `EntryConnection`) and helpers (`LoadConnections`, `SaveConnections`, `ResolveEntryConnection`) to `app/external.go` so embedders no longer need to import `internal/...` paths.
- Move the OpenClaw/OpenAI factory out of `main.go` into `app/factory.go` as `DefaultBackendFactory`, including the secret-aware OpenAI wrapper that persists API keys after auth-modal entry. The factory now also applies the user's configured connect-timeout preference, so the CLI behaviour doesn't regress through the collapse.
- Land focus on the Name input when opening the new-connection form. The previous `focusedField=0` resolved to the type radio in Add mode, where typed characters fell through `updateForm` and were silently dropped.
- Add an `OnFocusedFieldChanged(value string)` callback so embedders driving an external input surface can hydrate it on form Tab/Shift-Tab and view-entry transitions. Dedup'd by field identity, not value, so it fires on transitions only — never on keystrokes.
- Collapse `main.go` onto the new public surface and relocate the secret-aware-backend tests into the `app` package alongside the wrapper.

## Implementation details

The focused-field callback uses an identity key (`connections.add.name`, `connections.edit.<id>.url`, …) for change detection rather than the field's value. Reading the value at notification time means embedders see the pre-fill on Edit-mode entry and the empty state on Add, but a typing burst doesn't trigger N callbacks. Other views (chat, picker) return an empty identity, so embedders that subscribe will see their external input surface clear correctly when the TUI moves out of a form.