### PR TITLE
feat(app): add SetDataDir programmatic seam for embedder data root

### DIFF
--- a/app/external.go
+++ b/app/external.go
@@ -67,20 +67,31 @@ const (
 
 // DataDirEnvVar is the environment variable that overrides the
 // default lucinate state directory (where connections, secrets,
-// identity, and agents live). Embedders whose host platform doesn't
-// expose a writable user home directory — typically native-platform
-// hosts whose process inherits a read-only bundle path from
-// os.UserHomeDir() — set this before invoking app.New / app.Run;
-// pointing at a writable sandboxed location keeps every persistence
-// path inside the host's data container.
+// identity, and agents live). Useful for shell-driven CLI invocations
+// and integration tests; embedders that drive the program from
+// in-process Go code should prefer SetDataDir.
 const DataDirEnvVar = config.DataDirEnvVar
 
+// SetDataDir programmatically overrides the default state directory.
+// Embedders whose host platform exposes a sandboxed, platform-
+// conventional state directory through host APIs (rather than a
+// writable user home directory) call this once at startup with a
+// fully-resolved absolute path. Every persistence helper
+// (connections, secrets, identity, agents, preferences) then writes
+// inside it. The lucinate code does not impose a dotfile prefix on
+// top of the supplied path — the embedder picks the user-visible
+// directory name. SetDataDir must run before any other app.* helper
+// that touches disk (LoadConnections, ResolveEntryConnection,
+// Connect, Run). The CLI does not call SetDataDir; it falls back to
+// LUCINATE_DATA_DIR and then to <UserHomeDir>/.lucinate.
+func SetDataDir(dir string) { config.SetDataDir(dir) }
+
 // DataDir returns the resolved root directory used for all on-disk
-// lucinate state. Resolution: LUCINATE_DATA_DIR if set, else
-// <UserHomeDir>/.lucinate. Embedders typically don't need to call
-// this — every persistence helper goes through it transparently —
-// but it is exposed so embedders can surface the location to the
-// user (e.g. "your data lives at …").
+// lucinate state. Resolution: SetDataDir if non-empty, else
+// LUCINATE_DATA_DIR, else <UserHomeDir>/.lucinate. Embedders
+// typically don't need to call this — every persistence helper goes
+// through it transparently — but it is exposed so embedders can
+// surface the location to the user (e.g. "your data lives at …").
 func DataDir() (string, error) { return config.DataDir() }
 
 // LoadConnections reads the connection store from the lucinate

--- a/internal/config/datadir.go
+++ b/internal/config/datadir.go
@@ -3,30 +3,64 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // DataDirEnvVar is the environment variable that overrides the
-// default lucinate state directory. Embedders whose host platform
-// doesn't expose a writable user home directory — typically
-// native-platform hosts whose process inherits a read-only bundle
-// path from os.UserHomeDir() — set this to a writable sandboxed
-// location before the program starts. The CLI leaves it unset and
-// falls back to the platform's home directory.
+// default lucinate state directory. Set by callers that can't reach
+// SetDataDir before the first DataDir() call (typically shell-driven
+// CLI invocations and integration tests). Embedders that drive the
+// program from in-process Go code should prefer SetDataDir.
 const DataDirEnvVar = "LUCINATE_DATA_DIR"
+
+var (
+	dataDirMu       sync.RWMutex
+	dataDirOverride string
+)
+
+// SetDataDir programmatically overrides the default state directory.
+// Once set with a non-empty path, subsequent DataDir() calls return
+// it verbatim — every persistence helper (preferences, connections,
+// secrets, identity, agents) writes inside it, so the embedder's
+// chosen path becomes the entire on-disk root.
+//
+// Embedders whose host platform exposes a sandboxed, platform-
+// conventional state directory through host APIs (rather than a
+// writable home directory) call this once at startup, before any
+// other persistence helper runs. The expected shape is a fully-
+// resolved absolute path with no dotfile prefix — the lucinate code
+// does not add ".lucinate" or any other leading-dot component on top.
+//
+// Passing an empty string clears the override and restores fallback
+// resolution. Safe to call from any goroutine; in practice the
+// override is set once during startup.
+func SetDataDir(dir string) {
+	dataDirMu.Lock()
+	defer dataDirMu.Unlock()
+	dataDirOverride = dir
+}
 
 // DataDir returns the root directory for all on-disk lucinate state
 // (connections, secrets, identity, agents, preferences, skill cache).
 // Resolution order:
 //
-//  1. The LUCINATE_DATA_DIR environment variable, if set and non-empty.
-//  2. <user-home>/.lucinate.
+//  1. The most recent SetDataDir call, if non-empty.
+//  2. The LUCINATE_DATA_DIR environment variable, if set and non-empty.
+//  3. <user-home>/.lucinate (CLI fallback on platforms with a writable
+//     user home directory).
 //
 // The returned path is not created here — each caller is responsible
 // for provisioning the subdirectory layout it needs (with whatever
 // permission mode the data warrants).
 func DataDir() (string, error) {
-	if override := os.Getenv(DataDirEnvVar); override != "" {
+	dataDirMu.RLock()
+	override := dataDirOverride
+	dataDirMu.RUnlock()
+	if override != "" {
 		return override, nil
+	}
+	if env := os.Getenv(DataDirEnvVar); env != "" {
+		return env, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/config/datadir_test.go
+++ b/internal/config/datadir_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDir_HomeFallback(t *testing.T) {
+	t.Setenv(DataDirEnvVar, "")
+	SetDataDir("")
+	t.Cleanup(func() { SetDataDir("") })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if want := filepath.Join(home, ".lucinate"); got != want {
+		t.Errorf("DataDir = %q, want %q", got, want)
+	}
+}
+
+func TestDataDir_EnvVarOverridesHome(t *testing.T) {
+	SetDataDir("")
+	t.Cleanup(func() { SetDataDir("") })
+
+	t.Setenv("HOME", t.TempDir())
+	envDir := t.TempDir()
+	t.Setenv(DataDirEnvVar, envDir)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if got != envDir {
+		t.Errorf("DataDir = %q, want %q", got, envDir)
+	}
+}
+
+func TestDataDir_SetDataDirOverridesEnv(t *testing.T) {
+	t.Cleanup(func() { SetDataDir("") })
+
+	envDir := t.TempDir()
+	t.Setenv(DataDirEnvVar, envDir)
+
+	progDir := t.TempDir()
+	SetDataDir(progDir)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if got != progDir {
+		t.Errorf("DataDir = %q, want %q (env was %q)", got, progDir, envDir)
+	}
+}
+
+func TestDataDir_SetDataDirEmptyClearsOverride(t *testing.T) {
+	t.Cleanup(func() { SetDataDir("") })
+
+	envDir := t.TempDir()
+	t.Setenv(DataDirEnvVar, envDir)
+
+	SetDataDir(t.TempDir())
+	SetDataDir("")
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if got != envDir {
+		t.Errorf("DataDir = %q, want env fallback %q", got, envDir)
+	}
+}
+
+func TestDataDir_NoDotfilePrefixOnOverride(t *testing.T) {
+	t.Cleanup(func() { SetDataDir("") })
+
+	// Mirrors the embedder use case: a sandbox-conventional path with
+	// no leading-dot component. DataDir must return it verbatim so
+	// downstream subdirectories (identity/, secrets/, agents/) sit
+	// directly under the embedder-chosen root.
+	override := filepath.Join(t.TempDir(), "Application Support", "Lucinate")
+	SetDataDir(override)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if got != override {
+		t.Errorf("DataDir = %q, want %q (no dotfile prefix should be added)", got, override)
+	}
+}


### PR DESCRIPTION
Add a programmatic seam so embedders can specify the on-disk state root without going through an environment variable, and let them pick a non-dotfile, platform-conventional path.

## Summary
- New `config.SetDataDir(dir)` (re-exported as `app.SetDataDir`) overrides the resolved data root for every persistence helper (preferences, connections, secrets, identity, agents).
- Resolution order is now `SetDataDir` → `LUCINATE_DATA_DIR` → `<UserHomeDir>/.lucinate`; CLI behaviour is unchanged.
- The embedder-supplied path is used verbatim — no `.lucinate` prefix is prepended — so a native-platform host can pass a sandbox-conventional location (e.g. `Library/Application Support/Lucinate`) and it lands there directly.
- Doc on `app.SetDataDir` spells out the no-dotfile contract and the "call before any persistence helper" requirement.
- Tests cover the home fallback, env-var override, programmatic override beating env, clearing the override, and the no-dotfile guarantee.

## Implementation details
The previous embedder seam was the `LUCINATE_DATA_DIR` env var, which is awkward to set from in-process Go code on hosts whose configuration arrives via host APIs rather than the shell. The programmatic setter is mutex-guarded so it stays safe to call from any goroutine, though the expected pattern is a single startup call before `LoadConnections` / `ResolveEntryConnection` / `Connect` / `Run`.