### PR TITLE
feat: delete agents from picker with type-to-confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 
 - **Multiple backends** — connect to an [OpenClaw](https://github.com/openclaw/openclaw) gateway, a [Hermes Agent](https://github.com/nousresearch/hermes-agent) profile, or any OpenAI-compatible endpoint ([Ollama](https://ollama.com), vLLM, LM Studio, llamafile, OpenAI proper). Switch between saved connections with `/connections`.
 - **Streaming responses, conversation history, and multi-agent support**
-- **Create agents** directly from the TUI — gateway-managed for OpenClaw, or local `IDENTITY.md` + `SOUL.md` markdown for OpenAI-compatible backends. Hermes profiles are configured server-side via `hermes profile create`
+- **Create and delete agents** directly from the TUI — gateway-managed for OpenClaw, or local `IDENTITY.md` + `SOUL.md` markdown for OpenAI-compatible backends. Delete is type-the-name to confirm, with an optional "keep files" toggle so you can drop the listing without nuking the content. Hermes profiles are configured server-side via `hermes profile create`
 - **Markdown rendering** for assistant messages
 - **Shell commands** — run locally with `!` or remotely on the gateway with `!!`
 - **Message queueing** so you can keep typing while the agent is responding
@@ -96,6 +96,7 @@ Select an agent from the list to start chatting.
 |-----|--------|
 | `Enter` | Select agent |
 | `n` | Create a new agent |
+| `d` | Delete the highlighted agent (type-to-confirm) |
 | `Ctrl+C` | Quit |
 
 ### 4. Chat

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,3 +33,23 @@ On submit, `Backend.CreateAgent` is called with both fields. The gateway creates
 - The workspace field is hidden. On submit, the backend seeds `IDENTITY.md` and `SOUL.md` with defaults under `~/.lucinate/agents/<connection>/<agent>/`. Users edit those files on disk to customise the agent's identity and behaviour — see [connections.md](connections.md#openai-agent-storage).
 
 On success the agent list is reloaded and the new agent is auto-selected (see above). On failure the form stays open and the error is shown so the user can correct and retry.
+
+## Deleting an agent
+
+Pressing `d` on a highlighted agent enters `subStateConfirmDelete`. The substate is gated by the same `Capabilities.AgentManagement` flag as create — Hermes connections never expose it because profiles are server-managed.
+
+The view is deliberately loud: a red header with the agent's name, a bullet list of what's about to be removed (metadata, transcript, and on OpenClaw bindings), the local backup path, a `Delete files | Keep files` toggle, and a textinput labelled with the agent's display name.
+
+- **Type-to-confirm.** `confirm-delete` is only emitted from `Actions()` when the typed name matches the agent's display name (case-insensitive, whitespace-trimmed) and no request is in flight. That presence-toggle is the disable mechanism for native-platform embedders — the `Action` struct has no `Enabled` flag.
+- **Keep files toggle.** `tab` flips `m.keepFiles`, which becomes `!DeleteFiles` on the `backend.DeleteAgentParams` sent to the backend. The view's description line switches with the toggle so the user can read what the current mode will do before pressing enter.
+- **Pending state is snapshotted** (`pendingDeleteID`, `pendingDeleteName`) at substate entry from the passed `agentItem`, never re-read from `list.SelectedItem()` afterwards. A list re-render mid-flight cannot resolve the destructive cmd to the wrong agent.
+- **Esc** triggers `cancel-delete` and clears all pending state. **Enter** without a matching name is a no-op.
+- **Plain `d` is not bound** inside the substate because it's a printable character the user might type as part of the agent name.
+
+`agentDeletedMsg` carries the result. On success the picker clears pending state and reloads via `loadAgents()`. On error `pendingDeleteName` is preserved so the user can retry without retyping; `deleteErr` surfaces inline. Keystrokes are ignored while `m.deleting` is true — the network call has already left.
+
+The destructive vs preserve interpretation is per-backend:
+
+- **OpenClaw** — `Backend.DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` to the gateway. The pointer is always set explicitly — the gateway's implicit "preserve files" default never applies.
+- **OpenAI-compatible** — when `DeleteFiles=true` the agent directory is wiped via `AgentStore.Delete` (`os.RemoveAll`); when false it's moved to `<root>/.archive/<id>-<unixts>/` via `AgentStore.Archive` so IDENTITY.md, SOUL.md, and history.jsonl are recoverable on disk. See [backend_openai.md](backend_openai.md#agent-storage).
+- **Hermes** — `DeleteAgent` returns a clear error pointing at `hermes profile delete`. The UI gate (AgentManagement=false) means the user shouldn't reach it; the reject is defensive.

--- a/docs/backend_hermes.md
+++ b/docs/backend_hermes.md
@@ -11,12 +11,12 @@ See [connections.md](connections.md) for the cross-backend connection lifecycle 
 `Backend.Capabilities()` reports:
 
 - `AuthRecovery: AuthRecoveryAPIKey` — bearer-token auth-recovery modal, same as OpenAI.
-- `AgentManagement: false` — Hermes profiles are configured server-side (`hermes profile create` on the host), so the TUI's "new agent" affordance is hidden. `CreateAgent` returns an error if it ever gets called regardless.
+- `AgentManagement: false` — Hermes profiles are configured server-side (`hermes profile create` / `hermes profile delete` on the host), so the TUI's "new agent" and "delete agent" affordances are both hidden. `CreateAgent` and `DeleteAgent` both return clear errors if ever called regardless.
 - Everything else is off — `/status`, `/compact`, `/think`, `/stats`, `/crons`, `!!` render a "not available on this connection" system message.
 
 ## One profile, one agent
 
-`ListAgents` returns a single synthetic entry (ID `hermes`) representing the connected Hermes profile. The display name is the model surfaced by `GET /v1/models` — Hermes advertises the profile's pinned upstream model there. `CreateAgent` is rejected with a clear error pointing the user at `hermes profile create` on the host.
+`ListAgents` returns a single synthetic entry (ID `hermes`) representing the connected Hermes profile. The display name is the model surfaced by `GET /v1/models` — Hermes advertises the profile's pinned upstream model there. `CreateAgent` and `DeleteAgent` are both rejected with clear errors pointing the user at `hermes profile create` / `hermes profile delete` on the host.
 
 `SessionsList` returns one session keyed off the same synthetic ID. `CreateSession` is a no-op that round-trips the agent ID. There is no concept of multi-agent or multi-session within a single Hermes connection — to talk to a different personality, configure a different Hermes profile (which runs on its own port) and add it as a separate connection.
 

--- a/docs/backend_openai.md
+++ b/docs/backend_openai.md
@@ -33,6 +33,8 @@ All files are mode `0600` and the agent directory is `0700`. `agent.json` is rew
 
 The agent ID is derived from the user-supplied name via `slugify` (lowercase, alphanumerics and hyphens only) — the ID is also the session key, so it has to round-trip through gateway-protocol fields without escaping.
 
+A sibling `~/.lucinate/agents/<connection-id>/.archive/` directory holds agents the user deleted with the "Keep files" option set — see below.
+
 ### IDENTITY.md and SOUL.md seeding
 
 On create, the form seeds both files with placeholders the user can edit on disk later:
@@ -50,6 +52,17 @@ Users can edit either file between sessions without going through the TUI — `S
 - Identity only → `# Identity\n\n…`
 - Soul only → `# Soul\n\n…`
 - Neither → empty string (model gets no preamble)
+
+### Delete vs archive
+
+`Backend.DeleteAgent(ctx, params)` dispatches on `params.DeleteFiles` (the user's keep-vs-delete-files toggle on the picker — see [agents.md](agents.md#deleting-an-agent)):
+
+- `DeleteFiles=true` → `AgentStore.Delete` (`os.RemoveAll(AgentDir(id))`). The on-disk content is gone.
+- `DeleteFiles=false` → `AgentStore.Archive` renames the agent dir to `<root>/.archive/<id>-<unixts>/`. IDENTITY.md, SOUL.md, history.jsonl, and agent.json all survive verbatim so the user can recover them by hand.
+
+`AgentStore.List` filters by parsable `agent.json` at the top of each direct child of the picker root, so the `.archive` directory is naturally skipped (it has no `agent.json` of its own and `LoadMeta` returns an error). No special-case is needed.
+
+`DeleteAgent` calls `LoadMeta` first to surface a "not found" error rather than silently succeeding on a stale agent ID — important because the UI presence-toggles its `confirm-delete` action on `nameMatches()`, which can theoretically pass while the underlying agent has already vanished.
 
 ## Sessions and history
 

--- a/docs/backend_openclaw.md
+++ b/docs/backend_openclaw.md
@@ -34,6 +34,8 @@ Agents are owned by the gateway. `ListAgents` and `CreateAgent` (with name + wor
 
 The gateway seeds an `IDENTITY.md` file in the agent's workspace on creation; lucinate does not author it.
 
+`DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` over the wire. The `*bool` is always populated explicitly from the picker's keep-vs-delete-files toggle (see [agents.md](agents.md#deleting-an-agent)) — the gateway's implicit "preserve files" default never applies. When `deleteFiles=false` the gateway drops bindings but leaves the agent's workspace files in place; when true the workspace is wiped along with the bindings.
+
 ## Skill catalog injection
 
 The chat layer passes the active skill catalog through `ChatSendParams.Skills`. The backend prepends a `System:`-prefixed block — `Available agent skills (activate with /skill-name): …` — to the first turn of each session via `takePendingCatalog(sessionKey, skills)`. After the first turn, `catalogSent[sessionKey] = true` and subsequent sends omit the block.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -44,7 +44,7 @@ Legacy mode (`AppOptions.Backend != nil`, no `Store`) is for native-platform emb
 
 `backend.Backend.Capabilities()` reports a `Capabilities` struct (`internal/backend/backend.go`); the TUI type-asserts against optional sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `CronBackend`, `DeviceTokenAuth`, `APIKeyAuth`) at the relevant call sites. OpenClaw implements all of them. OpenAI and Hermes implement only `APIKeyAuth` — backend-only commands (`/status`, `/compact`, `/think`, `/stats`, `/crons`, `!!`) render a "not available on this connection" system message instead of erroring.
 
-The `Capabilities.AgentManagement` flag gates the picker's "new agent" affordance. OpenClaw and OpenAI opt in (the user creates agents via the form). Hermes leaves it false because profiles are configured server-side via `hermes profile create` on the host, so the create-agent button is hidden on Hermes connections.
+The `Capabilities.AgentManagement` flag gates both the picker's "new agent" affordance and its "delete agent" affordance. OpenClaw and OpenAI opt in (the user creates and deletes agents via the picker). Hermes leaves it false because profiles are configured server-side via `hermes profile create` on the host, so both buttons are hidden on Hermes connections; `Backend.DeleteAgent` and `Backend.CreateAgent` both reject defensively if reached.
 
 ## Auth-recovery modals
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -67,6 +67,17 @@ type Backend interface {
 	// correctly.
 	CreateAgent(ctx context.Context, params CreateAgentParams) error
 
+	// DeleteAgent removes an agent. The DeleteFiles field carries the
+	// user's explicit choice from the confirm view: when true, the
+	// agent's content (workspace files for OpenClaw; the agent
+	// directory for OpenAI-compat) is destroyed; when false, the
+	// content is preserved (gateway-side files left in place; local
+	// agents archived under <root>/.archive/<id>-<timestamp>/) so the
+	// user can recover anything they needed. Backends without user-
+	// driven CRUD (Hermes) reject; the TUI hides the affordance for
+	// those via the AgentManagement capability.
+	DeleteAgent(ctx context.Context, params DeleteAgentParams) error
+
 	// SessionsList returns the raw protocol.SessionsListResult JSON
 	// for the given agent so the existing TUI session browser keeps
 	// working unchanged.
@@ -136,6 +147,24 @@ type ChatSendParams struct {
 type SkillCatalogEntry struct {
 	Name        string
 	Description string
+}
+
+// DeleteAgentParams is the parameter struct for Backend.DeleteAgent.
+// AgentID is required; DeleteFiles carries the user's "keep files /
+// delete files" toggle from the confirm view. Backends interpret
+// DeleteFiles per their storage model — OpenClaw maps it to the
+// gateway's deleteFiles flag, OpenAI-compat maps true to a full
+// os.RemoveAll and false to an archive-and-rename, and Hermes
+// rejects.
+type DeleteAgentParams struct {
+	// AgentID is the agent to delete. Required.
+	AgentID string
+
+	// DeleteFiles is the user's explicit choice — true means
+	// destroy the agent's persisted content, false means preserve it
+	// (archived locally for OpenAI-compat, left on the gateway
+	// filesystem for OpenClaw).
+	DeleteFiles bool
 }
 
 // CreateAgentParams is the kitchen-sink parameter struct for

--- a/internal/backend/hermes/backend.go
+++ b/internal/backend/hermes/backend.go
@@ -199,6 +199,13 @@ func (b *Backend) CreateAgent(ctx context.Context, params backend.CreateAgentPar
 	return fmt.Errorf("agents are not user-creatable on Hermes connections; configure profiles with `hermes profile create`")
 }
 
+// DeleteAgent rejects for the same reason as CreateAgent: Hermes
+// profiles are managed server-side. AgentManagement=false hides the
+// affordance in the TUI; this is the defensive guard.
+func (b *Backend) DeleteAgent(ctx context.Context, params backend.DeleteAgentParams) error {
+	return fmt.Errorf("agents are not user-deletable on Hermes connections; manage profiles with `hermes profile delete`")
+}
+
 // SessionsList returns one synthetic session for the synthetic agent.
 // Last-message and updatedAt are best-effort: we hit the last
 // response we know about for the title preview, but if there's no

--- a/internal/backend/hermes/backend_test.go
+++ b/internal/backend/hermes/backend_test.go
@@ -102,6 +102,16 @@ func TestCreateAgent_Rejected(t *testing.T) {
 	}
 }
 
+func TestDeleteAgent_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	b := newBackend(t, srv)
+	err := b.DeleteAgent(context.Background(), backend.DeleteAgentParams{AgentID: "x", DeleteFiles: true})
+	if err == nil || !strings.Contains(err.Error(), "not user-deletable") {
+		t.Errorf("expected rejection, got %v", err)
+	}
+}
+
 func TestCapabilities_AgentManagementOff(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer srv.Close()

--- a/internal/backend/openai/agents.go
+++ b/internal/backend/openai/agents.go
@@ -24,11 +24,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
+
+// archiveDir is the subdirectory under each connection's agent root
+// where archived agent dirs live. It's intentionally a hidden name so
+// AgentStore.List skips it (List filters on parsable agent.json at
+// the top level of each direct child; .archive itself has none).
+const archiveDir = ".archive"
 
 // AgentMeta is the shape persisted to agent.json. Identity / soul /
 // history are stored alongside in their own files because they're
@@ -169,9 +176,29 @@ func (s *AgentStore) Create(name, identity, soul, model string) (AgentMeta, erro
 
 // Delete removes an agent and its transcript. Used by /reset to
 // clear an agent's history (the TUI re-creates it immediately so the
-// user perceives it as a clean slate).
+// user perceives it as a clean slate) and by the picker's delete
+// affordance when the user chose "delete files".
 func (s *AgentStore) Delete(agentID string) error {
 	return os.RemoveAll(s.AgentDir(agentID))
+}
+
+// Archive moves an agent directory to <root>/.archive/<id>-<unixts>/
+// so the user can recover IDENTITY.md, SOUL.md and history.jsonl from
+// disk later. The agent disappears from List because the archive
+// lives outside the picker's enumeration root (List skips entries
+// without a parsable agent.json at their top level, and the .archive
+// directory itself is one).
+func (s *AgentStore) Archive(agentID string) error {
+	src := s.AgentDir(agentID)
+	if _, err := os.Stat(src); err != nil {
+		return err
+	}
+	dest := filepath.Join(s.root, archiveDir)
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		return err
+	}
+	target := filepath.Join(dest, agentID+"-"+strconv.FormatInt(time.Now().Unix(), 10))
+	return os.Rename(src, target)
 }
 
 // LoadIdentity returns the IDENTITY.md body. Missing file returns

--- a/internal/backend/openai/agents_test.go
+++ b/internal/backend/openai/agents_test.go
@@ -188,6 +188,56 @@ func TestAgentStore_DeleteRemovesDirectory(t *testing.T) {
 	}
 }
 
+func TestAgentStore_ArchiveMovesDirectoryAndPreservesContent(t *testing.T) {
+	store := newTestStore(t)
+	meta, _ := store.Create("alpha", "id-body", "soul-body", "model-x")
+	_ = store.AppendMessage(meta.ID, Message{Role: "user", Content: "hi"})
+
+	if err := store.Archive(meta.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if _, err := os.Stat(store.AgentDir(meta.ID)); !os.IsNotExist(err) {
+		t.Errorf("original agent dir should be gone: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(store.Root(), archiveDir))
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 archived agent, got %d", len(entries))
+	}
+	archived := filepath.Join(store.Root(), archiveDir, entries[0].Name())
+	if !strings.HasPrefix(entries[0].Name(), meta.ID+"-") {
+		t.Errorf("archive name = %q, want prefix %q", entries[0].Name(), meta.ID+"-")
+	}
+
+	// Identity, soul, history all preserved verbatim under the
+	// archive — the whole point of the keep-files toggle.
+	for _, f := range []string{"IDENTITY.md", "SOUL.md", "history.jsonl", "agent.json"} {
+		if _, err := os.Stat(filepath.Join(archived, f)); err != nil {
+			t.Errorf("expected %s preserved under archive: %v", f, err)
+		}
+	}
+
+	// And List() ignores the archive dir — only directories with a
+	// parsable agent.json at the picker root count as agents.
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("List should skip archived agents, got %d", len(list))
+	}
+}
+
+func TestAgentStore_ArchiveMissingAgent(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.Archive("ghost"); err == nil {
+		t.Error("expected error archiving non-existent agent")
+	}
+}
+
 func TestAgentStore_FilesArePrivate(t *testing.T) {
 	store := newTestStore(t)
 	meta, _ := store.Create("alpha", "ident", "soul", "")

--- a/internal/backend/openai/backend.go
+++ b/internal/backend/openai/backend.go
@@ -210,6 +210,22 @@ func (b *Backend) CreateAgent(ctx context.Context, params backend.CreateAgentPar
 	return err
 }
 
+// DeleteAgent removes an agent from disk. When DeleteFiles is true
+// the agent directory is wiped (os.RemoveAll); when false the
+// directory is moved to <root>/.archive/<id>-<unixts>/ so the user
+// can recover IDENTITY.md, SOUL.md and history.jsonl from disk
+// later. Returns a wrapped error if the agent doesn't exist so a
+// stale UI doesn't silent-succeed.
+func (b *Backend) DeleteAgent(ctx context.Context, params backend.DeleteAgentParams) error {
+	if _, err := b.store.LoadMeta(params.AgentID); err != nil {
+		return fmt.Errorf("agent not found: %s: %w", params.AgentID, err)
+	}
+	if params.DeleteFiles {
+		return b.store.Delete(params.AgentID)
+	}
+	return b.store.Archive(params.AgentID)
+}
+
 // SessionsList returns a single-entry "session list" so the existing
 // TUI session browser keeps working: agent ≡ session 1:1, the
 // session key equals the agent ID.

--- a/internal/backend/openai/backend_test.go
+++ b/internal/backend/openai/backend_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +132,91 @@ func TestBackend_CreateAndListAgent(t *testing.T) {
 	}
 	if result.DefaultID != "researcher" {
 		t.Errorf("DefaultID = %q", result.DefaultID)
+	}
+}
+
+func TestBackend_DeleteAgent_DestroyRemovesDirectory(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	b := newBackend(t, srv)
+	if err := b.CreateAgent(context.Background(), backend.CreateAgentParams{
+		Name: "tonuke", Identity: "id", Soul: "soul", Model: "m",
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	if err := b.DeleteAgent(context.Background(), backend.DeleteAgentParams{
+		AgentID:     "tonuke",
+		DeleteFiles: true,
+	}); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := os.Stat(b.store.AgentDir("tonuke")); !os.IsNotExist(err) {
+		t.Errorf("agent dir should be removed: %v", err)
+	}
+	// And nothing should have been written to the archive — the
+	// destructive path bypasses Archive entirely.
+	if entries, _ := os.ReadDir(filepath.Join(b.store.Root(), ".archive")); len(entries) != 0 {
+		t.Errorf("destructive delete should not archive, got %d entries", len(entries))
+	}
+
+	result, _ := b.ListAgents(context.Background())
+	if len(result.Agents) != 0 {
+		t.Errorf("agent should be gone from list, got %d", len(result.Agents))
+	}
+}
+
+func TestBackend_DeleteAgent_KeepFilesArchives(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	b := newBackend(t, srv)
+	if err := b.CreateAgent(context.Background(), backend.CreateAgentParams{
+		Name: "toarchive", Identity: "id", Soul: "soul", Model: "m",
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	if err := b.DeleteAgent(context.Background(), backend.DeleteAgentParams{
+		AgentID:     "toarchive",
+		DeleteFiles: false,
+	}); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := os.Stat(b.store.AgentDir("toarchive")); !os.IsNotExist(err) {
+		t.Errorf("original dir should be moved: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(b.store.Root(), ".archive"))
+	if err != nil {
+		t.Fatalf("read .archive: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 archived agent, got %d", len(entries))
+	}
+
+	result, _ := b.ListAgents(context.Background())
+	if len(result.Agents) != 0 {
+		t.Errorf("archived agent should not appear in list, got %d", len(result.Agents))
+	}
+}
+
+func TestBackend_DeleteAgent_MissingAgent(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	b := newBackend(t, srv)
+	err := b.DeleteAgent(context.Background(), backend.DeleteAgentParams{
+		AgentID:     "ghost",
+		DeleteFiles: true,
+	})
+	if err == nil {
+		t.Error("expected error for missing agent")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got %v", err)
 	}
 }
 

--- a/internal/backend/openclaw/openclaw.go
+++ b/internal/backend/openclaw/openclaw.go
@@ -65,6 +65,10 @@ func (b *Backend) CreateAgent(ctx context.Context, params backend.CreateAgentPar
 	return b.client.CreateAgent(ctx, params.Name, params.Workspace)
 }
 
+func (b *Backend) DeleteAgent(ctx context.Context, params backend.DeleteAgentParams) error {
+	return b.client.DeleteAgent(ctx, params.AgentID, params.DeleteFiles)
+}
+
 func (b *Backend) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
 	return b.client.SessionsList(ctx, agentID)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -243,6 +243,24 @@ func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, er
 	return c.currentGW().AgentsList(ctx)
 }
 
+// DeleteAgent removes an agent via the gateway API. deleteFiles is
+// the user's explicit choice from the confirm view: when true, the
+// gateway also wipes the agent's workspace files; when false, only
+// bindings drop and the workspace stays on disk so the user can
+// reuse it. The result payload (ok / removed bindings count) is
+// discarded — callers care only about success vs failure.
+func (c *Client) DeleteAgent(ctx context.Context, agentID string, deleteFiles bool) error {
+	gw := c.currentGW()
+	flag := deleteFiles
+	if _, err := gw.AgentsDelete(ctx, protocol.AgentsDeleteParams{
+		AgentID:     agentID,
+		DeleteFiles: &flag,
+	}); err != nil {
+		return fmt.Errorf("agents delete: %w", err)
+	}
+	return nil
+}
+
 // CreateAgent provisions a new agent via the gateway API and seeds an
 // IDENTITY.md file for it.
 func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error {

--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -37,6 +37,11 @@ type fakeBackend struct {
 	clearedToken   bool
 	resetIdentity  bool
 
+	// Recorded DeleteAgent calls so tests can assert keep-files /
+	// delete-files routing.
+	deletedAgents []backend.DeleteAgentParams
+	deleteAgentErr error
+
 	// Cron RPC seams — tests pre-seed jobs / runs / errors and read
 	// back the recorded calls through these fields.
 	cronJobs        []protocol.CronJob
@@ -81,6 +86,10 @@ func (f *fakeBackend) ListAgents(ctx context.Context) (*protocol.AgentsListResul
 }
 func (f *fakeBackend) CreateAgent(ctx context.Context, params backend.CreateAgentParams) error {
 	return nil
+}
+func (f *fakeBackend) DeleteAgent(ctx context.Context, params backend.DeleteAgentParams) error {
+	f.deletedAgents = append(f.deletedAgents, params)
+	return f.deleteAgentErr
 }
 func (f *fakeBackend) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
 	return json.RawMessage(`{"sessions":[]}`), nil

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -63,8 +63,9 @@ func (d agentDelegate) Render(w io.Writer, m list.Model, index int, item list.It
 type selectSubState int
 
 const (
-	subStateList   selectSubState = iota
+	subStateList selectSubState = iota
 	subStateCreate
+	subStateConfirmDelete
 )
 
 var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
@@ -114,12 +115,33 @@ type selectModel struct {
 	newAgentID     string
 	workspaceEdited bool
 	nameValidMsg   string
+
+	// Confirm-delete substate.
+	pendingDeleteID   string
+	pendingDeleteName string
+	confirmInput      textinput.Model
+	deleting          bool
+	deleteErr         error
+	// keepFiles is the user's "preserve content / destroy content"
+	// toggle. False (the default) maps to backend.DeleteAgentParams
+	// DeleteFiles=true — i.e. the destructive option is the default,
+	// but the user still has to type the agent name to fire it.
+	keepFiles bool
 }
 
 // agentsLoadedMsg is sent when agents are fetched from the gateway.
 type agentsLoadedMsg struct {
 	result *protocol.AgentsListResult
 	err    error
+}
+
+// agentDeletedMsg is sent when a delete-agent RPC completes. err is
+// nil on success; the picker reloads the list. On error the confirm
+// substate stays open with deleteErr surfaced inline so the user can
+// retry or cancel.
+type agentDeletedMsg struct {
+	name string
+	err  error
 }
 
 // newSelectModel constructs the agent picker. showConnections=true
@@ -180,6 +202,21 @@ func (m selectModel) createAgent(name, workspace string) tea.Cmd {
 	}
 }
 
+// deleteAgent dispatches the backend delete RPC. keepFiles inverts to
+// DeleteAgentParams.DeleteFiles so the on-screen toggle reads
+// naturally ("keep files" / "delete files") while the backend
+// receives the destructive flag.
+func (m selectModel) deleteAgent(agentID, name string, keepFiles bool) tea.Cmd {
+	b := m.backend
+	return func() tea.Msg {
+		err := b.DeleteAgent(context.Background(), backend.DeleteAgentParams{
+			AgentID:     agentID,
+			DeleteFiles: !keepFiles,
+		})
+		return agentDeletedMsg{name: name, err: err}
+	}
+}
+
 func (m selectModel) Init() tea.Cmd {
 	return m.loadAgents()
 }
@@ -224,6 +261,50 @@ func (m *selectModel) initCreateForm() tea.Cmd {
 	}
 
 	return cmd
+}
+
+// initConfirmDelete prepares the delete-confirm substate from the
+// passed-in item. The display name and ID are snapshotted at entry
+// so a list re-render mid-flight cannot resolve to the wrong agent.
+// keepFiles defaults to false (destructive); the user has to actively
+// type the name to fire either path, so they're not one keystroke
+// away from data loss.
+func (m *selectModel) initConfirmDelete(item agentItem) tea.Cmd {
+	display := item.agent.Name
+	if display == "" {
+		display = item.agent.ID
+	}
+	m.subState = subStateConfirmDelete
+	m.pendingDeleteID = item.agent.ID
+	m.pendingDeleteName = display
+	m.deleting = false
+	m.deleteErr = nil
+	m.keepFiles = false
+
+	m.confirmInput = textinput.New()
+	m.confirmInput.CharLimit = 64
+	m.confirmInput.Placeholder = display
+	return m.confirmInput.Focus()
+}
+
+// nameMatches reports whether the typed confirmation matches the
+// pending agent's display name. Comparison is case-insensitive with
+// whitespace trim — exact-character pedantry is hostile UX, and the
+// destructive intent is gated by the typing act, not by perfect
+// transcription.
+func (m selectModel) nameMatches() bool {
+	return m.pendingDeleteName != "" &&
+		strings.EqualFold(strings.TrimSpace(m.confirmInput.Value()), m.pendingDeleteName)
+}
+
+// keepFilesLabel renders the toggle button label so its current state
+// reads off the action surface ("Keep files" when about to switch
+// from destructive to preserve, and vice versa).
+func (m selectModel) keepFilesLabel() string {
+	if m.keepFiles {
+		return "Delete files"
+	}
+	return "Keep files"
 }
 
 // switchFocus toggles between the form's input fields. With the
@@ -292,12 +373,34 @@ func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
 		m.loading = true
 		return m, m.loadAgents()
 
+	case agentDeletedMsg:
+		if msg.err != nil {
+			// Stay in the confirm substate so the user can read
+			// the error and either retry (correct the typed name
+			// if needed) or cancel cleanly. Don't clear the
+			// pending fields — those are needed for retry.
+			m.deleting = false
+			m.deleteErr = msg.err
+			return m, nil
+		}
+		m.subState = subStateList
+		m.pendingDeleteID = ""
+		m.pendingDeleteName = ""
+		m.deleting = false
+		m.deleteErr = nil
+		m.keepFiles = false
+		m.loading = true
+		return m, m.loadAgents()
+
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 	}
 
 	if m.subState == subStateCreate {
 		return m.updateCreateForm(msg)
+	}
+	if m.subState == subStateConfirmDelete {
+		return m.updateConfirmDelete(msg)
 	}
 
 	var cmd tea.Cmd
@@ -308,6 +411,9 @@ func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
 func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 	if m.subState == subStateCreate {
 		return m.handleCreateKey(msg)
+	}
+	if m.subState == subStateConfirmDelete {
+		return m.handleConfirmDeleteKey(msg)
 	}
 
 	// Enter is intrinsic list navigation (select the highlighted item)
@@ -343,12 +449,30 @@ func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 // interactions and intentionally exposes no actions — those keys are
 // inherent form navigation, not discoverable commands.
 func (m selectModel) Actions() []Action {
+	if m.subState == subStateConfirmDelete {
+		// In confirm-delete the only available actions are the
+		// destructive ones. confirm-delete only appears when the
+		// typed name matches and no request is in flight — that's
+		// how the disabled state is expressed for native embedders
+		// (the Action struct has no Enabled flag).
+		actions := []Action{
+			{ID: "toggle-keep-files", Label: m.keepFilesLabel(), Key: "tab"},
+			{ID: "cancel-delete", Label: "Cancel", Key: "esc"},
+		}
+		if m.nameMatches() && !m.deleting {
+			actions = append([]Action{{ID: "confirm-delete", Label: "Delete", Key: "enter"}}, actions...)
+		}
+		return actions
+	}
 	if m.subState != subStateList {
 		return nil
 	}
 	var actions []Action
 	if !m.loading && m.err == nil && m.allowAgentManagement {
 		actions = append(actions, Action{ID: "new-agent", Label: "New agent", Key: "n"})
+		if m.list.SelectedItem() != nil {
+			actions = append(actions, Action{ID: "delete-agent", Label: "Delete agent", Key: "d"})
+		}
 	}
 	if m.err != nil {
 		actions = append(actions, Action{ID: "retry", Label: "Retry", Key: "r"})
@@ -369,6 +493,36 @@ func (m selectModel) TriggerAction(id string) (selectModel, tea.Cmd) {
 			return m, nil
 		}
 		return m, m.initCreateForm()
+	case "delete-agent":
+		if m.loading || m.err != nil || !m.allowAgentManagement {
+			return m, nil
+		}
+		item, ok := m.list.SelectedItem().(agentItem)
+		if !ok {
+			return m, nil
+		}
+		return m, m.initConfirmDelete(item)
+	case "confirm-delete":
+		// Re-validate even though Actions() only emits this when
+		// nameMatches()&&!deleting — embedders are still in charge of
+		// their own dispatch and we don't trust them to filter.
+		if !m.nameMatches() || m.deleting {
+			return m, nil
+		}
+		m.deleting = true
+		m.deleteErr = nil
+		return m, m.deleteAgent(m.pendingDeleteID, m.pendingDeleteName, m.keepFiles)
+	case "cancel-delete":
+		m.subState = subStateList
+		m.pendingDeleteID = ""
+		m.pendingDeleteName = ""
+		m.deleting = false
+		m.deleteErr = nil
+		m.keepFiles = false
+		return m, nil
+	case "toggle-keep-files":
+		m.keepFiles = !m.keepFiles
+		return m, nil
 	case "retry":
 		if m.err == nil {
 			return m, nil
@@ -413,6 +567,50 @@ func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd)
 	}
 
 	return m.updateCreateForm(msg)
+}
+
+// handleConfirmDeleteKey routes keystrokes inside the confirm-delete
+// substate. The name input is the focal element so most printable
+// keys are passed straight through to it; only intrinsic form keys
+// (esc / enter / tab) are intercepted. Plain `d` for "delete-agent"
+// is intentionally NOT bound here — it's a printable character the
+// user might type as part of the agent name. The action key surface
+// (Action{ID:"toggle-keep-files", Key:"tab"}) handles native
+// embedder dispatch; tab/esc/enter handle direct keystrokes.
+func (m selectModel) handleConfirmDeleteKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
+	if m.deleting {
+		// Request in flight; ignore further input. The user can't
+		// cancel an in-flight DeleteAgent — the network call has
+		// already left.
+		return m, nil
+	}
+	switch msg.String() {
+	case "esc":
+		return m.TriggerAction("cancel-delete")
+	case "tab", "shift+tab":
+		return m.TriggerAction("toggle-keep-files")
+	case "enter":
+		if m.nameMatches() {
+			return m.TriggerAction("confirm-delete")
+		}
+		// Enter without a matching name is a no-op so the user
+		// can't bypass the type-to-confirm gate.
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.confirmInput, cmd = m.confirmInput.Update(msg)
+	return m, cmd
+}
+
+// updateConfirmDelete forwards non-key messages (cursor blink, etc.)
+// to the textinput so it animates correctly while focused.
+func (m selectModel) updateConfirmDelete(msg tea.Msg) (selectModel, tea.Cmd) {
+	if m.deleting {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.confirmInput, cmd = m.confirmInput.Update(msg)
+	return m, cmd
 }
 
 func (m selectModel) updateCreateForm(msg tea.Msg) (selectModel, tea.Cmd) {
@@ -472,6 +670,9 @@ func (m selectModel) View() string {
 	if m.subState == subStateCreate {
 		return banner + m.viewCreateForm()
 	}
+	if m.subState == subStateConfirmDelete {
+		return banner + m.viewConfirmDelete()
+	}
 	return banner + m.list.View() + "\n" + hints
 }
 
@@ -524,6 +725,98 @@ func (m selectModel) viewCreateForm() string {
 	}
 	b.WriteString("\n")
 	return b.String()
+}
+
+// viewConfirmDelete renders the loud delete-confirmation view. The
+// page deliberately spends real estate on warnings: the user is
+// about to lose the agent's identity, soul, transcript, and (unless
+// they toggle Keep files) the underlying file content.
+func (m selectModel) viewConfirmDelete() string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(headerStyle.Render(" Delete agent "))
+	b.WriteString("\n\n")
+
+	heading := fmt.Sprintf("  Delete %q?", m.pendingDeleteName)
+	b.WriteString(errorStyle.Render(heading))
+	b.WriteString("\n")
+	b.WriteString(errorStyle.Render("  ⚠  This is permanent and cannot be undone."))
+	b.WriteString("\n\n")
+
+	b.WriteString("  This will remove:\n")
+	b.WriteString("    • The agent's metadata and listing\n")
+	b.WriteString("    • The full conversation transcript\n")
+	if m.useWorkspace {
+		b.WriteString("    • Gateway bindings for this agent\n")
+	}
+	b.WriteString("\n")
+
+	b.WriteString("  Files mode: " + toggleView(m.keepFilesLabel(), "Delete files", "Keep files"))
+	b.WriteString(helpStyle.Render("   (tab to toggle)"))
+	b.WriteString("\n")
+	b.WriteString("    " + helpStyle.Render(m.filesModeDescription()))
+	b.WriteString("\n\n")
+
+	b.WriteString("  Back up anything you want to keep first:\n")
+	b.WriteString("    " + helpStyle.Render(m.backupHint()))
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("  Type the agent name (%q) to confirm:\n", m.pendingDeleteName))
+	b.WriteString("  " + m.confirmInput.View() + "\n")
+	if v := strings.TrimSpace(m.confirmInput.Value()); v != "" && !m.nameMatches() {
+		b.WriteString("  " + errorStyle.Render("Name doesn't match") + "\n")
+	}
+	b.WriteString("\n")
+
+	switch {
+	case m.deleting:
+		b.WriteString(statusStyle.Render("  Deleting..."))
+	case m.deleteErr != nil:
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.deleteErr)))
+		b.WriteString("\n")
+		b.WriteString(helpStyle.Render("  enter: retry (when name matches)  ·  esc: cancel"))
+	case m.nameMatches():
+		b.WriteString(helpStyle.Render("  enter: delete  ·  tab: toggle files mode  ·  esc: cancel"))
+	default:
+		b.WriteString(helpStyle.Render("  type the name above, then enter to delete  ·  tab: toggle files mode  ·  esc: cancel"))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// filesModeDescription explains what the current Keep/Delete files
+// toggle will actually do — wording is backend-aware so OpenClaw users
+// see "gateway workspace" copy and OpenAI-compat users see the local
+// archive path.
+func (m selectModel) filesModeDescription() string {
+	if m.useWorkspace {
+		if m.keepFiles {
+			return "Agent workspace files on the gateway will be left in place; only bindings are removed."
+		}
+		return "Agent workspace files on the gateway will be deleted along with the agent."
+	}
+	if m.keepFiles {
+		return "The agent directory will be moved to <root>/.archive/<id>-<timestamp>/ so IDENTITY.md, SOUL.md and the transcript are recoverable on disk."
+	}
+	return "IDENTITY.md, SOUL.md, and history.jsonl will be removed from disk."
+}
+
+// backupHint returns the path the user should back up before deleting,
+// formatted for the active backend type. For local-disk agents we try
+// to render the actual conn-id-rooted path; for OpenClaw the relevant
+// data lives on the gateway filesystem and we describe it in words.
+func (m selectModel) backupHint() string {
+	if m.useWorkspace {
+		return "Agent workspace and bindings on the gateway"
+	}
+	connID := ""
+	if m.activeConn != nil {
+		connID = m.activeConn.ID
+	}
+	if connID == "" {
+		connID = "<connection>"
+	}
+	return fmt.Sprintf("~/.lucinate/agents/%s/%s/", connID, m.pendingDeleteID)
 }
 
 func (m selectModel) selectedAgent() (agentItem, bool) {

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -6,7 +6,27 @@ import (
 
 	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
 )
+
+// loadAgents seeds the picker with a set of agents via agentsLoadedMsg,
+// matching the path the picker takes once ListAgents returns. Used by
+// the delete-flow tests.
+func loadAgents(m selectModel, agents ...protocol.AgentSummary) selectModel {
+	defaultID := ""
+	if len(agents) > 0 {
+		defaultID = agents[0].ID
+	}
+	m, _ = m.Update(agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: defaultID,
+			MainKey:   defaultID,
+			Agents:    agents,
+		},
+	})
+	return m
+}
 
 func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
 	m := newSelectModel(nil, false, false, nil)
@@ -297,6 +317,305 @@ func TestSelectModel_ConnectionsActionOnlyInManagedMode(t *testing.T) {
 		t.Errorf("expected key 'c', got %q", found.Key)
 	}
 }
+
+// hasAction reports whether the picker currently exposes an action
+// with the given ID. Used by the delete-flow tests to verify the
+// confirm-delete action toggles correctly with the typed-name match.
+func hasAction(m selectModel, id string) bool {
+	for _, a := range m.Actions() {
+		if a.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSelectModel_DeleteActionAppearsWhenManagementEnabled(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+
+	if !hasAction(m, "delete-agent") {
+		t.Errorf("expected delete-agent action when management is enabled and a list item is selected, got %+v", m.Actions())
+	}
+}
+
+func TestSelectModel_DeleteActionHiddenWhenManagementDisabled(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	// allowAgentManagement remains false (Hermes-style)
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+
+	if hasAction(m, "delete-agent") {
+		t.Errorf("expected delete-agent to be hidden when AgentManagement=false, got %+v", m.Actions())
+	}
+}
+
+func TestSelectModel_DeleteActionHiddenWhenLoading(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	// loading=true is the initial state — list never received a load msg.
+
+	if hasAction(m, "delete-agent") {
+		t.Errorf("expected delete-agent to be hidden while loading, got %+v", m.Actions())
+	}
+}
+
+func TestSelectModel_DeleteActionHiddenWhenEmptyList(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m) // no agents
+
+	if hasAction(m, "delete-agent") {
+		t.Errorf("expected delete-agent to be hidden when list is empty, got %+v", m.Actions())
+	}
+}
+
+func TestSelectModel_TriggerDeleteEntersConfirmSubstate(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha Agent"})
+
+	m, _ = m.TriggerAction("delete-agent")
+
+	if m.subState != subStateConfirmDelete {
+		t.Fatalf("expected subStateConfirmDelete, got %v", m.subState)
+	}
+	if m.pendingDeleteID != "alpha" {
+		t.Errorf("pendingDeleteID = %q, want alpha", m.pendingDeleteID)
+	}
+	if m.pendingDeleteName != "Alpha Agent" {
+		t.Errorf("pendingDeleteName = %q, want %q", m.pendingDeleteName, "Alpha Agent")
+	}
+	if m.keepFiles {
+		t.Error("keepFiles should default to false (destructive)")
+	}
+	if m.deleting {
+		t.Error("deleting should be false at substate entry")
+	}
+}
+
+func TestSelectModel_TriggerDeleteUsesIDWhenNameEmpty(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "id-only"})
+
+	m, _ = m.TriggerAction("delete-agent")
+	if m.pendingDeleteName != "id-only" {
+		t.Errorf("pendingDeleteName = %q, expected fallback to ID", m.pendingDeleteName)
+	}
+}
+
+func TestSelectModel_ConfirmDeleteRequiresNameMatch(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+
+	if hasAction(m, "confirm-delete") {
+		t.Error("confirm-delete should not appear before name is typed")
+	}
+
+	m.confirmInput.SetValue("wrong-name")
+	if hasAction(m, "confirm-delete") {
+		t.Error("confirm-delete should not appear with mismatched name")
+	}
+
+	m.confirmInput.SetValue("Alpha")
+	if !hasAction(m, "confirm-delete") {
+		t.Errorf("confirm-delete should appear when name matches, got %+v", m.Actions())
+	}
+}
+
+func TestSelectModel_ConfirmDeleteCaseInsensitive(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "My Agent"})
+	m, _ = m.TriggerAction("delete-agent")
+
+	m.confirmInput.SetValue("MY AGENT")
+	if !m.nameMatches() {
+		t.Error("expected case-insensitive match")
+	}
+
+	m.confirmInput.SetValue("  my agent  ")
+	if !m.nameMatches() {
+		t.Error("expected whitespace-trimmed match")
+	}
+}
+
+func TestSelectModel_ConfirmDeleteEscClearsState(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+	m.confirmInput.SetValue("Alpha")
+
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if m.subState != subStateList {
+		t.Errorf("expected return to subStateList, got %v", m.subState)
+	}
+	if m.pendingDeleteID != "" || m.pendingDeleteName != "" {
+		t.Errorf("expected pending fields cleared, got id=%q name=%q", m.pendingDeleteID, m.pendingDeleteName)
+	}
+}
+
+func TestSelectModel_ToggleKeepFilesFlipsState(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+
+	if m.keepFiles {
+		t.Fatal("expected keepFiles=false at entry")
+	}
+
+	m, _ = m.TriggerAction("toggle-keep-files")
+	if !m.keepFiles {
+		t.Error("expected keepFiles=true after first toggle")
+	}
+
+	// Action label should now read the inverse — i.e. the button
+	// offers to flip back to "Delete files".
+	for _, a := range m.Actions() {
+		if a.ID == "toggle-keep-files" && a.Label != "Delete files" {
+			t.Errorf("toggle label = %q, want %q", a.Label, "Delete files")
+		}
+	}
+
+	m, _ = m.TriggerAction("toggle-keep-files")
+	if m.keepFiles {
+		t.Error("expected keepFiles=false after second toggle")
+	}
+}
+
+func TestSelectModel_ToggleKeepFilesViaTabKey(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.allowAgentManagement = true
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !m.keepFiles {
+		t.Error("expected tab key to toggle keepFiles")
+	}
+}
+
+func TestSelectModel_DeleteCmdPassesKeepFilesChoice(t *testing.T) {
+	fb := newFakeBackend()
+	fb.caps.AgentManagement = true
+	m := newSelectModel(fb, false, false, nil)
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+	m.confirmInput.SetValue("Alpha")
+	// Toggle to keep files.
+	m, _ = m.TriggerAction("toggle-keep-files")
+
+	m, cmd := m.TriggerAction("confirm-delete")
+	if !m.deleting {
+		t.Fatal("expected deleting=true after confirm")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd from confirm-delete")
+	}
+	// Run the cmd to actually call the backend (the cmd's body
+	// invokes b.DeleteAgent and returns agentDeletedMsg).
+	_ = cmd()
+
+	if len(fb.deletedAgents) != 1 {
+		t.Fatalf("expected 1 DeleteAgent call, got %d", len(fb.deletedAgents))
+	}
+	got := fb.deletedAgents[0]
+	if got.AgentID != "alpha" {
+		t.Errorf("AgentID = %q, want alpha", got.AgentID)
+	}
+	if got.DeleteFiles {
+		t.Error("expected DeleteFiles=false (keepFiles=true was set)")
+	}
+}
+
+func TestSelectModel_ConfirmDeleteIgnoredWithoutMatch(t *testing.T) {
+	fb := newFakeBackend()
+	fb.caps.AgentManagement = true
+	m := newSelectModel(fb, false, false, nil)
+	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
+	m, _ = m.TriggerAction("delete-agent")
+	m.confirmInput.SetValue("nope")
+
+	m, cmd := m.TriggerAction("confirm-delete")
+	if cmd != nil {
+		t.Error("expected no cmd when name doesn't match")
+	}
+	if m.deleting {
+		t.Error("expected deleting to remain false")
+	}
+}
+
+func TestSelectModel_AgentDeletedSuccessReloads(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.subState = subStateConfirmDelete
+	m.deleting = true
+	m.pendingDeleteID = "alpha"
+	m.pendingDeleteName = "Alpha"
+
+	m, _ = m.Update(agentDeletedMsg{name: "Alpha"})
+
+	if m.subState != subStateList {
+		t.Errorf("subState = %v, want subStateList", m.subState)
+	}
+	if !m.loading {
+		t.Error("expected loading=true (reload) after successful delete")
+	}
+	if m.pendingDeleteID != "" || m.pendingDeleteName != "" {
+		t.Error("expected pending fields cleared on success")
+	}
+	if m.deleting {
+		t.Error("expected deleting=false on success")
+	}
+}
+
+func TestSelectModel_AgentDeletedErrorStaysInConfirm(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.subState = subStateConfirmDelete
+	m.deleting = true
+	m.pendingDeleteID = "alpha"
+	m.pendingDeleteName = "Alpha"
+
+	m, _ = m.Update(agentDeletedMsg{name: "Alpha", err: fmt.Errorf("boom")})
+
+	if m.subState != subStateConfirmDelete {
+		t.Errorf("expected to stay in confirm substate on error, got %v", m.subState)
+	}
+	if m.deleting {
+		t.Error("expected deleting=false on error")
+	}
+	if m.deleteErr == nil {
+		t.Error("expected deleteErr to be set")
+	}
+	// Pending fields preserved so the user can retry without
+	// re-typing.
+	if m.pendingDeleteID != "alpha" || m.pendingDeleteName != "Alpha" {
+		t.Errorf("expected pending fields preserved on error, got id=%q name=%q", m.pendingDeleteID, m.pendingDeleteName)
+	}
+}
+
+func TestSelectModel_DeletingBlocksKeystrokes(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil)
+	m.subState = subStateConfirmDelete
+	m.deleting = true
+	m.pendingDeleteID = "alpha"
+	m.pendingDeleteName = "Alpha"
+
+	prev := m.keepFiles
+	// Tab while deleting should NOT flip the toggle.
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.keepFiles != prev {
+		t.Error("tab should be ignored while a delete is in flight")
+	}
+}
+
+// Compile-time guard so the fake backend tracks DeleteAgent calls.
+var _ = backend.DeleteAgentParams{}
 
 func TestSelectModel_ConnectionsActionEmitsShowConnections(t *testing.T) {
 	m := newSelectModel(nil, false, true, nil)


### PR DESCRIPTION
Lets users delete agents from the picker, gated by a loud type-the-name confirmation and a per-backend choice to keep or destroy the agent's stored content.

## Summary
- Adds a `Delete agent` affordance to the agent picker — pressing `d` opens a confirm view that only fires once the user types the agent's display name (case-insensitive, whitespace-trimmed) so the destructive intent is gated on the typing act, not a single keystroke
- `tab` flips a `Delete files | Keep files` mode so users can drop the listing while keeping their content. OpenAI-compat archives the agent dir under `<root>/.archive/<id>-<timestamp>/` when keeping; OpenClaw passes the user's explicit choice through to the gateway's `deleteFiles` flag
- Hidden on Hermes connections (`AgentManagement=false`); the backend also rejects defensively in case the UI gate is ever bypassed
- Surfaces `Backend.DeleteAgent` so embedders that drive the picker through native controls get the same affordances as the TUI

## Implementation details
- Plain `d` is deliberately not bound inside the confirm substate because the user types the agent name there. Tab routes to the keep-files toggle, esc cancels, enter only fires when the typed name matches and no request is in flight
- `confirm-delete` is only emitted from `Actions()` when `nameMatches() && !deleting`. Toggling action presence is the disable mechanism for native embedders — the `Action` struct has no `Enabled` flag and adding one would have rippled across every embedder
- Pending ID and display name are snapshotted at substate entry so a list re-render mid-flight cannot resolve the destructive cmd to the wrong agent
- The OpenClaw client always sends an explicit `*bool` for `deleteFiles` so the gateway never falls back to its implicit "preserve files" default — the user's toggle choice is the source of truth
- The OpenAI-compat archive lives at `<root>/.archive/` and `AgentStore.List` already filters by parsable `agent.json` at the top of each direct child, so the archive is naturally skipped without a special-case
- On error the substate stays open with `pendingDeleteName` preserved so the user can retry without retyping; on success the picker reloads via `loadAgents`
