### PR TITLE
fix(tui): preserve chat scroll during streaming and gate bell on focus

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -428,6 +428,14 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.chatModel.applyConnState(msg)
 		return m, nil
 
+	case tea.FocusMsg:
+		m.chatModel.terminalFocused = true
+		return m, nil
+
+	case tea.BlurMsg:
+		m.chatModel.terminalFocused = false
+		return m, nil
+
 	case showConnectionsMsg:
 		if !m.managed {
 			return m, nil
@@ -799,5 +807,6 @@ func (m AppModel) View() tea.View {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
 	v.KeyboardEnhancements.ReportEventTypes = true
+	v.ReportFocus = true
 	return v
 }

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -116,6 +116,7 @@ type chatModel struct {
 	thinkingLevel    string // current thinking level; "" means not set / using gateway default
 	connState        ConnStateMsg
 	hideInput        bool // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
+	terminalFocused  bool // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -183,9 +184,10 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		agentName:    agentName,
 		renderer:     renderer,
 		modelID:      modelID,
-		prefs:        prefs,
-		historyLimit: prefs.HistoryLimit,
-		hideInput:    hideInput,
+		prefs:           prefs,
+		historyLimit:    prefs.HistoryLimit,
+		hideInput:       hideInput,
+		terminalFocused: true,
 	}
 }
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -213,7 +213,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			return nil
 		}
 		var cmds []tea.Cmd
-		if m.prefs.CompletionBell {
+		if m.shouldRingBell() {
 			cmds = append(cmds, bellCmd())
 		}
 		drainCmd := m.drainQueue()
@@ -263,6 +263,14 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		return m.drainQueue()
 	}
 	return nil
+}
+
+// shouldRingBell reports whether the completion bell should fire on a final
+// chat event. The bell is intended as a "look back at me" cue when the user
+// has switched away, so a focused terminal suppresses it even when the pref
+// is on.
+func (m *chatModel) shouldRingBell() bool {
+	return m.prefs.CompletionBell && !m.terminalFocused
 }
 
 // bellCmd returns a command that writes a BEL character to the terminal.

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -969,6 +969,7 @@ func TestHandleEvent_FinalWithBellPref(t *testing.T) {
 	m := newTestChatModel()
 	m.sending = true
 	m.prefs.CompletionBell = true
+	m.terminalFocused = false
 	m.messages = []chatMessage{
 		{role: "user", content: "hello"},
 		{role: "assistant", content: "text", streaming: true},
@@ -976,7 +977,31 @@ func TestHandleEvent_FinalWithBellPref(t *testing.T) {
 	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"text"}],"timestamp":123}`)
 	cmd := m.handleEvent(makeChatEvent("final", "run1", 3, finalMsg))
 	if cmd == nil {
-		t.Error("expected a non-nil cmd (should include bell)")
+		t.Error("expected a non-nil cmd (should include bell when terminal is blurred)")
+	}
+}
+
+func TestShouldRingBell(t *testing.T) {
+	tests := []struct {
+		name     string
+		pref     bool
+		focused  bool
+		wantRing bool
+	}{
+		{"pref off, focused", false, true, false},
+		{"pref off, blurred", false, false, false},
+		{"pref on, focused", true, true, false},
+		{"pref on, blurred", true, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestChatModel()
+			m.prefs.CompletionBell = tt.pref
+			m.terminalFocused = tt.focused
+			if got := m.shouldRingBell(); got != tt.wantRing {
+				t.Errorf("shouldRingBell() = %v, want %v", got, tt.wantRing)
+			}
+		})
 	}
 }
 

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -86,8 +86,14 @@ func (m *chatModel) updateViewport() {
 		content = padding + content
 	}
 
+	// Only auto-follow when the user is already pinned at the bottom. If they've
+	// scrolled up to read earlier messages, leave their position alone — otherwise
+	// the next delta or spinner tick would yank them back down.
+	wasAtBottom := m.viewport.AtBottom()
 	m.viewport.SetContent(content)
-	m.viewport.GotoBottom()
+	if wasAtBottom {
+		m.viewport.GotoBottom()
+	}
 }
 
 // narrowBodyMinWidth is the minimum body column width below which the inline

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
 func TestFormatCost(t *testing.T) {
@@ -241,6 +244,108 @@ func TestUpdateViewport_BottomAnchoring(t *testing.T) {
 
 	if len(m.viewport.View()) == 0 {
 		t.Error("viewport content should not be empty")
+	}
+}
+
+func TestUpdateViewport_PreservesScrollWhenUserScrolledUp(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(5)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+	}
+	for i := 0; i < 30; i++ {
+		m.messages = append(m.messages, chatMessage{role: "user", content: "filler line"})
+	}
+	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.updateViewport()
+
+	m.viewport.SetYOffset(0)
+	if m.viewport.AtBottom() {
+		t.Fatalf("precondition: viewport should not be at bottom after scrolling up")
+	}
+	scrolledOffset := m.viewport.YOffset()
+
+	last := &m.messages[len(m.messages)-1]
+	last.content = "incoming delta text"
+	last.awaitingDelta = false
+	m.updateViewport()
+
+	if got := m.viewport.YOffset(); got != scrolledOffset {
+		t.Errorf("scroll position should be preserved while user is scrolled up: got YOffset=%d, want %d", got, scrolledOffset)
+	}
+}
+
+func TestUpdate_MouseWheelScrollSurvivesStreamingDeltas(t *testing.T) {
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.viewport.SetWidth(80)
+	m.viewport.SetHeight(5)
+	for i := 0; i < 30; i++ {
+		m.messages = append(m.messages, chatMessage{role: "user", content: "filler line"})
+	}
+	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.updateViewport()
+
+	if !m.viewport.AtBottom() {
+		t.Fatalf("precondition: should start pinned at bottom")
+	}
+
+	wheelUp := tea.MouseWheelMsg{Button: tea.MouseWheelUp}
+	m, _ = m.Update(wheelUp)
+	if m.viewport.AtBottom() {
+		t.Fatalf("after MouseWheelUp the viewport should no longer be at bottom; YOffset=%d", m.viewport.YOffset())
+	}
+	scrolledOffset := m.viewport.YOffset()
+
+	last := &m.messages[len(m.messages)-1]
+	for i, deltaText := range []string{"a", "a b", "a b c", "a b c d"} {
+		last.content = deltaText
+		last.awaitingDelta = false
+		m.updateViewport()
+		if got := m.viewport.YOffset(); got != scrolledOffset {
+			t.Errorf("delta %d (%q): YOffset=%d, want %d (user should remain scrolled up)", i, deltaText, got, scrolledOffset)
+		}
+	}
+
+	tick := spinnerTickMsg{}
+	m.spinnerTicking = true
+	m, _ = m.Update(tick)
+	if got := m.viewport.YOffset(); got != scrolledOffset {
+		t.Errorf("spinner tick reset scroll: YOffset=%d, want %d", got, scrolledOffset)
+	}
+}
+
+func TestUpdateViewport_FollowsBottomWhenPinned(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(5)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+	}
+	for i := 0; i < 30; i++ {
+		m.messages = append(m.messages, chatMessage{role: "user", content: "filler line"})
+	}
+	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.updateViewport()
+
+	if !m.viewport.AtBottom() {
+		t.Fatalf("precondition: viewport should be at bottom after initial render")
+	}
+
+	last := &m.messages[len(m.messages)-1]
+	last.content = strings.Repeat("delta line\n", 10)
+	last.awaitingDelta = false
+	m.updateViewport()
+
+	if !m.viewport.AtBottom() {
+		t.Errorf("viewport should follow new content to bottom when user was pinned at bottom")
 	}
 }
 


### PR DESCRIPTION
Fixes scroll being yanked back to the bottom while a response is streaming, and stops the completion bell from firing when the terminal is already focused.

## Summary
- Closes #70 — `updateViewport` now only calls `GotoBottom()` when the user was already pinned at the bottom, so trackpad/keyboard scrolling holds during deltas and spinner ticks.
- Enable focus reporting (`v.ReportFocus`) and route `tea.FocusMsg` / `tea.BlurMsg` into a new `chatModel.terminalFocused` flag.
- Gate the completion bell behind `shouldRingBell()` so it only rings when the pref is on **and** the terminal is blurred — matching the original "look back at me" intent.
- Tests added: scroll preservation across deltas and a wheel-driven `Update` cycle, follow-to-bottom when pinned, and a table covering all four pref/focus combinations for the bell.

## Implementation details
`terminalFocused` defaults to `true` in `newChatModel` because terminals are normally focused at startup and bubbletea does not emit a synthetic `FocusMsg` on launch — without that default the first response after launch would always ring the bell.