### PR TITLE
feat(tui): display tool call status as inline cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Streaming responses, conversation history, and multi-agent support**
 - **Create and delete agents** directly from the TUI — gateway-managed for OpenClaw, or local `IDENTITY.md` + `SOUL.md` markdown for OpenAI-compatible backends. Delete is type-the-name to confirm, with an optional "keep files" toggle so you can drop the listing without nuking the content. Hermes profiles are configured server-side via `hermes profile create`
 - **Markdown rendering** for assistant messages
+- **Tool call cards** — when the agent invokes a tool, an inline card shows what's running, what arguments it got, and whether it succeeded or failed (OpenClaw)
 - **Shell commands** — run locally with `!` or remotely on the gateway with `!!`
 - **Message queueing** so you can keep typing while the agent is responding
 - **Local agent skills** loaded from `~/.agents/skills/` as slash commands
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
+- **Cron browser** — list, edit, run, and create scheduled jobs without leaving the terminal (OpenClaw)
 
 ## Install
 
@@ -117,8 +119,9 @@ Use `/config` to open the preferences view. Settings are persisted to `~/.lucina
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| Completion notification | On | Ring the terminal bell when a response completes |
+| Completion notification | On | Ring the terminal bell when a response completes (only if the terminal isn't focused) |
 | History limit | 50 | Number of messages loaded when restoring a session (range 10–500) |
+| Connect timeout | 15s | Per-attempt deadline for the initial connect and each reconnect (range 5–300s — bump it for slow local LLMs) |
 
 In the config view, use `Space` to toggle checkboxes and `←`/`→` to adjust numeric values.
 
@@ -130,6 +133,7 @@ Type these in the chat input. Tab autocompletes partial commands.
 |---------|--------|
 | `/help` | Show available commands |
 | `/agents` | Return to agent picker |
+| `/cancel` | Cancel the in-progress response (also: `Esc`) |
 | `/clear` | Clear chat display |
 | `/compact` | Compact session context (with confirmation) — OpenClaw only |
 | `/config` | Open preferences |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -55,6 +55,10 @@ The connection-status badge is rendered in the error colour and only appears whe
 
 A matching one-line system message is also added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. See [authentication.md](authentication.md#reconnect-after-disconnection) for the full lifecycle.
 
+## Tool call cards
+
+When the agent invokes a tool, an inline status card appears in the scrollback between assistant messages — name, one-line argument summary, and a state glyph that animates while running and resolves to ✓ or ✖. Lucinate opts into the `tool-events` capability on connect; backends without tool events (e.g. the OpenAI-compatible adapter) simply never emit them. Tool output bodies are not yet expandable — see [message-rendering.md](message-rendering.md#tool-call-cards) for the rendering contract and the open follow-up for an expand/collapse affordance.
+
 ## History depth
 
 The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/config` ("History limit") in steps of 10 (range 10–500). The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -63,7 +63,13 @@ When the agent invokes a tool, an inline status card appears in the scrollback b
 
 The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/config` ("History limit") in steps of 10 (range 10–500). The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
 
+When restored history is non-empty, a dimmed separator row is rendered above the new turn, labelled with the relative time of the most recent restored message (`Resumed from 2h ago`, `…`). The label comes from `formatSeparatorLabel` (`render.go`), driven by the `timestampMs` field on the synthetic separator `chatMessage`. See [message-rendering.md](message-rendering.md#message-roles) for the role.
+
 See [sessions.md](sessions.md#lifecycle) for how history loading fits into the session lifecycle.
+
+## Connect timeout
+
+Each (re)connect attempt has a per-attempt deadline applied to the WebSocket / HTTP handshake. The default is 15 seconds; the range is 5–300 seconds via `/config` ("Connect timeout"). The configured value is loaded by `app.DefaultBackendFactory` (`app/factory.go`) for every backend dispatch, so the same setting governs the initial connect and the supervisor's reconnect attempts. Bump it when targeting a slow local LLM that cold-starts on first request.
 
 ## Scrolling
 

--- a/docs/message-rendering.md
+++ b/docs/message-rendering.md
@@ -7,6 +7,7 @@ Each chat message has a role that determines how it is displayed in the TUI:
 - `user` — sent by the local user; shown right-aligned.
 - `assistant` — returned by the agent; rendered as markdown via Glamour.
 - `system` — local-only notices (errors, status, command output); shown in a muted style and never sent to the gateway.
+- `tool` — inline status card for an in-flight or completed tool call from the agent. See [Tool call cards](#tool-call-cards).
 
 ## The System: prefix convention
 
@@ -36,6 +37,30 @@ When session history is fetched from the gateway, each user message may contain 
 Assistant messages are conditionally rendered with Glamour. `looksLikeMarkdown()` in `internal/tui/history.go` checks for code fences, bold markers, pipe tables, list prefixes, headings, and numbered lists. If none are found the text is shown as plain text, avoiding unwanted paragraph indentation on short replies.
 
 The Glamour renderer is created in `setSize()` with a wrap width equal to the terminal width minus 4. `wordWrap()` in `render.go` is applied after rendering and preserves lines containing box-drawing characters (table borders) so they are not split.
+
+## Tool call cards
+
+When the agent invokes a tool, lucinate renders a single-line status card inline in the chat scrollback so the user can see what's running. Cards are driven by `agent` events with `stream == "tool"` from the gateway — declared via the `tool-events` capability on connect (see `internal/client/client.go`).
+
+Each card shows a state glyph, the tool name in bold, and a one-line argument summary:
+
+```
+⠋ search (query="hello world")
+✓ search (query="hello world")
+✖ read (path="/missing") — file not found
+```
+
+The state glyph cycles through the same braille spinner as the streaming cursor (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) while the tool is running, then flips to `✓` on success or `✖` on error. Errors append a one-line message extracted from the tool result.
+
+The mapping from event payload to card lives in `handleAgentEvent` (`internal/tui/events.go`):
+
+- `phase: "start"` — freezes any currently streaming assistant row, then appends a new `chatMessage` with `role: "tool"` and `toolState: "running"`. If the streaming assistant is still the empty pre-delta placeholder, it's dropped instead of frozen so we don't render a blank assistant block above the card.
+- `phase: "update"` — currently a no-op. Partial result streaming is deferred (see issue for expand/collapse output).
+- `phase: "result"` — finds the matching tool row by `toolCallId` and flips `toolState` to `"success"` or `"error"`.
+
+The `summariseArgs` helper picks a human-readable key from the args object (priority order: `command`, `path`, `file`, `filePath`, `query`, `url`, `name`, `message`, `text`) or falls back to compact JSON, truncated to 80 runes.
+
+The full output of a tool call is not currently rendered; only the header line is. An expand/collapse affordance similar to the official OpenClaw TUI's Ctrl+O is tracked separately.
 
 ## Streaming placeholder
 

--- a/docs/message-rendering.md
+++ b/docs/message-rendering.md
@@ -7,6 +7,7 @@ Each chat message has a role that determines how it is displayed in the TUI:
 - `user` — sent by the local user; shown right-aligned.
 - `assistant` — returned by the agent; rendered as markdown via Glamour.
 - `system` — local-only notices (errors, status, command output); shown in a muted style and never sent to the gateway.
+- `separator` — a dim divider row inserted between restored history and a new turn; labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`). The `timestampMs` field on `chatMessage` carries the unix-ms used by `formatSeparatorLabel`.
 - `tool` — inline status card for an in-flight or completed tool call from the agent. See [Tool call cards](#tool-call-cards).
 
 ## The System: prefix convention

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -195,6 +195,7 @@ func (c *Client) buildOptions() ([]gateway.Option, error) {
 		}),
 		gateway.WithRole(protocol.RoleOperator),
 		gateway.WithScopes(protocol.ScopeOperatorRead, protocol.ScopeOperatorWrite, protocol.ScopeOperatorAdmin, protocol.ScopeOperatorApprovals),
+		gateway.WithCaps(protocol.ClientCapToolEvents),
 		gateway.WithOnEvent(func(ev protocol.Event) {
 			select {
 			case c.events <- ev:

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -125,10 +125,15 @@ func spinnerTickCmd() tea.Cmd {
 	})
 }
 
-// hasStreamingMessage reports whether any assistant message is still streaming.
+// hasStreamingMessage reports whether any assistant message is still streaming
+// or a tool is in the running state. The spinner tick keeps firing as long as
+// either is true so both the streaming cursor and the tool-card glyph animate.
 func (m *chatModel) hasStreamingMessage() bool {
 	for i := range m.messages {
 		if m.messages[i].streaming {
+			return true
+		}
+		if m.messages[i].role == "tool" && m.messages[i].toolState == "running" {
 			return true
 		}
 	}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -21,6 +21,29 @@ type chatContentBlock struct {
 	Text string `json:"text"`
 }
 
+// toolEventData is the shape of the AgentEvent.Data map for stream=="tool"
+// events. The openclaw-go SDK ships ClientCapToolEvents but no typed payload
+// for the tool lifecycle, so this lives here until the SDK gains one.
+type toolEventData struct {
+	Phase      string          `json:"phase"` // "start", "update", "result"
+	Name       string          `json:"name"`
+	ToolCallID string          `json:"toolCallId"`
+	Args       json.RawMessage `json:"args,omitempty"`
+	Result     json.RawMessage `json:"result,omitempty"`
+	IsError    bool            `json:"isError,omitempty"`
+}
+
+// toolResultPayload mirrors the gateway's ToolResult shape just enough to
+// pull a one-line error message out of a failed tool result. Full output
+// rendering is intentionally deferred — see the "expand/collapse" follow-up
+// issue.
+type toolResultPayload struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
 // extractThinkingFromMessage parses the Message field and extracts thinking blocks.
 // Only final events carry structured content blocks; delta events are plain strings.
 func extractThinkingFromMessage(raw json.RawMessage) string {
@@ -143,6 +166,9 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		}
 		m.updateViewport()
 		return m.drainQueueSkipRefresh()
+
+	case protocol.EventAgent:
+		return m.handleAgentEvent(ev)
 	}
 
 	if ev.EventName != protocol.EventChat {
@@ -279,4 +305,168 @@ func bellCmd() tea.Cmd {
 		_, _ = os.Stdout.Write([]byte("\a"))
 		return nil
 	}
+}
+
+// handleAgentEvent processes an "agent" event frame. Only the tool-stream
+// lifecycle is consumed for now (start/result phases) — other streams
+// (lifecycle, item, approval) are ignored and may be wired up later.
+func (m *chatModel) handleAgentEvent(ev protocol.Event) tea.Cmd {
+	var agentEv protocol.AgentEvent
+	if err := json.Unmarshal(ev.Payload, &agentEv); err != nil {
+		logEvent("AGENT parse error: %v", err)
+		return nil
+	}
+	if agentEv.Stream != "tool" {
+		return nil
+	}
+
+	// AgentEvent.Data is map[string]any; round-trip through JSON to get a
+	// typed view.
+	rawData, err := json.Marshal(agentEv.Data)
+	if err != nil {
+		logEvent("TOOL marshal data error: %v", err)
+		return nil
+	}
+	var td toolEventData
+	if err := json.Unmarshal(rawData, &td); err != nil {
+		logEvent("TOOL parse error: %v", err)
+		return nil
+	}
+	if td.ToolCallID == "" {
+		return nil
+	}
+	logEvent("TOOL phase=%s name=%s id=%s isErr=%v", td.Phase, td.Name, td.ToolCallID, td.IsError)
+
+	switch td.Phase {
+	case "start":
+		// Freeze any currently streaming assistant message so subsequent
+		// chat deltas land on a fresh row after the tool card. Drop the
+		// pre-delta placeholder if it never received any text — leaving an
+		// empty assistant block above the tool card looks broken.
+		if len(m.messages) > 0 {
+			last := &m.messages[len(m.messages)-1]
+			if last.role == "assistant" && last.streaming {
+				if last.awaitingDelta && last.content == "" {
+					m.messages = m.messages[:len(m.messages)-1]
+				} else {
+					last.streaming = false
+					last.awaitingDelta = false
+				}
+			}
+		}
+		name := td.Name
+		if name == "" {
+			name = "tool"
+		}
+		m.messages = append(m.messages, chatMessage{
+			role:         "tool",
+			toolName:     name,
+			toolCallID:   td.ToolCallID,
+			toolArgsLine: summariseArgs(td.Args),
+			toolState:    "running",
+		})
+		m.updateViewport()
+		return m.ensureSpinnerTicking()
+
+	case "update":
+		// Partial results are ignored in this pass; the running glyph keeps
+		// ticking and the final phase resolves the card. See the
+		// expand/collapse follow-up for full output rendering.
+		return nil
+
+	case "result":
+		for i := range m.messages {
+			if m.messages[i].role != "tool" {
+				continue
+			}
+			if m.messages[i].toolCallID != td.ToolCallID {
+				continue
+			}
+			if td.IsError {
+				m.messages[i].toolState = "error"
+				m.messages[i].toolError = extractToolErrorText(td.Result)
+			} else {
+				m.messages[i].toolState = "success"
+			}
+			break
+		}
+		m.updateViewport()
+		return nil
+	}
+	return nil
+}
+
+// summariseArgs produces a short single-line preview of a tool's arguments.
+// For common shapes ({command:"..."}, {path:"..."}, {query:"..."}, ...) it
+// pulls the most useful key. Otherwise it falls back to compact JSON,
+// truncated.
+func summariseArgs(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return truncateForArgs(strings.TrimSpace(string(raw)))
+	}
+	// Prefer human-readable keys in priority order.
+	for _, key := range []string{"command", "path", "file", "filePath", "query", "url", "name", "message", "text"} {
+		if v, ok := obj[key]; ok {
+			s := unmarshalString(v)
+			if s == "" {
+				continue
+			}
+			return truncateForArgs(fmt.Sprintf("%s=%q", key, s))
+		}
+	}
+	// Fall back to compact JSON.
+	compact, err := json.Marshal(obj)
+	if err != nil {
+		return truncateForArgs(strings.TrimSpace(string(raw)))
+	}
+	return truncateForArgs(string(compact))
+}
+
+// unmarshalString tries to interpret raw as a JSON string. Returns the
+// string value, or an empty string if raw is not a string.
+func unmarshalString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return ""
+}
+
+// truncateForArgs limits the args summary to a single line, capped at
+// 80 runes with an ellipsis.
+func truncateForArgs(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	const max = 80
+	runes := []rune(s)
+	if len(runes) > max {
+		s = string(runes[:max-1]) + "…"
+	}
+	return s
+}
+
+// extractToolErrorText pulls a one-line error message out of a failed tool
+// result. The gateway nests error text under content[].text — fall back to
+// the raw JSON if the shape doesn't match.
+func extractToolErrorText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var payload toolResultPayload
+	if err := json.Unmarshal(raw, &payload); err == nil {
+		var parts []string
+		for _, c := range payload.Content {
+			if c.Type == "text" && c.Text != "" {
+				parts = append(parts, c.Text)
+			}
+		}
+		if joined := strings.TrimSpace(strings.Join(parts, " ")); joined != "" {
+			return truncateForArgs(joined)
+		}
+	}
+	return truncateForArgs(strings.TrimSpace(string(raw)))
 }

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -1349,3 +1349,181 @@ func TestFormatDuration_Hours(t *testing.T) {
 		t.Errorf("expected '1h1m', got %q", got)
 	}
 }
+
+// makeAgentToolEvent builds an "agent" event frame carrying a stream:"tool"
+// payload with the given phase and data fields.
+func makeAgentToolEvent(phase, name, toolCallID string, args, result json.RawMessage, isError bool) protocol.Event {
+	data := map[string]any{
+		"phase":      phase,
+		"name":       name,
+		"toolCallId": toolCallID,
+	}
+	if len(args) > 0 {
+		data["args"] = args
+	}
+	if len(result) > 0 {
+		data["result"] = result
+	}
+	if isError {
+		data["isError"] = true
+	}
+	agentEv := protocol.AgentEvent{
+		RunID:  "run1",
+		Stream: "tool",
+		Seq:    1,
+		Data:   data,
+	}
+	payload, _ := json.Marshal(agentEv)
+	return protocol.Event{EventName: protocol.EventAgent, Payload: payload}
+}
+
+func TestHandleAgentEvent_ToolStartFreezesStreamingAndAppendsCard(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{
+		{role: "user", content: "search please"},
+		{role: "assistant", content: "Sure, searching", streaming: true},
+	}
+
+	m.handleEvent(makeAgentToolEvent("start", "search", "tc-1",
+		json.RawMessage(`{"query":"hello"}`), nil, false))
+
+	if len(m.messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(m.messages))
+	}
+	if m.messages[1].streaming {
+		t.Error("expected streaming assistant to be frozen on tool start")
+	}
+	tool := m.messages[2]
+	if tool.role != "tool" {
+		t.Fatalf("expected role=tool, got %q", tool.role)
+	}
+	if tool.toolName != "search" {
+		t.Errorf("toolName = %q, want %q", tool.toolName, "search")
+	}
+	if tool.toolCallID != "tc-1" {
+		t.Errorf("toolCallID = %q, want %q", tool.toolCallID, "tc-1")
+	}
+	if tool.toolState != "running" {
+		t.Errorf("toolState = %q, want running", tool.toolState)
+	}
+	if !strings.Contains(tool.toolArgsLine, "query") || !strings.Contains(tool.toolArgsLine, "hello") {
+		t.Errorf("toolArgsLine = %q, want it to mention query=hello", tool.toolArgsLine)
+	}
+}
+
+func TestHandleAgentEvent_ToolStartDropsEmptyPlaceholder(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{
+		{role: "user", content: "hi"},
+		{role: "assistant", streaming: true, awaitingDelta: true},
+	}
+
+	m.handleEvent(makeAgentToolEvent("start", "search", "tc-1", nil, nil, false))
+
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages (user + tool), got %d", len(m.messages))
+	}
+	if m.messages[1].role != "tool" {
+		t.Errorf("expected the empty placeholder to be replaced by a tool row, got %q", m.messages[1].role)
+	}
+}
+
+func TestHandleAgentEvent_ToolResultSuccessFlipsState(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{
+		{role: "tool", toolName: "search", toolCallID: "tc-1", toolState: "running"},
+	}
+
+	m.handleEvent(makeAgentToolEvent("result", "search", "tc-1", nil,
+		json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`), false))
+
+	if m.messages[0].toolState != "success" {
+		t.Errorf("toolState = %q, want success", m.messages[0].toolState)
+	}
+	if m.messages[0].toolError != "" {
+		t.Errorf("toolError = %q, want empty on success", m.messages[0].toolError)
+	}
+}
+
+func TestHandleAgentEvent_ToolResultErrorCarriesMessage(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{
+		{role: "tool", toolName: "read", toolCallID: "tc-2", toolState: "running"},
+	}
+
+	result := json.RawMessage(`{"content":[{"type":"text","text":"file not found: /nope"}]}`)
+	m.handleEvent(makeAgentToolEvent("result", "read", "tc-2", nil, result, true))
+
+	if m.messages[0].toolState != "error" {
+		t.Errorf("toolState = %q, want error", m.messages[0].toolState)
+	}
+	if !strings.Contains(m.messages[0].toolError, "file not found") {
+		t.Errorf("toolError = %q, want it to mention 'file not found'", m.messages[0].toolError)
+	}
+}
+
+func TestHandleAgentEvent_NonToolStreamIgnored(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{
+		{role: "assistant", content: "thinking", streaming: true},
+	}
+
+	agentEv := protocol.AgentEvent{
+		RunID:  "run1",
+		Stream: "lifecycle",
+		Data:   map[string]any{"phase": "start"},
+	}
+	payload, _ := json.Marshal(agentEv)
+	m.handleEvent(protocol.Event{EventName: protocol.EventAgent, Payload: payload})
+
+	if len(m.messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(m.messages))
+	}
+	if !m.messages[0].streaming {
+		t.Error("non-tool agent stream should not freeze the streaming assistant")
+	}
+}
+
+func TestSummariseArgs_PrefersCommonKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"command", `{"command":"ls -la","cwd":"/tmp"}`, `command="ls -la"`},
+		{"path", `{"path":"/etc/hosts"}`, `path="/etc/hosts"`},
+		{"query", `{"query":"hello"}`, `query="hello"`},
+		{"url", `{"url":"https://example.com"}`, `url="https://example.com"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := summariseArgs(json.RawMessage(tc.raw))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummariseArgs_FallsBackToCompactJSON(t *testing.T) {
+	got := summariseArgs(json.RawMessage(`{"foo":1,"bar":"baz"}`))
+	// Order of keys in map iteration is non-deterministic; just check both
+	// keys appear and the result is one line.
+	if !strings.Contains(got, "foo") || !strings.Contains(got, "bar") {
+		t.Errorf("got %q, want it to contain both keys", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("got multi-line summary %q", got)
+	}
+}
+
+func TestSummariseArgs_TruncatesLongValues(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	got := summariseArgs(json.RawMessage(`{"command":"` + long + `"}`))
+	if n := len([]rune(got)); n > 80 {
+		t.Errorf("summary not truncated: runes=%d, value=%q", n, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected truncation ellipsis at end, got %q", got)
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -10,7 +10,7 @@ import (
 
 // chatMessage represents a single message in the conversation.
 type chatMessage struct {
-	role          string // "user", "assistant", "system", or "separator"
+	role          string // "user", "assistant", "system", "separator", or "tool"
 	content       string
 	raw           string // original markdown source when rendered is true; used to re-render on resize
 	thinking      string // reasoning/intermediate thought content from the model
@@ -19,6 +19,13 @@ type chatMessage struct {
 	errMsg        string
 	rendered      bool  // true if content has been glamour-rendered (contains ANSI codes)
 	timestampMs   int64 // unix millis; only used by "separator" rows to label resume time
+
+	// Tool fields populated only when role == "tool".
+	toolName     string
+	toolCallID   string
+	toolArgsLine string // single-line summary of the tool arguments
+	toolState    string // "running", "success", "error"
+	toolError    string // human-readable detail when toolState == "error"
 }
 
 // sessionStats holds token usage stats for display.

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -65,6 +65,9 @@ func (m *chatModel) updateViewport() {
 			} else {
 				b.WriteString(statusStyle.Render(wordWrap(msg.content, contentWidth)))
 			}
+
+		case "tool":
+			b.WriteString(m.renderToolCard(msg, contentWidth))
 		}
 	}
 
@@ -352,4 +355,44 @@ func buildSeparator(width int, label string) string {
 // word-wrapped as it would destroy their alignment.
 func isTableLine(line string) bool {
 	return strings.ContainsRune(line, '│') || strings.ContainsRune(line, '─')
+}
+
+// renderToolCard renders a single inline tool-status line. Running cards
+// animate via the shared spinner frame; success and error states use static
+// glyphs.
+func (m *chatModel) renderToolCard(msg chatMessage, contentWidth int) string {
+	var glyph string
+	var lineStyle lipgloss.Style
+	switch msg.toolState {
+	case "success":
+		glyph = "✓"
+		lineStyle = toolSuccessStyle
+	case "error":
+		glyph = "✖"
+		lineStyle = errorStyle
+	default:
+		glyph = spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+		lineStyle = toolRunningStyle
+	}
+
+	name := msg.toolName
+	if name == "" {
+		name = "tool"
+	}
+
+	var head strings.Builder
+	head.WriteString(glyph)
+	head.WriteString(" ")
+	head.WriteString(toolNameStyle.Render(name))
+	if msg.toolArgsLine != "" {
+		head.WriteString(" ")
+		head.WriteString("(")
+		head.WriteString(msg.toolArgsLine)
+		head.WriteString(")")
+	}
+	if msg.toolState == "error" && msg.toolError != "" {
+		head.WriteString(" — ")
+		head.WriteString(msg.toolError)
+	}
+	return lineStyle.Render(wordWrap(head.String(), contentWidth))
 }

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -497,6 +497,75 @@ func TestLastTimestampMs(t *testing.T) {
 	}
 }
 
+func TestRenderToolCard_Running(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(10)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "tool", toolName: "search", toolCallID: "tc1", toolArgsLine: `query="hello"`, toolState: "running"},
+		},
+	}
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+	if !strings.Contains(view, "search") {
+		t.Errorf("rendered view missing tool name: %q", view)
+	}
+	if !strings.Contains(view, `query="hello"`) {
+		t.Errorf("rendered view missing args summary: %q", view)
+	}
+	if !strings.Contains(view, spinnerFrames[0]) {
+		t.Errorf("running tool card should render the spinner frame, got: %q", view)
+	}
+}
+
+func TestRenderToolCard_Success(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(10)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "tool", toolName: "search", toolCallID: "tc1", toolState: "success"},
+		},
+	}
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+	if !strings.Contains(view, "✓") {
+		t.Errorf("success tool card should render ✓, got: %q", view)
+	}
+	if !strings.Contains(view, "search") {
+		t.Errorf("rendered view missing tool name: %q", view)
+	}
+}
+
+func TestRenderToolCard_Error(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(10)
+	m := &chatModel{
+		viewport:  vp,
+		width:     80,
+		agentName: "main",
+		messages: []chatMessage{
+			{role: "tool", toolName: "read", toolCallID: "tc1", toolState: "error", toolError: "file not found"},
+		},
+	}
+	m.updateViewport()
+	view := ansi.Strip(m.viewport.View())
+	if !strings.Contains(view, "✖") {
+		t.Errorf("error tool card should render ✖, got: %q", view)
+	}
+	if !strings.Contains(view, "file not found") {
+		t.Errorf("error tool card should include error detail, got: %q", view)
+	}
+}
+
 func TestNarrowLayout_Threshold(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -106,4 +106,14 @@ var (
 	// folds the same info into its own header bar.
 	connBannerStyle = lipgloss.NewStyle().
 			Foreground(subtle)
+
+	// Tool-card styles. Running reuses the muted status colour; success
+	// borrows the local-exec green so the visual language matches "this
+	// finished cleanly"; error falls through to errorStyle.
+	toolRunningStyle = lipgloss.NewStyle().
+				Foreground(subtle)
+	toolSuccessStyle = lipgloss.NewStyle().
+				Foreground(localExcClr)
+	toolNameStyle = lipgloss.NewStyle().
+			Bold(true)
 )


### PR DESCRIPTION
Render agent tool calls as inline status cards in the chat scrollback so the user can see what the agent is doing.

## Summary
- Declare the `tool-events` capability on connect (`gateway.WithCaps(protocol.ClientCapToolEvents)`) so the gateway routes the agent's tool stream to lucinate.
- Handle `agent` events with `stream == "tool"`: append a `tool` chat row on `phase: "start"`, freeze the streaming assistant so subsequent deltas land below the card, then flip the row to ✓ / ✖ on `phase: "result"`.
- New single-line card layout: state glyph + bold tool name + one-line argument summary, with the running glyph reusing the chat spinner cycle. `summariseArgs` prefers human-readable keys (`command`, `path`, `query`, `url`, `name`, `message`, `text`) before falling back to truncated compact JSON.
- Docs updated in `docs/message-rendering.md` and `docs/chat-ux.md`.
- Tool output expand/collapse (the official TUI's Ctrl+O affordance) is intentionally deferred and tracked in #90.

## Implementation details
The openclaw-go SDK exposes the `ClientCapToolEvents` constant but ships no typed payload struct, so `toolEventData` and `toolResultPayload` are defined locally in `internal/tui/events.go`. The shape mirrors the gateway emitter (`gateway/src/agents/pi-embedded-subscribe.handlers.tools.ts`). When the SDK ships typed structs, the local types should be replaced.

The card is keyed by `toolCallId`, so the result-phase update finds the right row even when multiple tools run in the same turn. If a tool starts before any assistant delta has arrived, the empty pre-delta placeholder is dropped (rather than frozen) so we don't render an empty assistant block above the card.

Closes #46.