### PR TITLE
feat(tui): show pairing instructions on NOT_PAIRED connect

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -702,6 +702,8 @@ func runConnect(conn *config.Connection, b backend.Backend, timeout time.Duratio
 	defer cancel()
 	if err := b.Connect(ctx); err != nil {
 		switch {
+		case isNotPairedErr(err):
+			return connectResultMsg{connection: conn, backend: b, authNeed: authRecoveryNotPaired, err: err}
 		case isTokenMismatchErr(err):
 			return connectResultMsg{connection: conn, backend: b, authNeed: authRecoveryTokenMismatch, err: err}
 		case isTokenMissingErr(err):
@@ -722,6 +724,14 @@ func isTokenMismatchErr(err error) bool {
 
 func isTokenMissingErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "gateway token missing")
+}
+
+// isNotPairedErr matches the gateway's NOT_PAIRED rejection. The
+// openclaw-go SDK formats hello rejections as
+// "connect rejected: NOT_PAIRED: pairing required", so the code is
+// the most reliable substring to look for.
+func isNotPairedErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "NOT_PAIRED")
 }
 
 // isAPIKeyErr matches the error string the OpenAI-compat backend emits

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,14 +1,30 @@
 package tui
 
 import (
+	"errors"
 	"runtime"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
+
+func TestRunConnect_RoutesNotPairedToPairingModal(t *testing.T) {
+	conn := &config.Connection{Name: "home"}
+	fake := newFakeBackend()
+	fake.connectErr = errors.New("connect: hello: connect rejected: NOT_PAIRED: pairing required")
+
+	res := runConnect(conn, fake, time.Second)
+	if res.authNeed != authRecoveryNotPaired {
+		t.Fatalf("authNeed = %v, want authRecoveryNotPaired", res.authNeed)
+	}
+	if res.backend != fake {
+		t.Error("expected backend to be retained on NOT_PAIRED so retry can reuse it")
+	}
+}
 
 func TestComputeWantsInput(t *testing.T) {
 	cases := []struct {

--- a/internal/tui/connecting.go
+++ b/internal/tui/connecting.go
@@ -22,6 +22,7 @@ const (
 	subStateDialing connectingSubState = iota
 	subStateAuthMismatchPrompt
 	subStateAuthTokenPrompt
+	subStatePairingRequired
 )
 
 // connectingModel handles the in-progress connect attempt and the
@@ -75,6 +76,8 @@ func (m *connectingModel) enterAuthModal(conn *config.Connection, b backend.Back
 		ti.CharLimit = 512
 		ti.Focus()
 		m.tokenInput = ti
+	case authRecoveryNotPaired:
+		m.subState = subStatePairingRequired
 	}
 }
 
@@ -96,6 +99,23 @@ func (m connectingModel) Update(msg tea.Msg) (connectingModel, tea.Cmd) {
 
 func (m connectingModel) handleKey(msg tea.KeyPressMsg) (connectingModel, tea.Cmd) {
 	switch m.subState {
+	case subStatePairingRequired:
+		switch msg.String() {
+		case "enter", "r":
+			b := m.backend
+			conn := m.connection
+			return m, func() tea.Msg {
+				return authResolvedMsg{connection: conn, backend: b}
+			}
+		case "esc", "q":
+			b := m.backend
+			conn := m.connection
+			return m, func() tea.Msg {
+				return authResolvedMsg{connection: conn, backend: b, cancelled: true}
+			}
+		}
+		return m, nil
+
 	case subStateAuthMismatchPrompt:
 		switch msg.String() {
 		case "1", "enter":
@@ -192,6 +212,11 @@ func (m connectingModel) Actions() []Action {
 		return []Action{
 			{ID: "auth-cancel", Label: "Cancel", Key: "esc"},
 		}
+	case subStatePairingRequired:
+		return []Action{
+			{ID: "pairing-retry", Label: "Retry", Key: "enter"},
+			{ID: "auth-cancel", Label: "Cancel", Key: "esc"},
+		}
 	}
 	return nil
 }
@@ -204,6 +229,8 @@ func (m connectingModel) TriggerAction(id string) (connectingModel, tea.Cmd) {
 		return m.handleKey(tea.KeyPressMsg{Code: '1', Text: "1"})
 	case "auth-reset-identity":
 		return m.handleKey(tea.KeyPressMsg{Code: '2', Text: "2"})
+	case "pairing-retry":
+		return m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 	case "auth-cancel":
 		return m.handleKey(tea.KeyPressMsg{Code: tea.KeyEsc})
 	}
@@ -227,6 +254,8 @@ func (m connectingModel) View() string {
 		return m.viewAuthMismatch()
 	case subStateAuthTokenPrompt:
 		return m.viewAuthToken()
+	case subStatePairingRequired:
+		return m.viewPairingRequired()
 	}
 	name := "gateway"
 	if m.connection != nil {
@@ -248,6 +277,26 @@ func (m connectingModel) viewAuthMismatch() string {
 	b.WriteString("  1) Clear stored token and retry  (recommended)\n")
 	b.WriteString("  2) Reset full identity and retry\n")
 	b.WriteString("  Esc) Cancel\n")
+	return b.String()
+}
+
+func (m connectingModel) viewPairingRequired() string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(headerStyle.Render(" Pairing required "))
+	b.WriteString("\n\n")
+	if m.authErr != nil {
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  %v", m.authErr)))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("  This device hasn't been paired with the gateway yet.\n")
+	b.WriteString("  An administrator must approve it before you can connect.\n\n")
+	b.WriteString("  On the gateway host, run:\n\n")
+	b.WriteString("    openclaw devices approve --latest\n\n")
+	b.WriteString("  This previews the pending request and prints the exact\n")
+	b.WriteString("  approve command. Run that command, then press Enter to retry.\n\n")
+	b.WriteString(helpStyle.Render("  Enter: retry | Esc: cancel"))
+	b.WriteString("\n")
 	return b.String()
 }
 

--- a/internal/tui/connecting.go
+++ b/internal/tui/connecting.go
@@ -286,7 +286,9 @@ func (m connectingModel) viewPairingRequired() string {
 	b.WriteString(headerStyle.Render(" Pairing required "))
 	b.WriteString("\n\n")
 	if m.authErr != nil {
-		b.WriteString(errorStyle.Render(fmt.Sprintf("  %v", m.authErr)))
+		wrapped := wordWrap(m.authErr.Error(), max(m.width-2, 20))
+		b.WriteString("  ")
+		b.WriteString(errorStyle.Render(indentMultiline(wrapped, "  ")))
 		b.WriteString("\n\n")
 	}
 	b.WriteString("  This device hasn't been paired with the gateway yet.\n")

--- a/internal/tui/connecting_test.go
+++ b/internal/tui/connecting_test.go
@@ -152,6 +152,70 @@ func TestConnectingModel_TokenPromptIgnoresEmpty(t *testing.T) {
 	}
 }
 
+func TestConnectingModel_PairingRequiredShowsInstructions(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	m := newConnectingModel(conn, false)
+	m.enterAuthModal(conn, nil, authRecoveryNotPaired, errors.New("connect: hello: connect rejected: NOT_PAIRED: pairing required"))
+
+	if m.subState != subStatePairingRequired {
+		t.Fatalf("subState = %v, want pairing-required", m.subState)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Pairing required") {
+		t.Errorf("view missing pairing-required header:\n%s", view)
+	}
+	if !strings.Contains(view, "openclaw devices approve --latest") {
+		t.Errorf("view missing approve command hint:\n%s", view)
+	}
+	if m.wantsInput() {
+		t.Error("pairing-required modal should not request a text input")
+	}
+	actions := m.Actions()
+	if len(actions) != 2 {
+		t.Errorf("expected 2 actions on pairing-required modal, got %d", len(actions))
+	}
+}
+
+func TestConnectingModel_PairingRequiredEnterRetries(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	fake := newFakeBackend()
+	m := newConnectingModel(conn, false)
+	m.enterAuthModal(conn, fake, authRecoveryNotPaired, errors.New("NOT_PAIRED"))
+
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected cmd from Enter on pairing-required modal")
+	}
+	resolved, ok := cmd().(authResolvedMsg)
+	if !ok {
+		t.Fatalf("expected authResolvedMsg, got %T", cmd())
+	}
+	if resolved.cancelled {
+		t.Error("retry should not be a cancellation")
+	}
+	if resolved.backend != fake {
+		t.Error("retry should reuse the same backend")
+	}
+}
+
+func TestConnectingModel_PairingRequiredEscCancels(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	m := newConnectingModel(conn, false)
+	m.enterAuthModal(conn, nil, authRecoveryNotPaired, errors.New("NOT_PAIRED"))
+
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("expected cmd from Esc on pairing-required modal")
+	}
+	resolved, ok := cmd().(authResolvedMsg)
+	if !ok {
+		t.Fatalf("expected authResolvedMsg, got %T", cmd())
+	}
+	if !resolved.cancelled {
+		t.Error("Esc should set Cancelled=true")
+	}
+}
+
 func TestConnectingModel_AuthCancelEmitsResolvedCancelled(t *testing.T) {
 	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
 	m := newConnectingModel(conn, false)

--- a/internal/tui/connecting_test.go
+++ b/internal/tui/connecting_test.go
@@ -176,6 +176,25 @@ func TestConnectingModel_PairingRequiredShowsInstructions(t *testing.T) {
 	}
 }
 
+func TestConnectingModel_PairingRequiredWrapsLongError(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	m := newConnectingModel(conn, false)
+	m.setSize(50, 24)
+	longErr := errors.New("connect: hello: connect rejected: NOT_PAIRED: pairing required: device is not approved by the gateway administrator yet")
+	m.enterAuthModal(conn, nil, authRecoveryNotPaired, longErr)
+
+	view := m.View()
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, longErr.Error()) {
+			t.Errorf("error rendered on a single line without wrapping at width=50:\n%s", view)
+		}
+	}
+	// Sanity-check that fragments of the error did still make it in.
+	if !strings.Contains(view, "NOT_PAIRED") || !strings.Contains(view, "administrator yet") {
+		t.Errorf("wrapped error lost content:\n%s", view)
+	}
+}
+
 func TestConnectingModel_PairingRequiredEnterRetries(t *testing.T) {
 	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
 	fake := newFakeBackend()

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -226,6 +226,7 @@ const (
 	authRecoveryTokenMismatch
 	authRecoveryTokenMissing
 	authRecoveryAPIKey
+	authRecoveryNotPaired
 )
 
 // authResolvedMsg is sent after the user has resolved an auth-recovery


### PR DESCRIPTION
Surfaces actionable pairing guidance when the gateway rejects a connection with `NOT_PAIRED` instead of bouncing the user back to the connections picker.

## Summary
- Detect the `NOT_PAIRED` rejection from the gateway in `runConnect` and route it into a new `subStatePairingRequired` modal on the connecting view
- Render a non-input modal explaining that the device needs administrator approval, with the discovery command `openclaw devices approve --latest` shown verbatim
- Offer Enter to retry (reuses the same backend so a re-approved device picks up its token on the next attempt) and Esc to return to the picker
- Wrap the in-modal error message to the terminal width so long messages no longer overflow

## Implementation details
The `--latest` form is a preview command in the OpenClaw CLI — it prints the pending request and the explicit `openclaw devices approve <request-id>` command to run, which the operator then executes. This sidesteps the implicit-latest race the OpenClaw CLI was hardened against, while still giving the user a single, copy-pasteable starting point.