### PR TITLE
build: distribute lucinate via Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Point go.mod replace at checked-out SDK
         run: go mod edit -replace github.com/a3tai/openclaw-go=./openclaw-go
 
+      - name: Mint Homebrew tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: lucinate-ai
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -36,3 +45,4 @@ jobs:
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,27 @@ archives:
 checksum:
   name_template: checksums.txt
 
+brews:
+  - name: lucinate
+    repository:
+      owner: lucinate-ai
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/lucinate-ai/lucinate"
+    description: "Terminal-native chat client for OpenClaw, Hermes, Ollama and OpenAI-compatible providers"
+    license: "Apache-2.0"
+    commit_author:
+      name: lucinate-bot
+      email: 1248633+outofcoffee@users.noreply.github.com
+    commit_msg_template: "build: brew formula update for {{ .ProjectName }} {{ .Tag }}"
+    test: |
+      system "#{bin}/lucinate", "--version"
+    install: |
+      bin.install "lucinate"
+    skip_upload: auto
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ No file browsers, no task boards, no dashboards. Just chat.
 
 ## Install
 
+With [Homebrew](https://brew.sh) (macOS / Linux):
+
+```sh
+brew install lucinate-ai/tap/lucinate
+```
+
+Or via the install script:
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/lucinate-ai/lucinate/main/install/lucinate.sh | sh
 ```


### PR DESCRIPTION
Add Homebrew distribution by publishing a generated formula to `lucinate-ai/homebrew-tap` on every release.

## Summary
- Extend `.goreleaser.yml` with a `brews:` block that pushes a `Formula/lucinate.rb` to the new tap, with `skip_upload: auto` so prereleases don't bump the formula
- Mint a short-lived, repo-scoped token in the release workflow via `actions/create-github-app-token`, then hand it to GoReleaser as `HOMEBREW_TAP_GITHUB_TOKEN`
- Document `brew install lucinate-ai/tap/lucinate` as the primary install option in the README

## Implementation details
A GitHub App installed against `homebrew-tap` only is used in preference to a PAT — the token is minted per run, expires after the job, and its blast radius is exactly one repository. The workflow expects the org to provide the `HOMEBREW_TAP_APP_ID` variable and the `HOMEBREW_TAP_APP_PRIVATE_KEY` secret.