### PR TITLE
feat(tui): auto-suggest localhost OpenClaw gateway URL

### DIFF
--- a/internal/tui/connections.go
+++ b/internal/tui/connections.go
@@ -374,6 +374,7 @@ func (m *connectionsModel) enterFormForEdit(conn config.Connection) {
 // We never overwrite user-entered text — switching back to OpenClaw
 // after typing in Ollama mode keeps whatever's in the URL field.
 func (m *connectionsModel) applyPresetDefaults(prev formPreset) {
+	const openclawURL = "http://localhost:18789"
 	const ollamaURL = "http://localhost:11434/v1"
 	const hermesURL = "http://127.0.0.1:8642/v1"
 	// Step 1: clear any prefill from the previous preset *before*
@@ -381,6 +382,11 @@ func (m *connectionsModel) applyPresetDefaults(prev formPreset) {
 	// empty field and can populate it. Without this ordering,
 	// Ollama → Hermes would skip the Hermes prefill because the
 	// fields still hold the Ollama values.
+	if prev == presetOpenClaw && m.formPreset != presetOpenClaw {
+		if m.urlInput.Value() == openclawURL {
+			m.urlInput.SetValue("")
+		}
+	}
 	if prev == presetOllama && m.formPreset != presetOllama {
 		if m.urlInput.Value() == ollamaURL {
 			m.urlInput.SetValue("")
@@ -421,7 +427,10 @@ func (m *connectionsModel) applyPresetDefaults(prev formPreset) {
 	case presetOpenAI:
 		m.urlInput.Placeholder = "https://api.openai.com/v1"
 	default:
-		m.urlInput.Placeholder = "https://gateway.example.com"
+		m.urlInput.Placeholder = openclawURL
+		if m.urlInput.Value() == "" {
+			m.urlInput.SetValue(openclawURL)
+		}
 	}
 }
 

--- a/internal/tui/connections_test.go
+++ b/internal/tui/connections_test.go
@@ -221,15 +221,16 @@ func TestConnectionsModel_TypeCycleUpdatesPreset(t *testing.T) {
 		t.Errorf("Hermes preset did not prefill name: %q", m.nameInput.Value())
 	}
 
-	// Down again wraps back to OpenClaw and clears the Hermes
-	// prefill so the user isn't stuck with localhost in a gateway
-	// URL field.
+	// Down again wraps back to OpenClaw: clears the Hermes prefill
+	// and installs the OpenClaw localhost gateway suggestion. The
+	// Hermes-derived name is also cleared since OpenClaw doesn't
+	// auto-suggest a name.
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyDown})
 	if m.formPreset != presetOpenClaw {
 		t.Errorf("expected wrap to OpenClaw, got %v", m.formPreset)
 	}
-	if m.urlInput.Value() != "" {
-		t.Errorf("expected URL cleared on switch away from Hermes, got %q", m.urlInput.Value())
+	if m.urlInput.Value() != "http://localhost:18789" {
+		t.Errorf("OpenClaw preset did not prefill URL: %q", m.urlInput.Value())
 	}
 	if m.nameInput.Value() != "" {
 		t.Errorf("expected name cleared on switch away from Hermes, got %q", m.nameInput.Value())


### PR DESCRIPTION
Pre-fill the OpenClaw localhost gateway URL in the new-connection form so first-time users on a local setup can connect without typing a URL.

## Summary
- The OpenClaw preset now pre-fills `http://localhost:18789` in the URL field and uses it as the placeholder, mirroring the existing Ollama and Hermes auto-suggest behaviour.
- Switching the type radio away from OpenClaw clears the suggestion if it hasn't been edited, so picking a different backend doesn't leave a stale localhost URL behind.
- Wrapping back to OpenClaw re-installs the suggestion.

## Implementation details
The name field is intentionally left blank for OpenClaw — unlike Ollama/Hermes, OpenClaw connections are typically given personal names (e.g. "home pi"), so an auto-suggested name would more often need to be deleted than kept.