### PR TITLE
docs: add PowerShell install one-liner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ With [Homebrew](https://brew.sh) (macOS / Linux):
 brew install lucinate-ai/tap/lucinate
 ```
 
-Or via the install script:
+Or via the install script (macOS / Linux):
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/lucinate-ai/lucinate/main/install/lucinate.sh | sh
+```
+
+On Windows, in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/lucinate-ai/lucinate/main/install/lucinate.ps1 | iex
 ```
 
 Or, if you have Go 1.24+:

--- a/install/lucinate.ps1
+++ b/install/lucinate.ps1
@@ -1,0 +1,55 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'lucinate-ai/lucinate'
+$Binary = 'lucinate'
+$InstallDir = Join-Path $env:LOCALAPPDATA "Programs\$Binary"
+
+$Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    'AMD64' { 'amd64' }
+    'ARM64' { 'arm64' }
+    'x86'   { 'amd64' }
+    default { throw "Unsupported architecture: $($env:PROCESSOR_ARCHITECTURE)" }
+}
+
+$Os = 'windows'
+$Ext = 'zip'
+
+$Headers = @{ 'User-Agent' = "$Binary-installer" }
+$Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers $Headers
+$Tag = $Release.tag_name
+$Version = $Tag.TrimStart('v')
+
+$Asset = "${Binary}_${Version}_${Os}_${Arch}.${Ext}"
+$Url = "https://github.com/$Repo/releases/download/$Tag/$Asset"
+
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $TmpDir | Out-Null
+
+try {
+    Write-Host "Downloading $Binary $Version for $Os/$Arch..."
+    $ArchivePath = Join-Path $TmpDir $Asset
+    Invoke-WebRequest -Uri $Url -OutFile $ArchivePath -Headers $Headers -UseBasicParsing
+    Expand-Archive -Path $ArchivePath -DestinationPath $TmpDir -Force
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $SourceBinary = Join-Path $TmpDir "$Binary.exe"
+    $DestBinary = Join-Path $InstallDir "$Binary.exe"
+    Copy-Item -Path $SourceBinary -Destination $DestBinary -Force
+
+    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $PathEntries = if ($UserPath) { $UserPath.Split(';') } else { @() }
+    if ($PathEntries -notcontains $InstallDir) {
+        $NewPath = if ($UserPath) { "$UserPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable('Path', $NewPath, 'User')
+        Write-Host "Added $InstallDir to user PATH (restart your shell to pick it up)."
+    }
+
+    Write-Host "$Binary $Version installed to $DestBinary"
+}
+finally {
+    Remove-Item -Recurse -Force -Path $TmpDir -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Document the new Windows PowerShell installer alongside the existing macOS/Linux options.

## Summary
- Add a PowerShell `irm | iex` one-liner to the README install section, pointing at `install/lucinate.ps1`.
- Label the existing `curl | sh` block as macOS/Linux for clarity.