### PR TITLE
feat(tui): show placeholder while conversation history loads

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -113,6 +113,7 @@ type chatModel struct {
 	prefs            config.Preferences
 	pendingConfirm   *pendingConfirmation
 	historyLimit     int
+	historyLoading   bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
 	thinkingLevel    string // current thinking level; "" means not set / using gateway default
 	connState        ConnStateMsg
 	hideInput        bool // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
@@ -191,6 +192,7 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		modelID:      modelID,
 		prefs:           prefs,
 		historyLimit:    prefs.HistoryLimit,
+		historyLoading:  true,
 		hideInput:       hideInput,
 		terminalFocused: true,
 	}
@@ -262,12 +264,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case historyLoadedMsg:
+		m.historyLoading = false
 		if msg.err == nil && len(msg.messages) > 0 {
 			lastTs := lastTimestampMs(msg.messages)
 			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
 			m.messages = append(hist, m.messages...)
-			m.updateViewport()
 		}
+		m.updateViewport()
 		return m, nil
 
 	case modelListMsg:

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -13,6 +13,10 @@ func (m *chatModel) updateViewport() {
 	var b strings.Builder
 	contentWidth := m.width - 4
 
+	if m.historyLoading && len(m.messages) == 0 && len(m.pendingMessages) == 0 {
+		b.WriteString(statusStyle.Render(wordWrap("Loading conversation history…", contentWidth)))
+	}
+
 	for i, msg := range m.messages {
 		if i > 0 {
 			b.WriteString("\n")

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -247,6 +247,56 @@ func TestUpdateViewport_BottomAnchoring(t *testing.T) {
 	}
 }
 
+func TestUpdateViewport_HistoryLoadingPlaceholder(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(20)
+	m := &chatModel{
+		viewport:       vp,
+		width:          80,
+		agentName:      "test",
+		historyLoading: true,
+	}
+
+	m.updateViewport()
+
+	view := ansi.Strip(m.viewport.View())
+	if !strings.Contains(view, "Loading conversation history") {
+		t.Errorf("viewport should show loading placeholder while historyLoading is true; got %q", view)
+	}
+
+	m.historyLoading = false
+	m.updateViewport()
+
+	view = ansi.Strip(m.viewport.View())
+	if strings.Contains(view, "Loading conversation history") {
+		t.Errorf("placeholder should disappear once historyLoading is cleared; got %q", view)
+	}
+}
+
+func TestUpdateViewport_PlaceholderYieldsToPendingMessage(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(20)
+	m := &chatModel{
+		viewport:        vp,
+		width:           80,
+		agentName:       "test",
+		historyLoading:  true,
+		pendingMessages: []string{"queued before history loaded"},
+	}
+
+	m.updateViewport()
+
+	view := ansi.Strip(m.viewport.View())
+	if strings.Contains(view, "Loading conversation history") {
+		t.Errorf("placeholder should yield to a queued message; got %q", view)
+	}
+	if !strings.Contains(view, "queued before history loaded") {
+		t.Errorf("queued message should still render; got %q", view)
+	}
+}
+
 func TestUpdateViewport_PreservesScrollWhenUserScrolledUp(t *testing.T) {
 	vp := viewport.New()
 	vp.SetWidth(80)


### PR DESCRIPTION
Render a "Loading conversation history…" line in the chat view while the initial history fetch is in flight, instead of leaving the messages area blank.

## Summary
- Add a `historyLoading` flag to `chatModel`, set true at construction and cleared when `historyLoadedMsg` arrives (success or error).
- Show a status-styled placeholder via `updateViewport()` when loading and there are no real or pending messages yet.
- Cover the empty-history and error paths so the viewport refreshes and the placeholder disappears even when no messages get appended.
- Add unit tests for the placeholder showing, clearing, and yielding to a queued message.

## Implementation details
The placeholder reuses the existing `statusStyle` and `wordWrap` helpers and flows through the same bottom-anchoring padding logic in `updateViewport()`, matching the `Loading sessions…` / `Connecting to gateway…` patterns already used elsewhere in the TUI. Static text (no spinner tick) keeps the change minimal and consistent with those precedents.