### PR TITLE
feat: check for updates on startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
+
+      # Notify the website repo so it can refresh public/latest.json,
+      # which the in-app update check fetches on startup. Skip
+      # pre-release tags (anything containing "-") so users on the
+      # stable channel never see an RC badge.
+      - name: Mint website dispatch token
+        id: website-token
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.WEBSITE_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.WEBSITE_DISPATCH_APP_PRIVATE_KEY }}
+          owner: lucinate-ai
+          repositories: website
+
+      - name: Notify website of new release
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ steps.website-token.outputs.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/lucinate-ai/website/dispatches \
+            -f event_type=release-published \
+            -f "client_payload[version]=${TAG}"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Use `/config` to open the preferences view. Settings are persisted to `~/.lucina
 | Setting | Default | Description |
 |---------|---------|-------------|
 | Completion notification | On | Ring the terminal bell when a response completes (only if the terminal isn't focused) |
+| Check for updates on startup | On | Once a day, fetch a tiny manifest from `lucinate.ai` and show a subtle `↑` badge in the chat header when a newer release is out. No telemetry — just a single GET. |
 | History limit | 50 | Number of messages loaded when restoring a session (range 10–500) |
 | Connect timeout | 15s | Per-attempt deadline for the initial connect and each reconnect (range 5–300s — bump it for slow local LLMs) |
 
@@ -203,6 +204,12 @@ OPENCLAW_GATEWAY_URL=https://your-gateway-host
 LUCINATE_OPENAI_BASE_URL=http://localhost:11434/v1
 LUCINATE_OPENAI_API_KEY=sk-...           # optional
 LUCINATE_OPENAI_DEFAULT_MODEL=llama3.2   # optional
+```
+
+Other knobs:
+
+```sh
+LUCINATE_DISABLE_UPDATE_CHECK=1          # opt out of the daily update check, regardless of the toggle in /config
 ```
 
 ## Built on

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -40,7 +40,7 @@ The spinner also appears while the model is thinking before any response deltas 
 
 The header line shows:
 
-- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected)
+- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected) · update-available badge (only when `prefs.UpdateChecksEnabled()` and the startup check found a newer release)
 - **Right:** token summary (input / output / cache) · total cost
 
 Stats are loaded on init and refreshed after each message exchange via `loadStats()`. The header is re-rendered on every `statsLoadedMsg`. Token and cost values come from `client.SessionUsage()`.
@@ -54,6 +54,12 @@ The connection-status badge is rendered in the error colour and only appears whe
 | `✖ auth failed — restart` | The gateway rejected the device token after restart. The supervisor has stopped retrying — Ctrl+C and re-run `lucinate` so the interactive auth recovery flow can run on stdin. |
 
 A matching one-line system message is also added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. See [authentication.md](authentication.md#reconnect-after-disconnection) for the full lifecycle.
+
+### Update-available badge
+
+A second header badge — `↑ vX.Y.Z`, rendered in the same warn style as `⚠ disconnected` — appears when the daily startup update check finds a newer release. The check is owned by `internal/update`: a single `GET https://lucinate.ai/latest.json` with a 5-second timeout, fired once per day from `AppModel.Init()`. Anything goes wrong (offline, captive portal, malformed manifest, non-stable build) and `update.Check` returns `nil, nil` — no badge, no error.
+
+The badge is suppressed once the user has seen it: `prefs.LatestSeenVersion` records the manifest version on every successful check, and the badge only appears when the manifest moves *past* that version. Toggle the whole thing off via the `Check for updates on startup` row in `/config`, or set `LUCINATE_DISABLE_UPDATE_CHECK=1` for an unconditional opt-out (useful in CI). The manifest URL itself can be overridden via `LUCINATE_UPDATE_MANIFEST_URL` for local testing.
 
 ## Tool call cards
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC
 github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/internal/config/preferences.go
+++ b/internal/config/preferences.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // DefaultHistoryLimit is the number of messages loaded when restoring a session.
@@ -17,18 +18,38 @@ const DefaultHistoryLimit = 50
 const DefaultConnectTimeoutSeconds = 15
 
 // Preferences holds user-configurable settings persisted to disk.
+//
+// CheckForUpdates is a *bool, not a bool, so an older config.json
+// that predates the field unmarshals to nil and is treated as
+// "enabled" — anything else would silently disable update checks
+// for every existing user. Read it through UpdateChecksEnabled.
 type Preferences struct {
-	CompletionBell        bool `json:"completionBell"`
-	HistoryLimit          int  `json:"historyLimit"`
-	ConnectTimeoutSeconds int  `json:"connectTimeoutSeconds"`
+	CompletionBell        bool   `json:"completionBell"`
+	HistoryLimit          int    `json:"historyLimit"`
+	ConnectTimeoutSeconds int    `json:"connectTimeoutSeconds"`
+	CheckForUpdates       *bool  `json:"checkForUpdates,omitempty"`
+	LastUpdateCheck       int64  `json:"lastUpdateCheck,omitempty"`
+	LatestSeenVersion     string `json:"latestSeenVersion,omitempty"`
+}
+
+// UpdateChecksEnabled reports whether the user has the startup
+// update check turned on. An unset field (older config files)
+// counts as enabled.
+func (p Preferences) UpdateChecksEnabled() bool {
+	if p.CheckForUpdates == nil {
+		return true
+	}
+	return *p.CheckForUpdates
 }
 
 // DefaultPreferences returns the default preference values.
 func DefaultPreferences() Preferences {
+	enabled := true
 	return Preferences{
 		CompletionBell:        true,
 		HistoryLimit:          DefaultHistoryLimit,
 		ConnectTimeoutSeconds: DefaultConnectTimeoutSeconds,
+		CheckForUpdates:       &enabled,
 	}
 }
 
@@ -65,6 +86,11 @@ func LoadPreferences() Preferences {
 	}
 	if p.ConnectTimeoutSeconds <= 0 {
 		p.ConnectTimeoutSeconds = DefaultConnectTimeoutSeconds
+	}
+	// Defensive against laptop clock changes — a future timestamp
+	// would otherwise wedge the daily rate-limit until time caught up.
+	if p.LastUpdateCheck > time.Now().Unix() {
+		p.LastUpdateCheck = 0
 	}
 	return p
 }

--- a/internal/config/preferences_test.go
+++ b/internal/config/preferences_test.go
@@ -95,4 +95,92 @@ func TestLoadPreferences_MissingFile(t *testing.T) {
 	if !p.CompletionBell {
 		t.Error("expected defaults when file is missing")
 	}
+	if !p.UpdateChecksEnabled() {
+		t.Error("expected update checks to default to enabled when file is missing")
+	}
+}
+
+func TestLoadPreferences_MissingCheckForUpdates(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configDir := filepath.Join(dir, ".lucinate")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Older config: lacks checkForUpdates entirely. A naive bool field
+	// would unmarshal to false and silently disable update checks for
+	// every existing user.
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"completionBell":true,"historyLimit":50}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := LoadPreferences()
+	if !loaded.UpdateChecksEnabled() {
+		t.Error("expected UpdateChecksEnabled to default to true for old config")
+	}
+	if loaded.CheckForUpdates != nil {
+		t.Errorf("expected CheckForUpdates to remain nil after loading legacy config, got %v", *loaded.CheckForUpdates)
+	}
+}
+
+func TestLoadPreferences_ExplicitlyDisabledUpdateChecks(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configDir := filepath.Join(dir, ".lucinate")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"checkForUpdates":false}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := LoadPreferences()
+	if loaded.UpdateChecksEnabled() {
+		t.Error("expected UpdateChecksEnabled to be false when user has explicitly disabled it")
+	}
+}
+
+func TestSaveAndLoad_UpdateCheckFields(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	disabled := false
+	p := DefaultPreferences()
+	p.CheckForUpdates = &disabled
+	p.LastUpdateCheck = 1700000000
+	p.LatestSeenVersion = "v1.2.3"
+	if err := SavePreferences(p); err != nil {
+		t.Fatalf("SavePreferences: %v", err)
+	}
+
+	loaded := LoadPreferences()
+	if loaded.UpdateChecksEnabled() {
+		t.Error("expected UpdateChecksEnabled to round-trip as false")
+	}
+	if loaded.LastUpdateCheck != 1700000000 {
+		t.Errorf("LastUpdateCheck round-trip: got %d", loaded.LastUpdateCheck)
+	}
+	if loaded.LatestSeenVersion != "v1.2.3" {
+		t.Errorf("LatestSeenVersion round-trip: got %q", loaded.LatestSeenVersion)
+	}
+}
+
+func TestLoadPreferences_FutureTimestampReset(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	configDir := filepath.Join(dir, ".lucinate")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"lastUpdateCheck":99999999999}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := LoadPreferences()
+	if loaded.LastUpdateCheck != 0 {
+		t.Errorf("expected future timestamp to be reset to 0, got %d", loaded.LastUpdateCheck)
+	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -121,6 +121,12 @@ type AppModel struct {
 	onFocusedFieldChanged func(string)
 	lastFocusedFieldKey   string
 	focusedFieldReported  bool
+
+	// Update-check state. Populated when the daily startup check
+	// finds a release the user hasn't yet seen.
+	updateAvailable bool
+	updateLatest    string
+	updateURL       string
 }
 
 // NewApp creates the root application model.
@@ -170,15 +176,19 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 }
 
 func (m AppModel) Init() tea.Cmd {
+	var cmd tea.Cmd
 	switch m.state {
 	case viewSelect:
-		return m.selectModel.Init()
+		cmd = m.selectModel.Init()
 	case viewConnecting:
-		return m.startConnect(m.connectingModel.connection)
+		cmd = m.startConnect(m.connectingModel.connection)
 	case viewConnections:
-		return m.connectionsModel.Init()
+		cmd = m.connectionsModel.Init()
 	}
-	return nil
+	if upd := updateCheckCmd(m.prefs); upd != nil {
+		cmd = tea.Batch(cmd, upd)
+	}
+	return cmd
 }
 
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -426,6 +436,26 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.prefs = msg.prefs
 		m.chatModel.prefs = msg.prefs
 		return m, nil
+
+	case updateCheckDoneMsg:
+		// Mutate prefs on the main loop so this never races the
+		// config view's writer. Newer is set only when there is a
+		// genuinely new version the user hasn't already seen.
+		m.prefs.LastUpdateCheck = msg.At
+		if msg.LatestSeen != "" {
+			m.prefs.LatestSeenVersion = msg.LatestSeen
+		}
+		if msg.Newer {
+			m.updateAvailable = true
+			m.updateLatest = msg.LatestSeen
+			m.updateURL = msg.URL
+			m.chatModel.updateLatest = msg.LatestSeen
+		}
+		prefs := m.prefs
+		return m, func() tea.Msg {
+			_ = config.SavePreferences(prefs)
+			return nil
+		}
 
 	case ConnStateMsg:
 		m.chatModel.applyConnState(msg)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/client"
@@ -91,33 +91,34 @@ const spinnerInterval = 120 * time.Millisecond
 
 // chatModel is the chat view.
 type chatModel struct {
-	viewport         viewport.Model
-	textarea         textarea.Model
-	messages         []chatMessage
-	backend          backend.Backend
-	connName         string // active connection name, rendered in the header bar
-	sessionKey       string
-	agentID          string
-	agentName        string
-	sending          bool
-	runID            string // active run ID for cancellation
-	pendingMessages  []string
-	width            int
-	height           int
-	renderer         *glamour.TermRenderer
-	stats            *sessionStats
-	modelID          string
-	skills []agentSkill
-	spinnerFrame     int
-	spinnerTicking   bool
-	prefs            config.Preferences
-	pendingConfirm   *pendingConfirmation
-	historyLimit     int
-	historyLoading   bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
-	thinkingLevel    string // current thinking level; "" means not set / using gateway default
-	connState        ConnStateMsg
-	hideInput        bool // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
-	terminalFocused  bool // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
+	viewport        viewport.Model
+	textarea        textarea.Model
+	messages        []chatMessage
+	backend         backend.Backend
+	connName        string // active connection name, rendered in the header bar
+	sessionKey      string
+	agentID         string
+	agentName       string
+	sending         bool
+	runID           string // active run ID for cancellation
+	pendingMessages []string
+	width           int
+	height          int
+	renderer        *glamour.TermRenderer
+	stats           *sessionStats
+	modelID         string
+	skills          []agentSkill
+	spinnerFrame    int
+	spinnerTicking  bool
+	prefs           config.Preferences
+	pendingConfirm  *pendingConfirmation
+	historyLimit    int
+	historyLoading  bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
+	thinkingLevel   string // current thinking level; "" means not set / using gateway default
+	connState       ConnStateMsg
+	hideInput       bool   // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
+	terminalFocused bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
+	updateLatest    string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -181,15 +182,15 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 	)
 
 	return chatModel{
-		viewport:     vp,
-		textarea:     ta,
-		backend:      b,
-		connName:     connName,
-		sessionKey:   sessionKey,
-		agentID:      agentID,
-		agentName:    agentName,
-		renderer:     renderer,
-		modelID:      modelID,
+		viewport:        vp,
+		textarea:        ta,
+		backend:         b,
+		connName:        connName,
+		sessionKey:      sessionKey,
+		agentID:         agentID,
+		agentName:       agentName,
+		renderer:        renderer,
+		modelID:         modelID,
 		prefs:           prefs,
 		historyLimit:    prefs.HistoryLimit,
 		historyLoading:  true,
@@ -766,6 +767,9 @@ func (m chatModel) View() string {
 	}
 	if badge := connectionBadge(m.connState); badge != "" {
 		left += " · " + badge
+	}
+	if m.updateLatest != "" {
+		left += " · " + headerBadgeWarnStyle.Render("↑ "+m.updateLatest)
 	}
 	right := ""
 	if m.stats != nil {

--- a/internal/tui/configview.go
+++ b/internal/tui/configview.go
@@ -43,6 +43,7 @@ func newConfigModel(prefs config.Preferences, hideHints bool) configModel {
 		hideHints: hideHints,
 		items: []configItem{
 			{label: "Completion notification (terminal bell)", key: "completionBell", kind: configItemBool, checked: prefs.CompletionBell},
+			{label: "Check for updates on startup", key: "checkForUpdates", kind: configItemBool, checked: prefs.UpdateChecksEnabled()},
 			{label: "History limit (messages loaded per session)", key: "historyLimit", kind: configItemInt, value: prefs.HistoryLimit, min: 10, max: 500, step: 10},
 			{label: "Connect timeout (seconds, increase for slow backends)", key: "connectTimeoutSeconds", kind: configItemInt, value: prefs.ConnectTimeoutSeconds, min: 5, max: 300, step: 5},
 		},
@@ -142,6 +143,9 @@ func (m *configModel) applyToPrefs() {
 		switch item.key {
 		case "completionBell":
 			m.prefs.CompletionBell = item.checked
+		case "checkForUpdates":
+			v := item.checked
+			m.prefs.CheckForUpdates = &v
 		case "historyLimit":
 			m.prefs.HistoryLimit = item.value
 		case "connectTimeoutSeconds":

--- a/internal/tui/configview_test.go
+++ b/internal/tui/configview_test.go
@@ -16,6 +16,23 @@ func newTestConfigModel() configModel {
 	return m
 }
 
+// cursorToKey moves m.cursor to the item with the given key by sending
+// KeyDown presses. Tests should not depend on a specific item index —
+// the row order changes when new preferences are added.
+func cursorToKey(t *testing.T, m configModel, key string) (configModel, int) {
+	t.Helper()
+	for i, it := range m.items {
+		if it.key == key {
+			for j := 0; j < i; j++ {
+				m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+			}
+			return m, i
+		}
+	}
+	t.Fatalf("config item with key %q not found", key)
+	return m, -1
+}
+
 func TestConfigModel_Init(t *testing.T) {
 	m := newTestConfigModel()
 	cmd := m.Init()
@@ -135,13 +152,12 @@ func TestConfigModel_View_ContainsHistoryLimit(t *testing.T) {
 
 func TestConfigModel_HistoryLimit_RightIncreases(t *testing.T) {
 	m := newTestConfigModel()
-	// Move cursor to history limit item (index 1).
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	initial := m.items[1].value
+	m, idx := cursorToKey(t, m, "historyLimit")
+	initial := m.items[idx].value
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	if m.items[1].value != initial+10 {
-		t.Errorf("expected %d after right, got %d", initial+10, m.items[1].value)
+	if m.items[idx].value != initial+10 {
+		t.Errorf("expected %d after right, got %d", initial+10, m.items[idx].value)
 	}
 	if cmd == nil {
 		t.Error("expected a cmd to save preferences")
@@ -156,12 +172,12 @@ func TestConfigModel_HistoryLimit_RightIncreases(t *testing.T) {
 
 func TestConfigModel_HistoryLimit_LeftDecreases(t *testing.T) {
 	m := newTestConfigModel()
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	initial := m.items[1].value
+	m, idx := cursorToKey(t, m, "historyLimit")
+	initial := m.items[idx].value
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
-	if m.items[1].value != initial-10 {
-		t.Errorf("expected %d after left, got %d", initial-10, m.items[1].value)
+	if m.items[idx].value != initial-10 {
+		t.Errorf("expected %d after left, got %d", initial-10, m.items[idx].value)
 	}
 	if cmd == nil {
 		t.Error("expected a cmd to save preferences")
@@ -171,11 +187,11 @@ func TestConfigModel_HistoryLimit_LeftDecreases(t *testing.T) {
 func TestConfigModel_HistoryLimit_RespectsMin(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: true, HistoryLimit: 10}
 	m := newConfigModel(prefs, false)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, idx := cursorToKey(t, m, "historyLimit")
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
-	if m.items[1].value != 10 {
-		t.Errorf("expected value to stay at min 10, got %d", m.items[1].value)
+	if m.items[idx].value != 10 {
+		t.Errorf("expected value to stay at min 10, got %d", m.items[idx].value)
 	}
 	if cmd != nil {
 		t.Error("expected nil cmd when at minimum")
@@ -185,11 +201,11 @@ func TestConfigModel_HistoryLimit_RespectsMin(t *testing.T) {
 func TestConfigModel_HistoryLimit_RespectsMax(t *testing.T) {
 	prefs := config.Preferences{CompletionBell: true, HistoryLimit: 500}
 	m := newConfigModel(prefs, false)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, idx := cursorToKey(t, m, "historyLimit")
 
 	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	if m.items[1].value != 500 {
-		t.Errorf("expected value to stay at max 500, got %d", m.items[1].value)
+	if m.items[idx].value != 500 {
+		t.Errorf("expected value to stay at max 500, got %d", m.items[idx].value)
 	}
 	if cmd != nil {
 		t.Error("expected nil cmd when at maximum")
@@ -198,11 +214,11 @@ func TestConfigModel_HistoryLimit_RespectsMax(t *testing.T) {
 
 func TestConfigModel_SpaceNoOpOnIntItem(t *testing.T) {
 	m := newTestConfigModel()
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, idx := cursorToKey(t, m, "historyLimit")
 
-	before := m.items[1].value
+	before := m.items[idx].value
 	m, cmd := m.Update(tea.KeyPressMsg{Code: ' '})
-	if m.items[1].value != before {
+	if m.items[idx].value != before {
 		t.Error("space should not change int item value")
 	}
 	if cmd != nil {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -305,3 +305,14 @@ type cronJobRemovedMsg struct {
 	jobID string
 	err   error
 }
+
+// updateCheckDoneMsg carries the outcome of the startup update check.
+// It always fires when a check runs (so the AppModel can persist the
+// new last-check timestamp on the main loop, never racing the config
+// view's writer); Newer is true only when the user should see a badge.
+type updateCheckDoneMsg struct {
+	At         int64  // unix seconds when the check completed
+	LatestSeen string // manifest version, or "" when the check returned nothing
+	Newer      bool   // true iff badge should appear (also implies caller hasn't already seen Latest)
+	URL        string // release URL when Newer is true
+}

--- a/internal/tui/updatecheck.go
+++ b/internal/tui/updatecheck.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+	"github.com/lucinate-ai/lucinate/internal/update"
+	"github.com/lucinate-ai/lucinate/internal/version"
+)
+
+// updateCheckURLEnvVar lets developers point the check at a local
+// httptest server while iterating. Unset in production — the default
+// manifest URL is the only thing real users hit.
+const updateCheckURLEnvVar = "LUCINATE_UPDATE_MANIFEST_URL"
+
+// updateCheckInterval is the minimum gap between successive checks.
+// Lucinate is a CLI; users may launch it dozens of times per day.
+const updateCheckInterval = 24 * time.Hour
+
+// updateCheckCmd returns a bubbletea Cmd that performs a single,
+// non-blocking update check. It returns nil when the check should be
+// skipped — env-var opt-out, the user's preference, the daily
+// rate-limit, or a non-stable build.
+//
+// The Cmd emits a single updateCheckDoneMsg with Newer=true only when
+// a newer release exists *and* the user has not already seen it on a
+// previous launch (suppressed via prefs.LatestSeenVersion).
+func updateCheckCmd(prefs config.Preferences) tea.Cmd {
+	if update.Disabled() {
+		return nil
+	}
+	if !prefs.UpdateChecksEnabled() {
+		return nil
+	}
+	if time.Now().Unix()-prefs.LastUpdateCheck < int64(updateCheckInterval.Seconds()) {
+		return nil
+	}
+	manifestURL := os.Getenv(updateCheckURLEnvVar)
+	if manifestURL == "" {
+		manifestURL = update.DefaultManifestURL
+	}
+	current := version.Version
+	lastSeen := prefs.LatestSeenVersion
+
+	return func() tea.Msg {
+		res, _ := update.Check(context.Background(), manifestURL, current)
+		done := updateCheckDoneMsg{At: time.Now().Unix()}
+		if res == nil {
+			return done
+		}
+		done.LatestSeen = res.Latest
+		done.URL = res.URL
+		// Suppress the badge if the user already noticed this version
+		// last time the binary launched.
+		done.Newer = res.Newer && res.Latest != lastSeen
+		return done
+	}
+}

--- a/internal/tui/updatecheck_test.go
+++ b/internal/tui/updatecheck_test.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+	"github.com/lucinate-ai/lucinate/internal/update"
+)
+
+func TestUpdateCheckCmd_NilWhenEnvVarDisables(t *testing.T) {
+	t.Setenv(update.DisableEnvVar, "1")
+	if updateCheckCmd(enabledPrefs()) != nil {
+		t.Error("expected nil cmd when env var disables update check")
+	}
+}
+
+func TestUpdateCheckCmd_NilWhenPrefDisabled(t *testing.T) {
+	off := false
+	prefs := enabledPrefs()
+	prefs.CheckForUpdates = &off
+	if updateCheckCmd(prefs) != nil {
+		t.Error("expected nil cmd when pref disables update check")
+	}
+}
+
+func TestUpdateCheckCmd_NilWhenWithinRateLimitWindow(t *testing.T) {
+	prefs := enabledPrefs()
+	prefs.LastUpdateCheck = time.Now().Unix() - 60 // 1 minute ago
+	if updateCheckCmd(prefs) != nil {
+		t.Error("expected nil cmd within the daily rate-limit window")
+	}
+}
+
+func TestUpdateCheckCmd_RunsWhenStale(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"v9.9.9","url":"https://example/v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv(updateCheckURLEnvVar, srv.URL)
+	prefs := enabledPrefs()
+	prefs.LastUpdateCheck = time.Now().Add(-48 * time.Hour).Unix()
+
+	cmd := updateCheckCmd(prefs)
+	if cmd == nil {
+		t.Fatal("expected a cmd when last check is older than the rate limit")
+	}
+	msg := cmd()
+	done, ok := msg.(updateCheckDoneMsg)
+	if !ok {
+		t.Fatalf("expected updateCheckDoneMsg, got %T", msg)
+	}
+	// Note: this test uses internal/version.Version which is "dev"
+	// during go test, so update.Check short-circuits and returns nil.
+	// We assert the timestamp gets recorded regardless — that's the
+	// rate-limit invariant we care about.
+	if done.At == 0 {
+		t.Error("expected At to be a recent unix timestamp")
+	}
+}
+
+func TestUpdateCheckDoneMsg_PersistsAndBadges(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	app := AppModel{prefs: config.DefaultPreferences()}
+	msg := updateCheckDoneMsg{
+		At:         1700000000,
+		LatestSeen: "v2.0.0",
+		Newer:      true,
+		URL:        "https://example/v2.0.0",
+	}
+
+	next, cmd := app.update(msg)
+	app = next
+	if !app.updateAvailable || app.updateLatest != "v2.0.0" || app.updateURL != "https://example/v2.0.0" {
+		t.Errorf("expected update fields populated, got %+v", app)
+	}
+	if app.chatModel.updateLatest != "v2.0.0" {
+		t.Errorf("expected chatModel.updateLatest to be set, got %q", app.chatModel.updateLatest)
+	}
+	if app.prefs.LastUpdateCheck != 1700000000 || app.prefs.LatestSeenVersion != "v2.0.0" {
+		t.Errorf("expected prefs to be persisted on the model, got %+v", app.prefs)
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd to persist preferences")
+	}
+	cmd() // exercise the save path; SavePreferences ignores errors here
+
+	loaded := config.LoadPreferences()
+	if loaded.LatestSeenVersion != "v2.0.0" || loaded.LastUpdateCheck != 1700000000 {
+		t.Errorf("expected SavePreferences to round-trip the new fields, got %+v", loaded)
+	}
+}
+
+func TestUpdateCheckDoneMsg_NewerFalseSuppressesBadge(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	app := AppModel{prefs: config.DefaultPreferences()}
+	msg := updateCheckDoneMsg{At: 1700000000, LatestSeen: "v1.0.0", Newer: false}
+	next, _ := app.update(msg)
+	if next.updateAvailable {
+		t.Error("badge must not appear when Newer is false")
+	}
+	if next.chatModel.updateLatest != "" {
+		t.Error("chatModel.updateLatest must remain empty when Newer is false")
+	}
+}
+
+func enabledPrefs() config.Preferences {
+	prefs := config.DefaultPreferences()
+	return prefs
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,135 @@
+// Package update fetches a small JSON manifest from the project
+// website and reports whether a newer release is available. It is
+// designed to fail quietly: a network blip, a captive portal, a
+// malformed manifest — none of these should ever surface to the user.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+// DefaultManifestURL is where lucinate looks for the latest-version
+// manifest in production. Tests inject their own URL.
+const DefaultManifestURL = "https://lucinate.ai/latest.json"
+
+// DefaultRequestTimeout bounds the whole request — a slow network
+// shouldn't delay TUI startup.
+const DefaultRequestTimeout = 5 * time.Second
+
+// DisableEnvVar is the environment variable that unconditionally
+// disables the update check, regardless of saved preferences. Any
+// truthy value (1/true/yes/on, case-insensitive) opts out.
+const DisableEnvVar = "LUCINATE_DISABLE_UPDATE_CHECK"
+
+// maxBodyBytes caps the response body. The manifest is tiny; anything
+// larger is a misconfiguration or hostile.
+const maxBodyBytes = 4096
+
+// Manifest is the JSON shape published at DefaultManifestURL.
+type Manifest struct {
+	Version string `json:"version"`
+	URL     string `json:"url"`
+}
+
+// Result describes the outcome of a successful check. Newer is true
+// only when Latest is strictly greater than the current version.
+type Result struct {
+	Latest string
+	URL    string
+	Newer  bool
+}
+
+// Disabled reports whether the environment variable opt-out is set.
+func Disabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(DisableEnvVar))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// Check fetches the manifest at manifestURL and compares it against
+// current. It returns (nil, nil) for any non-actionable outcome:
+// network failure, parse failure, non-semver current, or no newer
+// version. It only returns a non-nil Result with Newer=true when
+// there is something worth telling the user.
+//
+// The caller's context is wrapped with DefaultRequestTimeout.
+func Check(ctx context.Context, manifestURL, current string) (*Result, error) {
+	if !shouldCheckCurrent(current) {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, DefaultRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, nil
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "lucinate/"+current)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+	// Captive portals love returning HTML with a 200. Reject anything
+	// that isn't claiming JSON before we waste a json.Decoder on it.
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(strings.ToLower(ct), "application/json") {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if err != nil {
+		return nil, nil
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, nil
+	}
+	if !semver.IsValid(m.Version) {
+		return nil, nil
+	}
+
+	res := &Result{Latest: m.Version, URL: m.URL}
+	res.Newer = semver.Compare(m.Version, current) > 0
+	if !res.Newer {
+		return nil, nil
+	}
+	return res, nil
+}
+
+// shouldCheckCurrent returns true only for clean stable release
+// versions. Dev builds, git-describe pseudo-versions, and any
+// pre-release tag are skipped so we never falsely badge a build
+// that is already ahead of the published latest.
+func shouldCheckCurrent(current string) bool {
+	if current == "" || current == "dev" {
+		return false
+	}
+	if !semver.IsValid(current) {
+		return false
+	}
+	if semver.Prerelease(current) != "" {
+		return false
+	}
+	if semver.Build(current) != "" {
+		return false
+	}
+	return true
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,171 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheck_ReportsNewer(t *testing.T) {
+	srv := jsonServer(`{"version":"v1.2.0","url":"https://example/v1.2.0"}`)
+	defer srv.Close()
+
+	res, err := Check(context.Background(), srv.URL, "v1.1.0")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res == nil {
+		t.Fatal("want a result, got nil")
+	}
+	if !res.Newer || res.Latest != "v1.2.0" || res.URL != "https://example/v1.2.0" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestCheck_ReturnsNilWhenNotNewer(t *testing.T) {
+	cases := []struct {
+		name, manifest, current string
+	}{
+		{"equal", `{"version":"v1.2.0","url":"x"}`, "v1.2.0"},
+		{"older manifest", `{"version":"v1.0.0","url":"x"}`, "v1.2.0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := jsonServer(c.manifest)
+			defer srv.Close()
+			res, err := Check(context.Background(), srv.URL, c.current)
+			if err != nil || res != nil {
+				t.Fatalf("want nil/nil, got %+v / %v", res, err)
+			}
+		})
+	}
+}
+
+func TestCheck_SkipsNonStableCurrent(t *testing.T) {
+	cases := []string{
+		"",
+		"dev",
+		"not-a-version",
+		"1.2.3",            // missing v prefix
+		"v1.2.3-rc.1",      // prerelease
+		"v1.2.3-1-gabcdef", // git-describe pseudo
+		"v1.2.3+meta",      // build metadata
+	}
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"v9.9.9","url":"x"}`))
+	}))
+	defer srv.Close()
+
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			res, err := Check(context.Background(), srv.URL, c)
+			if err != nil || res != nil {
+				t.Fatalf("want nil/nil for current=%q, got %+v / %v", c, res, err)
+			}
+		})
+	}
+	if hits != 0 {
+		t.Fatalf("expected zero HTTP requests, got %d", hits)
+	}
+}
+
+func TestCheck_QuietFailureModes(t *testing.T) {
+	t.Run("non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+		assertCheckNil(t, srv.URL, "v1.0.0")
+	})
+
+	t.Run("html content-type", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html>captive portal</html>`))
+		}))
+		defer srv.Close()
+		assertCheckNil(t, srv.URL, "v1.0.0")
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		srv := jsonServer(`not json`)
+		defer srv.Close()
+		assertCheckNil(t, srv.URL, "v1.0.0")
+	})
+
+	t.Run("invalid manifest version", func(t *testing.T) {
+		srv := jsonServer(`{"version":"banana","url":"x"}`)
+		defer srv.Close()
+		assertCheckNil(t, srv.URL, "v1.0.0")
+	})
+
+	t.Run("unreachable host", func(t *testing.T) {
+		// Non-routable address; relies on the request timeout.
+		assertCheckNil(t, "http://127.0.0.1:1/none", "v1.0.0")
+	})
+}
+
+func TestCheck_BodySizeIsCapped(t *testing.T) {
+	huge := strings.Repeat("x", maxBodyBytes*4)
+	srv := jsonServer(huge)
+	defer srv.Close()
+	assertCheckNil(t, srv.URL, "v1.0.0")
+}
+
+func TestCheck_RespectsContextDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"v9.9.9","url":"x"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	res, err := Check(ctx, srv.URL, "v1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("want nil result, got %+v", res)
+	}
+}
+
+func TestDisabled(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
+		t.Setenv(DisableEnvVar, v)
+		if !Disabled() {
+			t.Fatalf("Disabled()=false for %q, want true", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "no", "off", "maybe"} {
+		t.Setenv(DisableEnvVar, v)
+		if Disabled() {
+			t.Fatalf("Disabled()=true for %q, want false", v)
+		}
+	}
+}
+
+func jsonServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func assertCheckNil(t *testing.T, srvURL, current string) {
+	t.Helper()
+	res, err := Check(context.Background(), srvURL, current)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("want nil result, got %+v", res)
+	}
+}


### PR DESCRIPTION
Surface a discreet "update available" badge on launch so users notice new releases without polling GitHub.

## Summary

- New `internal/update` package fetches `https://lucinate.ai/latest.json` once a day with a 5s timeout, semver-compares against the linker-injected version, and quiet-fails on any error (offline, captive portal, malformed JSON, non-stable build).
- Static manifest hosted on the website avoids GitHub's anonymous releases-API rate limit; release workflow now sends a `repository_dispatch` to the website repo on stable tags so the manifest stays in sync (pre-release tags are skipped).
- New `Check for updates on startup` toggle in `/config` plus `LUCINATE_DISABLE_UPDATE_CHECK` env-var override; both honoured before any HTTP.
- Header badge `↑ vX.Y.Z` reuses the existing warn style. Suppressed via `prefs.LatestSeenVersion` once the user has seen a given version, so the same release never re-pesters across launches.
- Docs refreshed: README preferences table + env-vars section, `docs/chat-ux.md` header-bar subsection.

## Implementation details

- `Preferences.CheckForUpdates` is a `*bool`, not a `bool`, so an older `config.json` lacking the field unmarshals to nil and is treated as enabled — a plain bool would silently disable checks for every existing user. Read it through the new `UpdateChecksEnabled()` helper.
- `LastUpdateCheck` is reset on load if it's in the future, so a laptop clock change can't wedge the daily rate-limit until time catches up.
- The update-check goroutine never writes preferences directly. It emits a single `updateCheckDoneMsg` and the AppModel persists on the main loop, so the goroutine and the config view's writer cannot race.
- `update.Check` skips any non-stable current version (`dev`, `git describe` pseudo-versions, prerelease tags, build metadata). This prevents a local build that's one commit ahead of the latest tag from falsely badging itself as out of date.