### PR TITLE
feat(app): add DisableExitKeys for embedded hosts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -131,6 +131,18 @@ type RunOptions struct {
 	// the inline hint, leaves it false.
 	HideActionHints bool
 
+	// DisableExitKeys suppresses every quit shortcut the program would
+	// otherwise honour: ctrl+c at the app level, and the bubbles list's
+	// default `q` / `esc` / `ctrl+c` Quit bindings on each picker view.
+	// Embedders running inside a host that doesn't allow programmatic
+	// process termination — iOS, where Apple's HIG forbids quitting and
+	// `tea.Quit` would only stop the TUI loop while the host view stays
+	// mounted — set this true so the rendered "q quit" footer text and
+	// the bound shortcut both disappear together. The CLI, whose user
+	// reaches the program through a shell that can't otherwise dismiss
+	// it, leaves this false.
+	DisableExitKeys bool
+
 	// DisableMouse stops the program from emitting the
 	// alt-screen mouse-tracking enable sequence. Embedders driving the
 	// program through a virtual terminal whose host wants to handle
@@ -271,6 +283,7 @@ func New(opts RunOptions) (*Program, error) {
 	tuiOpts := tui.AppOptions{
 		HideInputArea:         opts.HideInputArea,
 		HideActionHints:       opts.HideActionHints,
+		DisableExitKeys:       opts.DisableExitKeys,
 		DisableMouse:          opts.DisableMouse,
 		OnInputFocusChanged:   opts.OnInputFocusChanged,
 		OnActionsChanged:      opts.OnActionsChanged,

--- a/app/app.go
+++ b/app/app.go
@@ -135,12 +135,12 @@ type RunOptions struct {
 	// otherwise honour: ctrl+c at the app level, and the bubbles list's
 	// default `q` / `esc` / `ctrl+c` Quit bindings on each picker view.
 	// Embedders running inside a host that doesn't allow programmatic
-	// process termination — iOS, where Apple's HIG forbids quitting and
-	// `tea.Quit` would only stop the TUI loop while the host view stays
-	// mounted — set this true so the rendered "q quit" footer text and
-	// the bound shortcut both disappear together. The CLI, whose user
-	// reaches the program through a shell that can't otherwise dismiss
-	// it, leaves this false.
+	// process termination — a native-platform shell whose OS forbids
+	// quitting, where `tea.Quit` would only stop the TUI loop while
+	// the host view stays mounted — set this true so the rendered
+	// "q quit" footer text and the bound shortcut both disappear
+	// together. The CLI, whose user reaches the program through a
+	// terminal that can't otherwise dismiss it, leaves this false.
 	DisableExitKeys bool
 
 	// DisableMouse stops the program from emitting the

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -106,10 +106,10 @@ func TestConfigModel_Actions(t *testing.T) {
 // don't make the test brittle.
 func TestHideActionHints_Suppresses(t *testing.T) {
 	t.Run("select", func(t *testing.T) {
-		shown := newSelectModel(nil, false, false, nil)
+		shown := newSelectModel(nil, false, false, nil, false)
 		shown.loading = false
 		shown.allowAgentManagement = true
-		hidden := newSelectModel(nil, true, false, nil)
+		hidden := newSelectModel(nil, true, false, nil, false)
 		hidden.loading = false
 		hidden.allowAgentManagement = true
 		if !strings.Contains(shown.View(), "n: new agent") {
@@ -120,9 +120,9 @@ func TestHideActionHints_Suppresses(t *testing.T) {
 		}
 	})
 	t.Run("sessions", func(t *testing.T) {
-		shown := newSessionsModel(nil, "a", "A", "m", "k", false, nil)
+		shown := newSessionsModel(nil, "a", "A", "m", "k", false, nil, false)
 		shown.loading = false
-		hidden := newSessionsModel(nil, "a", "A", "m", "k", true, nil)
+		hidden := newSessionsModel(nil, "a", "A", "m", "k", true, nil, false)
 		hidden.loading = false
 		if !strings.Contains(shown.View(), "esc: back") {
 			t.Fatalf("expected hint with hideHints=false, got: %q", shown.View())

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -37,6 +37,7 @@ type BackendFactory func(*config.Connection) (backend.Backend, error)
 type AppOptions struct {
 	HideInputArea   bool
 	HideActionHints bool
+	DisableExitKeys bool
 	DisableMouse    bool
 
 	// Store, when non-nil, enables managed mode: the TUI owns the
@@ -86,27 +87,28 @@ type AppOptions struct {
 
 // AppModel is the root bubbletea model.
 type AppModel struct {
-	state             viewState
-	connectionsModel  connectionsModel
-	connectingModel   connectingModel
-	selectModel       selectModel
-	chatModel         chatModel
-	sessionsModel     sessionsModel
-	configModel       configModel
-	cronsModel        cronsModel
-	backend           backend.Backend
-	activeConn        *config.Connection // the connection backend belongs to; rendered in status bars
-	store             *config.Connections
-	backendFactory    BackendFactory
-	onBackendChanged  func(backend.Backend)
-	onConnsChanged    func(config.Connections)
-	prefs             config.Preferences
-	width             int
-	height            int
-	hideInput         bool
-	hideActionHints   bool
-	disableMouse      bool
-	managed           bool
+	state            viewState
+	connectionsModel connectionsModel
+	connectingModel  connectingModel
+	selectModel      selectModel
+	chatModel        chatModel
+	sessionsModel    sessionsModel
+	configModel      configModel
+	cronsModel       cronsModel
+	backend          backend.Backend
+	activeConn       *config.Connection // the connection backend belongs to; rendered in status bars
+	store            *config.Connections
+	backendFactory   BackendFactory
+	onBackendChanged func(backend.Backend)
+	onConnsChanged   func(config.Connections)
+	prefs            config.Preferences
+	width            int
+	height           int
+	hideInput        bool
+	hideActionHints  bool
+	disableExitKeys  bool
+	disableMouse     bool
+	managed          bool
 
 	onInputFocusChanged func(bool)
 	lastWantsInput      bool
@@ -131,18 +133,19 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 	managed := opts.Store != nil
 
 	m := AppModel{
-		backend:              b,
-		prefs:                config.LoadPreferences(),
-		hideInput:            opts.HideInputArea,
-		hideActionHints:      opts.HideActionHints,
-		disableMouse:         opts.DisableMouse,
-		store:                opts.Store,
-		backendFactory:       opts.BackendFactory,
-		onBackendChanged:     opts.OnBackendChanged,
-		onConnsChanged:       opts.OnConnectionsChanged,
-		managed:              managed,
-		onInputFocusChanged:  opts.OnInputFocusChanged,
-		onActionsChanged:     opts.OnActionsChanged,
+		backend:               b,
+		prefs:                 config.LoadPreferences(),
+		hideInput:             opts.HideInputArea,
+		hideActionHints:       opts.HideActionHints,
+		disableExitKeys:       opts.DisableExitKeys,
+		disableMouse:          opts.DisableMouse,
+		store:                 opts.Store,
+		backendFactory:        opts.BackendFactory,
+		onBackendChanged:      opts.OnBackendChanged,
+		onConnsChanged:        opts.OnConnectionsChanged,
+		managed:               managed,
+		onInputFocusChanged:   opts.OnInputFocusChanged,
+		onActionsChanged:      opts.OnActionsChanged,
 		onFocusedFieldChanged: opts.OnFocusedFieldChanged,
 	}
 
@@ -151,7 +154,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		// Legacy: jump straight into the agent picker. No active
 		// connection — embedders manage that elsewhere.
 		m.state = viewSelect
-		m.selectModel = newSelectModel(b, opts.HideActionHints, managed, nil)
+		m.selectModel = newSelectModel(b, opts.HideActionHints, managed, nil, opts.DisableExitKeys)
 	case opts.Initial != nil:
 		// Managed with an initial pick: try to connect first, surface
 		// errors / auth modals from there.
@@ -160,7 +163,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 	default:
 		// Managed without an initial pick: open the connections picker.
 		m.state = viewConnections
-		m.connectionsModel = newConnectionsModel(opts.Store, opts.HideActionHints)
+		m.connectionsModel = newConnectionsModel(opts.Store, opts.HideActionHints, opts.DisableExitKeys)
 	}
 
 	return m
@@ -451,7 +454,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		}
 		m.backend = nil
 		m.activeConn = nil
-		m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints)
+		m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 		m.connectionsModel.setSize(m.width, m.height)
 		m.state = viewConnections
 		return m, m.connectionsModel.Init()
@@ -468,7 +471,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case authResolvedMsg:
 		if msg.cancelled {
 			// User backed out of the auth modal — return to the picker.
-			m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints)
+			m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 			m.connectionsModel.setSize(m.width, m.height)
 			m.state = viewConnections
 			if msg.backend != nil {
@@ -501,7 +504,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			// branch implies a programming error elsewhere.
 			return m, nil
 		}
-		m.cronsModel = newCronsModel(cron, msg.filterAgentID, msg.filterLabel, m.hideActionHints, m.activeConn)
+		m.cronsModel = newCronsModel(cron, msg.filterAgentID, msg.filterLabel, m.hideActionHints, m.activeConn, m.disableExitKeys)
 		m.cronsModel.setSize(m.width, m.height)
 		m.state = viewCrons
 		return m, m.cronsModel.Init()
@@ -511,7 +514,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		return m, nil
 
 	case showSessionsMsg:
-		m.sessionsModel = newSessionsModel(m.backend, msg.agentID, msg.agentName, msg.modelID, msg.mainKey, m.hideActionHints, m.activeConn)
+		m.sessionsModel = newSessionsModel(m.backend, msg.agentID, msg.agentName, msg.modelID, msg.mainKey, m.hideActionHints, m.activeConn, m.disableExitKeys)
 		m.sessionsModel.setSize(m.width, m.height)
 		m.state = viewSessions
 		return m, m.sessionsModel.Init()
@@ -558,6 +561,14 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "ctrl+c":
+			if m.disableExitKeys {
+				// Embedded host disallows process termination
+				// (e.g. iOS, where Apple's HIG forbids quitting and
+				// tea.Quit would only stop the TUI loop while the
+				// host view stays mounted). Swallow the keypress so
+				// it doesn't accidentally tear down half the program.
+				return m, nil
+			}
 			return m, tea.Quit
 		case "esc":
 			if m.state == viewConfig {
@@ -759,7 +770,7 @@ func (m AppModel) handleConnectResult(msg connectResultMsg) (AppModel, tea.Cmd) 
 			b := msg.backend
 			go cb(b) // blocking send; do off the event loop
 		}
-		m.selectModel = newSelectModel(msg.backend, m.hideActionHints, m.managed, m.activeConn)
+		m.selectModel = newSelectModel(msg.backend, m.hideActionHints, m.managed, m.activeConn, m.disableExitKeys)
 		m.selectModel.setSize(m.width, m.height)
 		m.state = viewSelect
 		var cmd tea.Cmd = m.selectModel.Init()
@@ -781,7 +792,7 @@ func (m AppModel) handleConnectResult(msg connectResultMsg) (AppModel, tea.Cmd) 
 	}
 
 	// Unrecoverable: bounce back to the picker with the error.
-	m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints)
+	m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 	m.connectionsModel.setSize(m.width, m.height)
 	if msg.err != nil {
 		m.connectionsModel.lastErr = msg.err

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -562,10 +562,10 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c":
 			if m.disableExitKeys {
-				// Embedded host disallows process termination
-				// (e.g. iOS, where Apple's HIG forbids quitting and
+				// Embedded host disallows process termination — on a
+				// native-platform shell whose OS forbids quitting,
 				// tea.Quit would only stop the TUI loop while the
-				// host view stays mounted). Swallow the keypress so
+				// host view stays mounted. Swallow the keypress so
 				// it doesn't accidentally tear down half the program.
 				return m, nil
 			}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -168,9 +168,9 @@ func TestNewApp_ManagedWithInitialStartsAtConnecting(t *testing.T) {
 }
 
 // TestAppModel_DisableExitKeysSwallowsCtrlC: when an embedded host can't
-// be dismissed by terminating the process (iOS), ctrl+c at the app level
-// must not return tea.Quit — it would only stop the TUI loop while the
-// host view stays mounted, leaving a dead Go session behind a frozen UI.
+// be dismissed by terminating the process, ctrl+c at the app level must
+// not return tea.Quit — it would only stop the TUI loop while the host
+// view stays mounted, leaving a dead Go session behind a frozen UI.
 func TestAppModel_DisableExitKeysSwallowsCtrlC(t *testing.T) {
 	store := &config.Connections{}
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -144,7 +144,7 @@ func TestNewApp_LegacyClientStartsAtSelect(t *testing.T) {
 func TestNewApp_ManagedNoInitialStartsAtConnections(t *testing.T) {
 	store := &config.Connections{}
 	m := NewApp(nil, AppOptions{
-		Store:         store,
+		Store:          store,
 		BackendFactory: func(*config.Connection) (backend.Backend, error) { return nil, nil },
 	})
 	if m.state != viewConnections {
@@ -158,12 +158,50 @@ func TestNewApp_ManagedWithInitialStartsAtConnecting(t *testing.T) {
 	store := &config.Connections{}
 	conn, _ := store.Add(config.ConnectionFields{Name: "home", Type: config.ConnTypeOpenClaw, URL: "https://home.example.com"})
 	m := NewApp(nil, AppOptions{
-		Store:         store,
-		Initial:       conn,
+		Store:          store,
+		Initial:        conn,
 		BackendFactory: func(*config.Connection) (backend.Backend, error) { return nil, nil },
 	})
 	if m.state != viewConnecting {
 		t.Errorf("managed-with-initial should start at viewConnecting, got %v", m.state)
+	}
+}
+
+// TestAppModel_DisableExitKeysSwallowsCtrlC: when an embedded host can't
+// be dismissed by terminating the process (iOS), ctrl+c at the app level
+// must not return tea.Quit — it would only stop the TUI loop while the
+// host view stays mounted, leaving a dead Go session behind a frozen UI.
+func TestAppModel_DisableExitKeysSwallowsCtrlC(t *testing.T) {
+	store := &config.Connections{}
+
+	// Default behaviour: ctrl+c quits.
+	cli := NewApp(nil, AppOptions{
+		Store:          store,
+		BackendFactory: func(*config.Connection) (backend.Backend, error) { return nil, nil },
+	})
+	_, cmd := cli.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected ctrl+c to return a tea.Quit command on the CLI")
+	}
+	if msg := cmd(); msg == nil {
+		t.Fatal("expected non-nil quit message from ctrl+c")
+	} else if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("expected tea.QuitMsg, got %T", msg)
+	}
+
+	// DisableExitKeys=true: ctrl+c is a no-op.
+	embedded := NewApp(nil, AppOptions{
+		Store:           store,
+		BackendFactory:  func(*config.Connection) (backend.Backend, error) { return nil, nil },
+		DisableExitKeys: true,
+	})
+	_, cmd = embedded.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(tea.QuitMsg); ok {
+				t.Fatal("DisableExitKeys=true should suppress tea.Quit on ctrl+c")
+			}
+		}
 	}
 }
 

--- a/internal/tui/connbanner_test.go
+++ b/internal/tui/connbanner_test.go
@@ -35,7 +35,7 @@ func TestRenderConnectionBanner(t *testing.T) {
 
 func TestSelectModel_RendersConnectionBanner(t *testing.T) {
 	conn := &config.Connection{Name: "home", Type: config.ConnTypeOpenClaw}
-	m := newSelectModel(newFakeBackend(), false, false, conn)
+	m := newSelectModel(newFakeBackend(), false, false, conn, false)
 	m.setSize(120, 40)
 	// Move out of the loading state so View() renders the list +
 	// banner rather than the loading placeholder.

--- a/internal/tui/connections.go
+++ b/internal/tui/connections.go
@@ -186,7 +186,7 @@ func newConnectionsModel(store *config.Connections, hideHints, disableExitKeys b
 	if disableExitKeys {
 		// The bubbles list's default Quit binding catches q / esc and
 		// emits tea.Quit; ForceQuit catches ctrl+c. Embedders whose
-		// host can't be dismissed by terminating the process (iOS) get
+		// host can't be dismissed by terminating the process get
 		// neither shortcut, and the rendered "q quit" footer hint
 		// disappears with the binding.
 		l.KeyMap.Quit.Unbind()

--- a/internal/tui/connections.go
+++ b/internal/tui/connections.go
@@ -176,13 +176,22 @@ func presetForConnection(conn config.Connection) formPreset {
 	return presetOpenAI
 }
 
-func newConnectionsModel(store *config.Connections, hideHints bool) connectionsModel {
+func newConnectionsModel(store *config.Connections, hideHints, disableExitKeys bool) connectionsModel {
 	l := list.New(nil, connectionDelegate{}, 0, 0)
 	l.Title = "Connections"
 	l.SetShowStatusBar(false)
 	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
+	if disableExitKeys {
+		// The bubbles list's default Quit binding catches q / esc and
+		// emits tea.Quit; ForceQuit catches ctrl+c. Embedders whose
+		// host can't be dismissed by terminating the process (iOS) get
+		// neither shortcut, and the rendered "q quit" footer hint
+		// disappears with the binding.
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
 	return connectionsModel{
 		store:     store,
 		list:      l,

--- a/internal/tui/connections_test.go
+++ b/internal/tui/connections_test.go
@@ -465,7 +465,7 @@ func TestConnectionsModel_DisableExitKeysUnbindsListQuit(t *testing.T) {
 	// With DisableExitKeys=false the bubbles list still binds q/esc to
 	// Quit and ctrl+c to ForceQuit, and the help footer renders
 	// "q quit". Embedded hosts that can't be dismissed by terminating
-	// the process (iOS) need both shortcuts and the hint gone.
+	// the process need both shortcuts and the hint gone.
 	on := newConnectionsModel(&config.Connections{}, false, true)
 	if on.list.KeyMap.Quit.Enabled() {
 		t.Error("DisableExitKeys=true should unbind list Quit (q/esc)")

--- a/internal/tui/connections_test.go
+++ b/internal/tui/connections_test.go
@@ -34,7 +34,7 @@ func focusTypeRadio(m connectionsModel) connectionsModel {
 }
 
 func TestConnectionsModel_RendersEmptyState(t *testing.T) {
-	m := newConnectionsModel(&config.Connections{}, false)
+	m := newConnectionsModel(&config.Connections{}, false, false)
 	out := m.View()
 	if !strings.Contains(out, "No connections yet") {
 		t.Errorf("expected empty-state hint in view, got:\n%s", out)
@@ -43,7 +43,7 @@ func TestConnectionsModel_RendersEmptyState(t *testing.T) {
 
 func TestConnectionsModel_RendersListItems(t *testing.T) {
 	store := newSeededStore(t)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 	out := m.View()
@@ -58,7 +58,7 @@ func TestConnectionsModel_RendersListItems(t *testing.T) {
 func TestConnectionsModel_DefaultBadge(t *testing.T) {
 	store := newSeededStore(t)
 	store.MarkUsed(store.Connections[0].ID)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 	if !strings.Contains(m.View(), "(default)") {
@@ -68,7 +68,7 @@ func TestConnectionsModel_DefaultBadge(t *testing.T) {
 
 func TestConnectionsModel_NewConnectionFlow(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 
 	// Trigger 'n' (new).
@@ -100,7 +100,7 @@ func TestConnectionsModel_NewConnectionFlow(t *testing.T) {
 
 func TestConnectionsModel_NewConnectionRejectsInvalidURL(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 
 	m.nameInput.SetValue("bad")
@@ -120,7 +120,7 @@ func TestConnectionsModel_NewConnectionRejectsInvalidURL(t *testing.T) {
 
 func TestConnectionsModel_DeleteConfirmFlow(t *testing.T) {
 	store := newSeededStore(t)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 
@@ -160,7 +160,7 @@ func TestConnectionsModel_DeleteConfirmFlow(t *testing.T) {
 
 func TestConnectionsModel_EnterEmitsPickedMsg(t *testing.T) {
 	store := newSeededStore(t)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 	m.list.Select(0)
@@ -181,7 +181,7 @@ func TestConnectionsModel_EnterEmitsPickedMsg(t *testing.T) {
 
 func TestConnectionsModel_TypeCycleUpdatesPreset(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 	m = focusTypeRadio(m)
 
@@ -239,7 +239,7 @@ func TestConnectionsModel_TypeCycleUpdatesPreset(t *testing.T) {
 
 func TestConnectionsModel_OllamaPresetPersistsAsOpenAI(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 	m = focusTypeRadio(m)
 
@@ -275,7 +275,7 @@ func TestConnectionsModel_OllamaPresetPersistsAsOpenAI(t *testing.T) {
 
 func TestConnectionsModel_HermesPresetPersistsAsHermes(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 	m = focusTypeRadio(m)
 
@@ -312,7 +312,7 @@ func TestConnectionsModel_HermesPresetPersistsAsHermes(t *testing.T) {
 
 func TestConnectionsModel_OpenAITabOrderIncludesModel(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 	m = focusTypeRadio(m)
 
@@ -330,7 +330,7 @@ func TestConnectionsModel_OpenAITabOrderIncludesModel(t *testing.T) {
 
 func TestConnectionsModel_EditFormSkipsTypeRadio(t *testing.T) {
 	store := newSeededStore(t)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 	m.list.Select(0)
@@ -353,7 +353,7 @@ func TestConnectionsModel_EditFormSkipsTypeRadio(t *testing.T) {
 
 func TestConnectionsModel_NewOpenAIConnectionPersistsModel(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 	m = focusTypeRadio(m)
 
@@ -382,7 +382,7 @@ func TestConnectionsModel_NewOpenAIConnectionPersistsModel(t *testing.T) {
 
 func TestConnectionsModel_NewFormRendersOnlyRelevantFields(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 
 	// OpenClaw form: no model field rendered.
@@ -411,7 +411,7 @@ func TestConnectionsModel_NewFormRendersOnlyRelevantFields(t *testing.T) {
 
 func TestConnectionsModel_TabAdvancesFocus(t *testing.T) {
 	store := &config.Connections{}
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m, _ = m.TriggerAction("new-connection")
 
 	// New form lands focus on Name so the host's first keystroke
@@ -441,7 +441,7 @@ func TestConnectionsModel_TabAdvancesFocus(t *testing.T) {
 
 func TestConnectionsModel_EditFlow(t *testing.T) {
 	store := newSeededStore(t)
-	m := newConnectionsModel(store, false)
+	m := newConnectionsModel(store, false, false)
 	m.setSize(80, 20)
 	m.rebuildItems()
 	m.list.Select(0)
@@ -461,14 +461,33 @@ func TestConnectionsModel_EditFlow(t *testing.T) {
 	}
 }
 
+func TestConnectionsModel_DisableExitKeysUnbindsListQuit(t *testing.T) {
+	// With DisableExitKeys=false the bubbles list still binds q/esc to
+	// Quit and ctrl+c to ForceQuit, and the help footer renders
+	// "q quit". Embedded hosts that can't be dismissed by terminating
+	// the process (iOS) need both shortcuts and the hint gone.
+	on := newConnectionsModel(&config.Connections{}, false, true)
+	if on.list.KeyMap.Quit.Enabled() {
+		t.Error("DisableExitKeys=true should unbind list Quit (q/esc)")
+	}
+	if on.list.KeyMap.ForceQuit.Enabled() {
+		t.Error("DisableExitKeys=true should unbind list ForceQuit (ctrl+c)")
+	}
+
+	off := newConnectionsModel(&config.Connections{}, false, false)
+	if !off.list.KeyMap.Quit.Enabled() {
+		t.Error("DisableExitKeys=false should keep the default Quit binding for the CLI")
+	}
+}
+
 func TestConnectionsModel_ActionsListReflectsState(t *testing.T) {
-	m := newConnectionsModel(&config.Connections{}, false)
+	m := newConnectionsModel(&config.Connections{}, false, false)
 	if got := m.Actions(); len(got) != 1 || got[0].ID != "new-connection" {
 		t.Errorf("empty store should expose only New, got %+v", got)
 	}
 
 	store := newSeededStore(t)
-	m = newConnectionsModel(store, false)
+	m = newConnectionsModel(store, false, false)
 	m.rebuildItems()
 	m.list.Select(0)
 	gotIDs := []string{}

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/config"
@@ -229,10 +229,10 @@ type cronForm struct {
 	deliveryMode  string // "none", "announce", "webhook"
 	enabled       bool
 
-	focused      cronFormField
-	saving       bool
-	err          error
-	unsupported  string // non-empty when the existing job's kind cannot be edited; rendered as a banner
+	focused     cronFormField
+	saving      bool
+	err         error
+	unsupported string // non-empty when the existing job's kind cannot be edited; rendered as a banner
 }
 
 // cronsModel is the cron browser view.
@@ -270,13 +270,17 @@ type cronsModel struct {
 	height     int
 }
 
-func newCronsModel(cron backend.CronBackend, filterAgentID, filterLabel string, hideHints bool, activeConn *config.Connection) cronsModel {
+func newCronsModel(cron backend.CronBackend, filterAgentID, filterLabel string, hideHints bool, activeConn *config.Connection, disableExitKeys bool) cronsModel {
 	l := list.New(nil, cronDelegate{}, 0, 0)
 	l.Title = "Cron"
 	l.SetShowStatusBar(false)
 	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
+	if disableExitKeys {
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
 
 	return cronsModel{
 		list:          l,

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -3,14 +3,14 @@ package tui
 import (
 	"testing"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 )
 
 func newTestCronsModel(t *testing.T) (cronsModel, *fakeBackend) {
 	t.Helper()
 	fake := newFakeBackend()
-	m := newCronsModel(fake, "agent-1", "Scout", false, nil)
+	m := newCronsModel(fake, "agent-1", "Scout", false, nil, false)
 	m.setSize(120, 40)
 	return m, fake
 }
@@ -294,7 +294,7 @@ func TestCronsForm_EditSubmitUsesRawUpdate(t *testing.T) {
 		Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "old text", Model: "haiku-4-5"},
 	}}
 	m, _ = m.Update(cronsLoadedMsg{jobs: jobs})
-	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})  // open detail
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})   // open detail
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'e', Text: "e"}) // open edit form
 	if m.subset != cronSubForm {
 		t.Fatalf("expected form substate, got %v", m.subset)

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
-	teatest "github.com/charmbracelet/x/exp/teatest/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 	"github.com/charmbracelet/x/ansi"
+	teatest "github.com/charmbracelet/x/exp/teatest/v2"
 
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
@@ -291,7 +291,7 @@ func TestRender_ChatView_RemoteExecModeHelpText(t *testing.T) {
 // tests assert against).
 func newLoadedSelectAdapter(t *testing.T, agents ...protocol.AgentSummary) selectModelAdapter {
 	t.Helper()
-	m := newSelectModel(newFakeBackend(), false, false, nil)
+	m := newSelectModel(newFakeBackend(), false, false, nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -328,7 +328,7 @@ func TestRender_SelectView_ShowsCreateHint(t *testing.T) {
 }
 
 func TestRender_SelectView_LoadingState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.setSize(120, 40)
 	adapter := selectModelAdapter{inner: m}
 
@@ -358,7 +358,7 @@ func TestRender_SelectView_CreateFormLabels(t *testing.T) {
 func TestRender_SelectView_CreateFormHidesWorkspaceForLocalBackend(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentWorkspace = false
-	m := newSelectModel(fb, false, false, nil)
+	m := newSelectModel(fb, false, false, nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -387,7 +387,7 @@ func TestRender_SelectView_CreateFormHidesWorkspaceForLocalBackend(t *testing.T)
 func TestSelectModel_LocalBackendCreateFormShape(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentWorkspace = false
-	m := newSelectModel(fb, true, false, nil)
+	m := newSelectModel(fb, true, false, nil, false)
 	m.initCreateForm()
 	out := m.viewCreateForm()
 	if strings.Contains(out, "Workspace:") {
@@ -405,7 +405,7 @@ func TestSelectModel_LocalBackendCreateFormShape(t *testing.T) {
 }
 
 func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{err: errString("gateway unreachable")})
 	adapter := selectModelAdapter{inner: m}
@@ -440,7 +440,7 @@ func (a sessionsModelAdapter) View() tea.View {
 // newLoadedSessionsAdapter returns a sessionsModelAdapter with sessions already loaded.
 func newLoadedSessionsAdapter(t *testing.T, sessions ...sessionItem) sessionsModelAdapter {
 	t.Helper()
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil)
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(sessionsLoadedMsg{sessions: sessions})
 	return sessionsModelAdapter{inner: m}
@@ -470,7 +470,7 @@ func TestRender_SessionsView_ShowsCreateHint(t *testing.T) {
 }
 
 func TestRender_SessionsView_LoadingState(t *testing.T) {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil)
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil, false)
 	m.setSize(120, 40)
 	adapter := sessionsModelAdapter{inner: m}
 
@@ -490,7 +490,7 @@ func TestRender_SessionsView_EmptyState(t *testing.T) {
 }
 
 func TestRender_SessionsView_ErrorState(t *testing.T) {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil)
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil, false)
 	m.setSize(120, 40)
 	m, _ = m.Update(sessionsLoadedMsg{err: errString("network timeout")})
 	adapter := sessionsModelAdapter{inner: m}

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -7,11 +7,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/config"
@@ -72,13 +72,13 @@ var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
 // selectModel is the agent selection view.
 type selectModel struct {
-	list             list.Model
-	backend          backend.Backend
-	loading          bool
-	err              error
-	mainKey          string
-	selected         bool
-	hideHints        bool
+	list      list.Model
+	backend   backend.Backend
+	loading   bool
+	err       error
+	mainKey   string
+	selected  bool
+	hideHints bool
 	// showConnections enables the "Connections" action so the user
 	// can jump back to the connections picker from the agent list
 	// without going through chat first. Only meaningful in managed
@@ -106,15 +106,15 @@ type selectModel struct {
 	activeConn *config.Connection
 
 	// Create-agent form state.
-	subState       selectSubState
-	nameInput      textinput.Model
-	workInput      textinput.Model
-	focusedField   int // 0 = name, 1 = workspace (when useWorkspace)
-	creating       bool
-	createErr      error
-	newAgentID     string
+	subState        selectSubState
+	nameInput       textinput.Model
+	workInput       textinput.Model
+	focusedField    int // 0 = name, 1 = workspace (when useWorkspace)
+	creating        bool
+	createErr       error
+	newAgentID      string
 	workspaceEdited bool
-	nameValidMsg   string
+	nameValidMsg    string
 
 	// Confirm-delete substate.
 	pendingDeleteID   string
@@ -152,7 +152,7 @@ type agentDeletedMsg struct {
 // here so the picker doesn't have to keep asking. activeConn (when
 // non-nil) is rendered as a thin status row at the top of the view
 // so the user can see which connection is in scope.
-func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeConn *config.Connection) selectModel {
+func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeConn *config.Connection, disableExitKeys bool) selectModel {
 	useWorkspace := false
 	allowAgentMgmt := false
 	if b != nil {
@@ -171,6 +171,10 @@ func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeCo
 	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
+	if disableExitKeys {
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
 
 	return selectModel{
 		list:                 l,

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 )
@@ -29,7 +29,7 @@ func loadAgents(m selectModel, agents ...protocol.AgentSummary) selectModel {
 }
 
 func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -59,7 +59,7 @@ func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -80,7 +80,7 @@ func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 
 	msg := agentsLoadedMsg{
 		err: fmt.Errorf("connection failed"),
@@ -97,7 +97,7 @@ func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormActivation(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	// Simulate agents loaded so the list is ready.
 	m.loading = false
 	m.allowAgentManagement = true
@@ -110,7 +110,7 @@ func TestSelectModel_CreateFormActivation(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormCancel(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.loading = false
 	m.allowAgentManagement = true
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
@@ -126,7 +126,7 @@ func TestSelectModel_CreateFormCancel(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormNotActivatedWhileLoading(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	// loading is true by default
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
@@ -179,7 +179,7 @@ func TestValidateName(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -202,7 +202,7 @@ func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -221,7 +221,7 @@ func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -244,7 +244,7 @@ func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedError(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -264,7 +264,7 @@ func TestSelectModel_AgentCreatedError(t *testing.T) {
 }
 
 func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.newAgentID = "new-agent"
 
 	m, _ = m.Update(agentsLoadedMsg{
@@ -294,14 +294,14 @@ func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
 }
 
 func TestSelectModel_ConnectionsActionOnlyInManagedMode(t *testing.T) {
-	legacy := newSelectModel(nil, false, false, nil)
+	legacy := newSelectModel(nil, false, false, nil, false)
 	for _, a := range legacy.Actions() {
 		if a.ID == "connections" {
 			t.Errorf("legacy mode should not expose connections action, got %+v", legacy.Actions())
 		}
 	}
 
-	managed := newSelectModel(nil, false, true, nil)
+	managed := newSelectModel(nil, false, true, nil, false)
 	// Loaded state — no error — so the new-agent action is also
 	// present. Find the connections action.
 	var found *Action
@@ -331,7 +331,7 @@ func hasAction(m selectModel, id string) bool {
 }
 
 func TestSelectModel_DeleteActionAppearsWhenManagementEnabled(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 
@@ -341,7 +341,7 @@ func TestSelectModel_DeleteActionAppearsWhenManagementEnabled(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenManagementDisabled(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	// allowAgentManagement remains false (Hermes-style)
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 
@@ -351,7 +351,7 @@ func TestSelectModel_DeleteActionHiddenWhenManagementDisabled(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenLoading(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	// loading=true is the initial state — list never received a load msg.
 
@@ -361,7 +361,7 @@ func TestSelectModel_DeleteActionHiddenWhenLoading(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenEmptyList(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m) // no agents
 
@@ -371,7 +371,7 @@ func TestSelectModel_DeleteActionHiddenWhenEmptyList(t *testing.T) {
 }
 
 func TestSelectModel_TriggerDeleteEntersConfirmSubstate(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha Agent"})
 
@@ -395,7 +395,7 @@ func TestSelectModel_TriggerDeleteEntersConfirmSubstate(t *testing.T) {
 }
 
 func TestSelectModel_TriggerDeleteUsesIDWhenNameEmpty(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "id-only"})
 
@@ -406,7 +406,7 @@ func TestSelectModel_TriggerDeleteUsesIDWhenNameEmpty(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteRequiresNameMatch(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -427,7 +427,7 @@ func TestSelectModel_ConfirmDeleteRequiresNameMatch(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteCaseInsensitive(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "My Agent"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -444,7 +444,7 @@ func TestSelectModel_ConfirmDeleteCaseInsensitive(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteEscClearsState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -461,7 +461,7 @@ func TestSelectModel_ConfirmDeleteEscClearsState(t *testing.T) {
 }
 
 func TestSelectModel_ToggleKeepFilesFlipsState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -490,7 +490,7 @@ func TestSelectModel_ToggleKeepFilesFlipsState(t *testing.T) {
 }
 
 func TestSelectModel_ToggleKeepFilesViaTabKey(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -504,7 +504,7 @@ func TestSelectModel_ToggleKeepFilesViaTabKey(t *testing.T) {
 func TestSelectModel_DeleteCmdPassesKeepFilesChoice(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentManagement = true
-	m := newSelectModel(fb, false, false, nil)
+	m := newSelectModel(fb, false, false, nil, false)
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
 	m.confirmInput.SetValue("Alpha")
@@ -537,7 +537,7 @@ func TestSelectModel_DeleteCmdPassesKeepFilesChoice(t *testing.T) {
 func TestSelectModel_ConfirmDeleteIgnoredWithoutMatch(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentManagement = true
-	m := newSelectModel(fb, false, false, nil)
+	m := newSelectModel(fb, false, false, nil, false)
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
 	m.confirmInput.SetValue("nope")
@@ -552,7 +552,7 @@ func TestSelectModel_ConfirmDeleteIgnoredWithoutMatch(t *testing.T) {
 }
 
 func TestSelectModel_AgentDeletedSuccessReloads(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -575,7 +575,7 @@ func TestSelectModel_AgentDeletedSuccessReloads(t *testing.T) {
 }
 
 func TestSelectModel_AgentDeletedErrorStaysInConfirm(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -600,7 +600,7 @@ func TestSelectModel_AgentDeletedErrorStaysInConfirm(t *testing.T) {
 }
 
 func TestSelectModel_DeletingBlocksKeystrokes(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil)
+	m := newSelectModel(nil, false, false, nil, false)
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -618,7 +618,7 @@ func TestSelectModel_DeletingBlocksKeystrokes(t *testing.T) {
 var _ = backend.DeleteAgentParams{}
 
 func TestSelectModel_ConnectionsActionEmitsShowConnections(t *testing.T) {
-	m := newSelectModel(nil, false, true, nil)
+	m := newSelectModel(nil, false, true, nil, false)
 	_, cmd := m.TriggerAction("connections")
 	if cmd == nil {
 		t.Fatal("expected cmd from connections action")

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -104,7 +104,7 @@ type sessionsModel struct {
 	activeConn *config.Connection // rendered above the session list — see renderConnectionBanner.
 }
 
-func newSessionsModel(b backend.Backend, agentID, agentName, modelID, mainKey string, hideHints bool, activeConn *config.Connection) sessionsModel {
+func newSessionsModel(b backend.Backend, agentID, agentName, modelID, mainKey string, hideHints bool, activeConn *config.Connection, disableExitKeys bool) sessionsModel {
 	l := list.New(nil, sessionDelegate{}, 0, 0)
 	l.Title = "Sessions"
 	l.SetShowStatusBar(false)
@@ -113,6 +113,10 @@ func newSessionsModel(b backend.Backend, agentID, agentName, modelID, mainKey st
 	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
 	l.SetFilteringEnabled(false)
+	if disableExitKeys {
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
 
 	return sessionsModel{
 		list:       l,

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newTestSessionsModel() sessionsModel {
-	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil)
+	m := newSessionsModel(nil, "agent-1", "Scout", "model-1", "main-key", false, nil, false)
 	m.setSize(120, 40)
 	return m
 }
@@ -202,7 +202,7 @@ func TestSkipHeaders_SkipsGroupHeader(t *testing.T) {
 	// After loading, the list has [header, s1, s2] and selection is at index 1.
 	// Move up should skip the header.
 	m.list.Select(0) // put on the header
-	m.skipHeaders(1)  // move down
+	m.skipHeaders(1) // move down
 	if m.list.Index() != 1 {
 		t.Errorf("expected index 1 after skipping header, got %d", m.list.Index())
 	}


### PR DESCRIPTION
Adds an opt-in `RunOptions.DisableExitKeys` flag for embedders whose host disallows programmatic process termination, suppressing every quit shortcut so the rendered help text matches reality.

## Summary

- New `DisableExitKeys bool` on `app.RunOptions`, plumbed through to `tui.AppOptions` and into each list-backed picker (`connections`, `select`, `sessions`, `crons`).
- When set, the bubbles list's default `Quit` (`q` / `esc`) and `ForceQuit` (`ctrl+c`) bindings are unbound, which also removes the matching "q quit" entry from the help footer.
- `AppModel.Update` no longer returns `tea.Quit` on `ctrl+c` while the flag is set; the keypress is swallowed.
- Regression coverage: `TestAppModel_DisableExitKeysSwallowsCtrlC` and `TestConnectionsModel_DisableExitKeysUnbindsListQuit`.
- The CLI leaves the flag at its zero value, so existing behaviour is unchanged.

## Implementation details

The hint text and the bound shortcut share the same `key.Binding` value on the bubbles list, so `Unbind()` removes them together. That keeps the rendered footer honest without having to reach into the list's help renderer.

The flag was added rather than reusing `HideActionHints` because the two concerns are independent: a host can have a hardware keyboard attached (hints visible) yet still be unable to honour a quit shortcut. Conflating them would re-introduce the misleading "q quit" hint on those configurations.