### PR TITLE
fix(client): re-dial after first-time pairing and time-bound session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Switch between saved connections at any time with `/connections` from the chat v
 lucinate
 ```
 
-#### Optional (OpenClaw only)
+#### First-time pairing (OpenClaw only)
 
-On first run, lucinate generates an Ed25519 device identity under `~/.lucinate/identity/<endpoint>/` (keyed by gateway host) and sends a pairing request to the gateway. On the gateway host, run:
+On first run, lucinate generates an Ed25519 device identity under `~/.lucinate/identity/<endpoint>/` (keyed by gateway host) and sends a pairing request to the gateway. The TUI shows a "pairing required" prompt with the next steps. On the gateway host, run:
 
 ```sh
 openclaw device list --pending
@@ -102,7 +102,7 @@ You should see lucinate's device ID. Approve it:
 openclaw device approve <device-id>
 ```
 
-Then restart lucinate — subsequent connections use the stored device token automatically.
+Press Enter in the lucinate prompt to retry — the connection completes in place, the gateway issues a device token, and you land in the agent picker. No restart needed.
 
 ### 3. Pick an agent
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,48 +20,59 @@ On first run, `identity.Store.LoadOrGenerate()` creates an Ed25519 keypair under
 
 ## First-run pairing flow
 
-1. Run `lucinate` — the client connects to the gateway with the device identity but no token. The gateway registers a pending pairing request.
-2. On the gateway host, an administrator approves the device:
+1. Run `lucinate` — the client connects to the gateway with the device identity but no token. The gateway responds `NOT_PAIRED` and registers a pending pairing request.
+2. The connecting view enters its `subStatePairingRequired` modal (`internal/tui/connecting.go`) with on-screen instructions. On the gateway host, an administrator approves the device:
    ```
    openclaw device list --pending
    openclaw device approve <device-id>
    ```
-3. Restart `lucinate`. The client reconnects; the gateway issues a device token, which is saved to the endpoint's identity directory via `client.store.SaveDeviceToken()`.
+3. The user presses Enter in the modal. `authResolvedMsg{}` triggers `retryConnect` (`internal/tui/app.go`), which re-invokes `Connect` on the same backend. The gateway accepts the connection and issues a fresh device token in `hello.Auth.DeviceToken`, which `client.dial` persists via `store.SaveDeviceToken`.
+4. `dial` then closes the bootstrap connection and re-dials with the freshly-issued token (see [Re-dial after first-time pairing](#re-dial-after-first-time-pairing)). The TUI advances to the agent picker — no process restart required.
 
-The save is non-fatal — if it fails, a warning is logged but the session continues. On subsequent runs the saved token is loaded and presented on connect.
+The token save is non-fatal — if it fails, a warning is logged but the session continues. On subsequent runs the saved token is loaded and presented on connect.
 
 **Note:** Bootstrap tokens were removed in v0.10.2. Device pairing is the only setup path.
 
+## Re-dial after first-time pairing
+
+The bootstrap connect for a freshly approved device authenticates by Ed25519 device-key signature alone — the token field on `connect` is empty because the client doesn't have one yet. The gateway issues the first device token in `hello-ok`. Reusing that bootstrap connection for scoped RPCs leaves `sessions.create` silently stalled; the OpenClaw protocol expects scoped operations to run on a connection that authenticated *with* the token at connect time.
+
+`internal/client/client.go` handles this inline: when `dial` observes that it presented an empty token AND the gateway returned a non-empty `hello.Auth.DeviceToken`, it persists the token, closes the bootstrap `gateway.Client`, and dials a second time so the surviving connection carries the issued token. Subsequent launches (token already on disk → bootstrap presents it → gateway returns no new one) skip the second dial. Tests pin both branches in `internal/client/dial_test.go`.
+
+The TUI also wraps `CreateSession` (`internal/tui/app.go`) in a per-call `context.WithTimeout` derived as `2 ×` the configured connect timeout, so any future stall in this region surfaces as a UI error in the agent picker rather than freezing the view.
+
 ## Subsequent runs
 
-1. Load `OPENCLAW_GATEWAY_URL` from environment.
+1. Load `OPENCLAW_GATEWAY_URL` from environment, or use a saved connection from `~/.lucinate/connections.json`.
 2. Load the Ed25519 identity and stored device token from `~/.lucinate/identity/<endpoint>/`.
 3. Open a WebSocket connection to the gateway with the identity and token. The gateway SDK (`github.com/a3tai/openclaw-go`) attaches the token to all API calls.
-4. On a successful `Hello` handshake, any refreshed token is saved back to disk.
+4. On a successful `Hello` handshake, any refreshed token is saved back to disk; no second dial is needed because the connection already authenticated with a token.
 5. Proceed to the agent picker.
 
-If the token is expired or revoked the gateway rejects the connection and an error is shown in the agent picker. The user can press `r` to retry after the device has been re-approved.
+If the token is expired or revoked the gateway rejects the connection and the connecting view opens the appropriate auth-recovery modal (see below).
 
 ## Interactive auth recovery on connect
 
-When the initial connect fails with an auth error, `connectWithAuth` in `main.go` handles it interactively before exiting:
+When `Connect` fails with a recognised auth error, `runConnect` in `internal/tui/app.go` classifies it via the `isNotPairedErr` / `isTokenMismatchErr` / `isTokenMissingErr` / `isAPIKeyErr` predicates and `handleConnectResult` opens the matching modal sub-state in `internal/tui/connecting.go`:
 
-- **Token mismatch** (`gateway token mismatch`) — the stored device token is no longer valid for this gateway (for example, the device was removed and re-added). The user is offered three choices:
-  1. Clear the stored token and retry pairing (default).
-  2. Reset the device identity entirely (new keypair) and retry pairing.
-  3. Quit.
-- **Token missing** (`gateway token missing`) — the gateway requires a pre-shared auth token that the client doesn't have. This can occur on a first-time connect, or as a follow-up after a clear/reset retry. The user is prompted to paste the gateway auth token, which is saved via `client.StoreToken()` and the connect is retried.
+- **Not paired** (`NOT_PAIRED`) — pairing-required modal: instructions to run `openclaw device approve` on the gateway host, then Enter to retry. See [First-run pairing flow](#first-run-pairing-flow).
+- **Token mismatch** (`gateway token mismatch`) — the stored device token is no longer valid for this gateway (for example, the device was removed and re-added). The modal offers three choices, each routed through the `DeviceTokenAuth` sub-interface on the live backend:
+  1. Clear the stored token and retry pairing (`ClearToken`, default).
+  2. Reset the device identity entirely (new keypair) and retry pairing (`ResetIdentity`).
+  3. Cancel back to the connections picker.
+- **Token missing** (`gateway token missing`) — text prompt for a pre-shared token; submission stores via `DeviceTokenAuth.StoreToken` and the connect is retried.
+- **API key required** (HTTP 401/403 from any `/v1` request on OpenAI-compat or Hermes connections) — text prompt for an API key; submission stores via `APIKeyAuth.StoreAPIKey`.
 
-Both flows read from `os.Stdin`, so they only trigger in an interactive terminal. Non-interactive callers will see the original error and exit.
+All four flows happen inside the running TUI — modal text inputs, not stdin. Cancellation routes back to the connections picker; the active backend is closed before the next pick.
 
 ## Reconnect after disconnection
 
 Once the TUI is running, a supervisor in `internal/client/supervisor.go` watches the gateway connection (`Client.Done()`) and reconnects automatically if it drops — for example, when the gateway is restarted.
 
-- **Backoff schedule:** 1s, 2s, 4s, 8s, 15s, then 30s for every subsequent attempt. Each attempt has a 15s connect timeout (matching `connectTimeout` for the initial connect).
-- **State surface:** the supervisor pushes `tui.ConnStateMsg` into the bubbletea program. The chat header shows `⚠ disconnected`, `⟳ reconnecting (attempt N)`, or `✖ auth failed — restart`. A one-line system message is added to the chat scrollback on disconnect and on recovery.
+- **Backoff schedule:** 1s, 2s, 4s, 8s, 15s, then 30s for every subsequent attempt. Each attempt's connect timeout comes from `prefs.ConnectTimeoutSeconds` (default 15s), the same knob that floors the initial connect.
+- **State surface:** the supervisor pushes `tui.ConnStateMsg` into the bubbletea program. The chat header shows `⚠ disconnected`, `⟳ reconnecting (attempt N)`, or `✖ auth failed`. A one-line system message is added to the chat scrollback on disconnect and on recovery.
 - **In-flight streams:** if a reply was streaming when the connection dropped, the placeholder is cleared so the input is usable again. The gateway has no resume protocol for an interrupted run; the partial reply is abandoned.
-- **Auth failures:** if the gateway rejects the device token after restart (`gateway token mismatch` / `token missing`), the supervisor stops retrying. The chat banner instructs the user to quit (Ctrl+C) and restart so the interactive `connectWithAuth` flow can prompt for a fix — that flow needs `os.Stdin`, which bubbletea owns once the TUI is up.
+- **Auth failures:** if the gateway rejects the device token mid-session (`gateway token mismatch` / `token missing`), the supervisor stops retrying. The chat banner advises switching connections via `/connections` so the connecting view's auth-recovery modal can run on the chosen connection. The supervisor cannot drive the modal itself — that flow lives on the connect path, not the reconnect path.
 
 ## Scopes
 

--- a/docs/backend_openai.md
+++ b/docs/backend_openai.md
@@ -16,7 +16,7 @@ See [connections.md](connections.md) for the cross-backend connection lifecycle 
 
 `Connect(ctx)` issues `GET /v1/models`. A 401 or 403 is surfaced as the canonical `api key required` error so the connecting view routes it to the API-key modal. Any other ≥400 response surfaces as `connect: HTTP <code>: <body>`.
 
-The API key is sent as `Authorization: Bearer <key>` when present and omitted otherwise (some endpoints — Ollama, vLLM without auth — accept anonymous requests). The auth modal calls `StoreAPIKey`, which updates the in-memory key on the live backend and (via the `secretAwareBackend` shim in `main.go`) writes through to `~/.lucinate/secrets/secrets.json` so the next launch reuses it without re-prompting.
+The API key is sent as `Authorization: Bearer <key>` when present and omitted otherwise (some endpoints — Ollama, vLLM without auth — accept anonymous requests). The auth modal calls `StoreAPIKey`, which updates the in-memory key on the live backend and (via the `secretAwareOpenAIBackend` shim in `app/factory.go`) writes through to `~/.lucinate/secrets/secrets.json` so the next launch reuses it without re-prompting.
 
 ## Agent storage
 

--- a/docs/backend_openclaw.md
+++ b/docs/backend_openclaw.md
@@ -23,10 +23,11 @@ See [connections.md](connections.md) for the cross-backend connection lifecycle 
 
 `Connect`, `Close`, `Events`, and `Supervise` are pass-throughs to the underlying client. The TUI's connecting view routes auth failures into modal sub-states:
 
+- `NOT_PAIRED` → pairing-required modal: instructions to approve the device on the gateway host, then Enter to retry.
 - `gateway token mismatch` → device-token modal: clear / reset identity / cancel. `ClearToken` and `ResetIdentity` come from the `DeviceTokenAuth` sub-interface.
 - `gateway token missing` → device-token text prompt; submission stores via `StoreToken`.
 
-Tokens and the Ed25519 device identity live under `~/.lucinate/identity/<endpoint>/`, isolated per gateway endpoint — see [authentication.md](authentication.md) for the full pairing flow.
+Tokens and the Ed25519 device identity live under `~/.lucinate/identity/<endpoint>/`, isolated per gateway endpoint. The first successful connect after a fresh approval re-dials transparently so the surviving connection authenticates with the issued token — see [authentication.md](authentication.md) for the full pairing flow and the re-dial rationale.
 
 ## Agent and session model
 

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -51,7 +51,7 @@ The connection-status badge is rendered in the error colour and only appears whe
 |---|---|
 | `⚠ disconnected` | The supervisor has just observed the WebSocket close; reconnect not yet attempted. |
 | `⟳ reconnecting` (or `attempt N`) | A reconnect attempt is in progress. The attempt counter is shown from the second attempt onwards. |
-| `✖ auth failed — restart` | The gateway rejected the device token after restart. The supervisor has stopped retrying — Ctrl+C and re-run `lucinate` so the interactive auth recovery flow can run on stdin. |
+| `✖ auth failed` | The gateway rejected the device token mid-session. The supervisor has stopped retrying — open `/connections` and re-pick the same connection so the connecting view's auth-recovery modal can prompt for a fix. |
 
 A matching one-line system message is also added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. See [authentication.md](authentication.md#reconnect-after-disconnection) for the full lifecycle.
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -60,7 +60,7 @@ The submission flow dispatches on `connectingModel.authNeed` rather than on Go i
 
 API keys live at `~/.lucinate/secrets/secrets.json` (mode 0600), keyed by connection ID. `config.GetAPIKey(connID)` and `config.SetAPIKey(connID, key)` are the public surface. `LUCINATE_OPENAI_API_KEY` falls back when no per-connection key is stored.
 
-The `secretAwareBackend` shim in `main.go` wraps `*openai.Backend` so `StoreAPIKey` writes through to disk during the auth-modal resolution path; the next launch reuses the key without re-prompting.
+The `secretAwareOpenAIBackend` and `secretAwareHermesBackend` shims in `app/factory.go` wrap their respective concrete backends so `StoreAPIKey` writes through to `~/.lucinate/secrets/secrets.json` during the auth-modal resolution path; the next launch reuses the key without re-prompting.
 
 A future enhancement is to back this with the OS keychain (Keychain on macOS, libsecret on Linux, Credential Manager on Windows) and fall back to the JSON file when no keychain is available — kept on disk for now to avoid platform-specific dependencies on first run.
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -146,29 +146,62 @@ func (c *Client) Reconnect(ctx context.Context) error {
 }
 
 // dial loads identity, builds options, and performs the SDK handshake.
+//
+// First-time pairing is handled inline: if the bootstrap connect
+// presented no device token (the device key signature alone got us
+// past the gateway's NOT_PAIRED gate after an admin approval) and the
+// gateway issued a fresh token in hello-ok, the bootstrap client is
+// closed and a second dial is performed with the new token. The
+// OpenClaw protocol expects scoped operations to run on a connection
+// that authenticated with the token at connect time; staying on the
+// bootstrap connection causes subsequent RPCs (sessions.create in
+// particular) to silently stall.
 func (c *Client) dial(ctx context.Context) error {
-	opts, err := c.buildOptions()
+	requestedToken := c.store.LoadDeviceToken()
+
+	gw, err := c.dialOnce(ctx)
 	if err != nil {
 		return err
 	}
 
-	gw := gateway.NewClient(opts...)
-	if err := gw.Connect(ctx, c.cfg.WSURL); err != nil {
-		return fmt.Errorf("connect: %w", err)
+	issued := ""
+	if hello := gw.Hello(); hello != nil && hello.Auth != nil {
+		issued = hello.Auth.DeviceToken
+	}
+	if issued != "" {
+		if err := c.store.SaveDeviceToken(issued); err != nil {
+			log.Printf("warning: failed to save device token: %v", err)
+		}
+	}
+
+	if requestedToken == "" && issued != "" {
+		_ = gw.Close()
+		gw2, err := c.dialOnce(ctx)
+		if err != nil {
+			return fmt.Errorf("post-pair re-dial: %w", err)
+		}
+		gw = gw2
 	}
 
 	c.mu.Lock()
 	c.gw = gw
 	c.mu.Unlock()
-
-	// Save device token if issued.
-	if hello := gw.Hello(); hello != nil && hello.Auth != nil && hello.Auth.DeviceToken != "" {
-		if err := c.store.SaveDeviceToken(hello.Auth.DeviceToken); err != nil {
-			log.Printf("warning: failed to save device token: %v", err)
-		}
-	}
-
 	return nil
+}
+
+// dialOnce performs a single SDK handshake, picking up the latest
+// device token from the store on each call so a re-dial after a
+// first-time pairing presents the freshly-issued token.
+func (c *Client) dialOnce(ctx context.Context) (*gateway.Client, error) {
+	opts, err := c.buildOptions()
+	if err != nil {
+		return nil, err
+	}
+	gw := gateway.NewClient(opts...)
+	if err := gw.Connect(ctx, c.cfg.WSURL); err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	return gw, nil
 }
 
 // buildOptions assembles the gateway SDK options for a connection attempt.

--- a/internal/client/dial_test.go
+++ b/internal/client/dial_test.go
@@ -1,0 +1,187 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/a3tai/openclaw-go/identity"
+	"github.com/a3tai/openclaw-go/protocol"
+	"github.com/gorilla/websocket"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// newRealStoreInTempDir returns an identity.Store rooted at a
+// per-test temp directory, optionally pre-seeded with a device token.
+// Real signing is required because the gateway connect path runs the
+// device key through ed25519 before the test handler ever sees it.
+func newRealStoreInTempDir(t *testing.T, presetToken string) *identity.Store {
+	t.Helper()
+	store, err := identity.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("identity.NewStore: %v", err)
+	}
+	if _, err := store.LoadOrGenerate(); err != nil {
+		t.Fatalf("LoadOrGenerate: %v", err)
+	}
+	if presetToken != "" {
+		if err := store.SaveDeviceToken(presetToken); err != nil {
+			t.Fatalf("SaveDeviceToken: %v", err)
+		}
+	}
+	return store
+}
+
+// TestDial_RedialsAfterFirstTimePairing pins the first-time-pairing
+// fix: when the bootstrap connect presents an empty device token and
+// the gateway issues a fresh one in hello-ok, the client must close
+// the bootstrap connection and re-dial so subsequent RPCs run on a
+// connection that authenticated with the issued token. Skipping the
+// re-dial leaves scoped operations (sessions.create most visibly)
+// silently stalling on the bootstrap connection.
+func TestDial_RedialsAfterFirstTimePairing(t *testing.T) {
+	const issuedToken = "issued-from-hello"
+
+	var mu sync.Mutex
+	var presentedTokens []string
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		challenge := protocol.ConnectChallenge{Nonce: "n", Ts: time.Now().UnixMilli()}
+		evData, _ := protocol.MarshalEvent("connect.challenge", challenge)
+		_ = conn.WriteMessage(websocket.TextMessage, evData)
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var req protocol.Request
+		if err := json.Unmarshal(msg, &req); err != nil {
+			return
+		}
+		var params protocol.ConnectParams
+		_ = json.Unmarshal(req.Params, &params)
+
+		mu.Lock()
+		presentedTokens = append(presentedTokens, params.Auth.Token)
+		dialIndex := len(presentedTokens)
+		mu.Unlock()
+
+		hello := protocol.HelloOK{
+			Type:     "hello-ok",
+			Protocol: protocol.ProtocolVersion,
+			Policy:   protocol.HelloPolicy{TickIntervalMs: 15000},
+		}
+		// Only the first dial — the bootstrap one — gets a fresh
+		// device token. A real gateway behaves the same: subsequent
+		// connects authenticate via the token they presented and get
+		// no new one in reply.
+		if dialIndex == 1 {
+			hello.Auth = &protocol.HelloAuth{DeviceToken: issuedToken}
+		}
+		respData, _ := protocol.MarshalResponse(req.ID, hello)
+		_ = conn.WriteMessage(websocket.TextMessage, respData)
+
+		// Hold the connection open briefly so the client's read loop
+		// has a moment to attach; avoids a flake where the test ends
+		// before the SDK observes the response.
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/"
+	store := newRealStoreInTempDir(t, "")
+	c := NewWithIdentityStore(&config.Config{GatewayURL: srv.URL, WSURL: wsURL}, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.dial(ctx); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(presentedTokens) != 2 {
+		t.Fatalf("expected 2 dials (bootstrap + post-pair re-dial), got %d: %v", len(presentedTokens), presentedTokens)
+	}
+	if presentedTokens[0] != "" {
+		t.Errorf("bootstrap dial should present no token, got %q", presentedTokens[0])
+	}
+	if presentedTokens[1] != issuedToken {
+		t.Errorf("re-dial should present issued token %q, got %q", issuedToken, presentedTokens[1])
+	}
+	if got := store.LoadDeviceToken(); got != issuedToken {
+		t.Errorf("issued token should be persisted, got %q", got)
+	}
+}
+
+// TestDial_NoRedialWhenAlreadyPaired pins the symmetric case: a
+// subsequent launch (we already have a stored token, gateway returns
+// no new one) must not perform a wasteful second dial.
+func TestDial_NoRedialWhenAlreadyPaired(t *testing.T) {
+	var mu sync.Mutex
+	dials := 0
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		mu.Lock()
+		dials++
+		mu.Unlock()
+
+		challenge := protocol.ConnectChallenge{Nonce: "n", Ts: time.Now().UnixMilli()}
+		evData, _ := protocol.MarshalEvent("connect.challenge", challenge)
+		_ = conn.WriteMessage(websocket.TextMessage, evData)
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var req protocol.Request
+		_ = json.Unmarshal(msg, &req)
+
+		hello := protocol.HelloOK{
+			Type:     "hello-ok",
+			Protocol: protocol.ProtocolVersion,
+			Policy:   protocol.HelloPolicy{TickIntervalMs: 15000},
+		}
+		respData, _ := protocol.MarshalResponse(req.ID, hello)
+		_ = conn.WriteMessage(websocket.TextMessage, respData)
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/"
+	store := newRealStoreInTempDir(t, "pre-existing")
+	c := NewWithIdentityStore(&config.Config{GatewayURL: srv.URL, WSURL: wsURL}, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.dial(ctx); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if dials != 1 {
+		t.Fatalf("expected exactly 1 dial when already paired, got %d", dials)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -645,8 +645,11 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 				if item.sessionKey == m.selectModel.mainKey {
 					createKey = item.sessionKey
 				}
+				timeout := m.requestTimeoutFromPrefs()
 				return m, func() tea.Msg {
-					key, err := b.CreateSession(context.Background(), agentID, createKey)
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+					defer cancel()
+					key, err := b.CreateSession(ctx, agentID, createKey)
 					return sessionCreatedMsg{
 						sessionKey: key,
 						agentID:    agentID,
@@ -692,6 +695,17 @@ func (m AppModel) connectTimeoutFromPrefs() time.Duration {
 		secs = config.DefaultConnectTimeoutSeconds
 	}
 	return time.Duration(secs) * time.Second
+}
+
+// requestTimeoutFromPrefs returns the per-RPC deadline used to cap
+// in-TUI gateway calls so a silently-stuck request surfaces as an
+// error instead of freezing the picker. Derived as 2× the socket
+// connect deadline so it stays above the WebSocket handshake floor —
+// a request can never legitimately complete faster than its
+// connection, so a deadline tighter than the connect timeout would
+// race the dial it depends on.
+func (m AppModel) requestTimeoutFromPrefs() time.Duration {
+	return 2 * m.connectTimeoutFromPrefs()
 }
 
 // startConnect kicks off a Connect attempt for the given connection

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,12 +1,15 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"runtime"
 	"testing"
 	"time"
 
+	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/config"
@@ -299,5 +302,54 @@ func runCmd(t *testing.T, cmd tea.Cmd) {
 		for _, c := range batch {
 			runCmd(t, c)
 		}
+	}
+}
+
+// TestAppModel_CreateSessionHonoursRequestTimeout: a stuck CreateSession
+// (the symptom seen after first-time pairing, where the freshly
+// authenticated connection silently drops the RPC) must surface as a
+// timeout error rather than freezing the agent picker. The deadline is
+// derived from the user-tunable connect timeout in preferences, so a
+// floor on that value also floors the request deadline.
+func TestAppModel_CreateSessionHonoursRequestTimeout(t *testing.T) {
+	fake := newFakeBackend()
+	fake.createSessionHook = func(ctx context.Context, agentID, key string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	m := AppModel{
+		state:   viewSelect,
+		backend: fake,
+		prefs:   config.Preferences{ConnectTimeoutSeconds: 1},
+	}
+	m.selectModel = newSelectModel(fake, true, false, nil, false)
+	m.selectModel.list.SetItems([]list.Item{
+		agentItem{agent: protocol.AgentSummary{ID: "demo", Name: "demo"}, sessionKey: "demo"},
+	})
+	m.selectModel.loading = false
+	m.selectModel.selected = true
+
+	_, cmd := m.update(agentsLoadedMsg{result: &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "demo", Name: "demo"}},
+	}})
+	if cmd == nil {
+		t.Fatal("expected a session-create command after agent selection")
+	}
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+
+	select {
+	case msg := <-done:
+		created, ok := msg.(sessionCreatedMsg)
+		if !ok {
+			t.Fatalf("expected sessionCreatedMsg, got %T", msg)
+		}
+		if !errors.Is(created.err, context.DeadlineExceeded) {
+			t.Fatalf("expected DeadlineExceeded, got %v", created.err)
+		}
+	case <-time.After(2 * time.Second + 500*time.Millisecond):
+		t.Fatal("CreateSession command never returned — request deadline is not wired")
 	}
 }

--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -42,6 +42,11 @@ type fakeBackend struct {
 	deletedAgents []backend.DeleteAgentParams
 	deleteAgentErr error
 
+	// createSessionHook, when non-nil, replaces the default
+	// CreateSession behaviour so tests can drive timeout / error
+	// paths without inventing a separate fake.
+	createSessionHook func(ctx context.Context, agentID, key string) (string, error)
+
 	// Cron RPC seams — tests pre-seed jobs / runs / errors and read
 	// back the recorded calls through these fields.
 	cronJobs        []protocol.CronJob
@@ -95,6 +100,9 @@ func (f *fakeBackend) SessionsList(ctx context.Context, agentID string) (json.Ra
 	return json.RawMessage(`{"sessions":[]}`), nil
 }
 func (f *fakeBackend) CreateSession(ctx context.Context, agentID, key string) (string, error) {
+	if f.createSessionHook != nil {
+		return f.createSessionHook(ctx, agentID, key)
+	}
 	return key, nil
 }
 func (f *fakeBackend) SessionDelete(ctx context.Context, sessionKey string) error { return nil }


### PR DESCRIPTION
The agent picker froze after a device's first-ever pairing approval. The bootstrap connect that precedes a fresh approval authenticates by Ed25519 device-key signature alone — the gateway issues the first device token in `hello-ok` — and reusing that bootstrap connection for scoped RPCs leaves `sessions.create` silently stalled. This change fixes the root cause by re-dialling once the token is in hand, and adds a defensive deadline so any future stall in the same region surfaces as an error rather than a frozen UI.

## Summary

- `client.dial` now snapshots the token it presented, persists any token issued in `hello.Auth.DeviceToken`, and — when the bootstrap connect carried no token — closes the bootstrap `gateway.Client` and re-dials so the surviving connection authenticates with the issued token. Subsequent launches (token already on disk) skip the second dial.
- `internal/tui/app.go` wraps the in-TUI `CreateSession` call with `context.WithTimeout`, derived as `2× connectTimeoutFromPrefs()`. The 2× factor keeps the request deadline above the WebSocket handshake floor, so a slow-but-legitimate connect can't race its own dial.
- Tests: `internal/client/dial_test.go` exercises both branches of the dial logic against a gorilla `httptest` WebSocket server (re-dial after first-time pairing; no re-dial when a token is already on disk). `internal/tui/app_test.go` proves the agent-select path returns `context.DeadlineExceeded` when `CreateSession` blocks indefinitely.
- Docs refreshed: pairing flow no longer says "restart lucinate"; `connectWithAuth`/`os.Stdin` references replaced with the actual TUI modal flow in `internal/tui/connecting.go`; the new re-dial behaviour is documented in `docs/authentication.md`; stale `secretAwareBackend in main.go` references corrected to `app/factory.go`.

## Implementation details

The dial function previously did the handshake once and returned. The fix splits that into `dialOnce` (single SDK handshake) called from `dial`, which orchestrates the optional second pass. Token persistence happens between the two dials so that even if the second connect fails, the issued token is on disk for the next launch — the user isn't sent back to first-time pairing.

The request-deadline wrapper deliberately scopes only to `CreateSession`, which is the exact site the bug surfaced. A blanket sweep across every `context.Background()` callsite was out of scope and risked masking other behaviours.