### PR TITLE
feat(tui): add fuzzy-filter model picker to /model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,13 @@ require (
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/a3tai/openclaw-go v1.20260325.1-0.20260417064242-ec5cddc23822
+	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260419004333-9332b2225b80
 	github.com/joho/godotenv v1.5.1
 	github.com/olekukonko/tablewriter v1.1.4
+	github.com/sahilm/fuzzy v0.1.1
+	golang.org/x/mod v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -21,7 +24,6 @@ require (
 	github.com/aymanbagabas/go-udiff v0.4.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
@@ -44,11 +46,9 @@ require (
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,6 +22,7 @@ const (
 	viewSessions
 	viewConfig
 	viewCrons
+	viewModelPicker
 )
 
 // BackendFactory builds an unconnected backend.Backend for a stored
@@ -95,6 +96,7 @@ type AppModel struct {
 	sessionsModel    sessionsModel
 	configModel      configModel
 	cronsModel       cronsModel
+	modelPicker      modelPickerModel
 	backend          backend.Backend
 	activeConn       *config.Connection // the connection backend belongs to; rendered in status bars
 	store            *config.Connections
@@ -233,6 +235,8 @@ func (m AppModel) Actions() []Action {
 		return m.configModel.Actions()
 	case viewCrons:
 		return m.cronsModel.Actions()
+	case viewModelPicker:
+		return m.modelPicker.Actions()
 	}
 	return nil
 }
@@ -266,6 +270,10 @@ func (m AppModel) TriggerAction(id string) (AppModel, tea.Cmd) {
 	case viewCrons:
 		var cmd tea.Cmd
 		m.cronsModel, cmd = m.cronsModel.TriggerAction(id)
+		return m, cmd
+	case viewModelPicker:
+		var cmd tea.Cmd
+		m.modelPicker, cmd = m.modelPicker.TriggerAction(id)
 		return m, cmd
 	}
 	return m, nil
@@ -415,6 +423,8 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.configModel.setSize(msg.Width, msg.Height)
 		case viewCrons:
 			m.cronsModel.setSize(msg.Width, msg.Height)
+		case viewModelPicker:
+			m.modelPicker.setSize(msg.Width, msg.Height)
 		}
 		return m, nil
 
@@ -549,6 +559,16 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.state = viewSessions
 		return m, m.sessionsModel.Init()
 
+	case showModelPickerMsg:
+		m.modelPicker = newModelPickerModel(m.backend, msg.sessionKey, msg.currentModelID, m.hideActionHints, m.activeConn, m.disableExitKeys)
+		m.modelPicker.setSize(m.width, m.height)
+		m.state = viewModelPicker
+		return m, m.modelPicker.Init()
+
+	case goBackFromModelPickerMsg:
+		m.state = viewChat
+		return m, nil
+
 	case sessionSelectedMsg:
 		agentID := msg.agentID
 		if agentID == "" {
@@ -677,6 +697,11 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case viewCrons:
 		var cmd tea.Cmd
 		m.cronsModel, cmd = m.cronsModel.Update(msg)
+		return m, cmd
+
+	case viewModelPicker:
+		var cmd tea.Cmd
+		m.modelPicker, cmd = m.modelPicker.Update(msg)
 		return m, cmd
 	}
 
@@ -850,6 +875,8 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView(m.configModel.View())
 	case viewCrons:
 		v = tea.NewView(m.cronsModel.View())
+	case viewModelPicker:
+		v = tea.NewView(m.modelPicker.View())
 	default:
 		v = tea.NewView("")
 	}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -274,22 +274,6 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.updateViewport()
 		return m, nil
 
-	case modelListMsg:
-		if msg.err != nil {
-			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
-		} else {
-			var lines []string
-			for _, mc := range msg.models {
-				lines = append(lines, fmt.Sprintf("  %s (%s)", mc.ID, mc.Provider))
-			}
-			m.messages = append(m.messages, chatMessage{
-				role:    "system",
-				content: "Available models:\n" + strings.Join(lines, "\n") + "\n\nUse /model <name> to switch",
-			})
-		}
-		m.updateViewport()
-		return m, nil
-
 	case modelSwitchedMsg:
 		if msg.err != nil {
 			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -164,7 +164,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/model — list available models\n/model <name> — switch model\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/model — open model picker (filter as you type)\n/model <name> — switch model directly\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -255,13 +255,13 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
 	if len(parts) == 1 {
-		b := m.backend
+		sessionKey := m.sessionKey
+		currentModelID := m.modelID
 		return true, func() tea.Msg {
-			result, err := b.ModelsList(context.Background())
-			if err != nil {
-				return modelListMsg{err: err}
+			return showModelPickerMsg{
+				sessionKey:     sessionKey,
+				currentModelID: currentModelID,
 			}
-			return modelListMsg{models: result.Models}
 		}
 	}
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -80,16 +80,25 @@ type GatewayEventMsg protocol.Event
 // goBackMsg signals the AppModel to return to agent selection.
 type goBackMsg struct{}
 
-// modelListMsg is returned when the model list is fetched.
-type modelListMsg struct {
-	models []protocol.ModelChoice
-	err    error
-}
-
 // modelSwitchedMsg is returned after switching models.
 type modelSwitchedMsg struct {
 	modelID string
 	err     error
+}
+
+// showModelPickerMsg signals the AppModel to switch to the model picker.
+type showModelPickerMsg struct {
+	sessionKey     string
+	currentModelID string
+}
+
+// goBackFromModelPickerMsg signals the AppModel to return to the chat view.
+type goBackFromModelPickerMsg struct{}
+
+// modelsLoadedMsg is returned when the model list is fetched for the picker.
+type modelsLoadedMsg struct {
+	models []protocol.ModelChoice
+	err    error
 }
 
 // execSubmittedMsg signals the exec request was submitted (output comes via events).

--- a/internal/tui/models.go
+++ b/internal/tui/models.go
@@ -1,0 +1,302 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/a3tai/openclaw-go/protocol"
+	"github.com/sahilm/fuzzy"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// modelItem is a list item for the model picker.
+type modelItem struct {
+	model protocol.ModelChoice
+}
+
+// FilterValue is the haystack the bubbles list filter (here: fuzzy
+// match) runs against. Concatenating Name, ID, and Provider lets the
+// user type any of them — e.g. "sonnet", "claude-sonnet-4", or
+// "anthropic" all rank the same model.
+func (i modelItem) FilterValue() string {
+	parts := []string{i.model.Name, i.model.ID, i.model.Provider}
+	return strings.Join(parts, " ")
+}
+
+// modelDelegate renders each model row in the picker.
+type modelDelegate struct{}
+
+func (d modelDelegate) Height() int                             { return 2 }
+func (d modelDelegate) Spacing() int                            { return 1 }
+func (d modelDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d modelDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	i, ok := item.(modelItem)
+	if !ok {
+		return
+	}
+
+	title := i.model.Name
+	if title == "" {
+		title = i.model.ID
+	}
+
+	subtitle := i.model.ID
+	if i.model.Provider != "" {
+		subtitle = i.model.Provider + " · " + i.model.ID
+	}
+
+	if index == m.Index() {
+		str := lipgloss.NewStyle().
+			Foreground(accent).
+			Bold(true).
+			Render(fmt.Sprintf("> %s", title))
+		str += "\n" + lipgloss.NewStyle().
+			Foreground(subtle).
+			Render(fmt.Sprintf("  %s", subtitle))
+		fmt.Fprint(w, str)
+	} else {
+		str := fmt.Sprintf("  %s", title)
+		str += "\n" + lipgloss.NewStyle().
+			Foreground(subtle).
+			Render(fmt.Sprintf("  %s", subtitle))
+		fmt.Fprint(w, str)
+	}
+}
+
+// fuzzyFilter adapts sahilm/fuzzy to the bubbles list FilterFunc
+// signature. Empty terms short-circuit to every item in original order
+// so the unfiltered list isn't reshuffled.
+func fuzzyFilter(term string, targets []string) []list.Rank {
+	if strings.TrimSpace(term) == "" {
+		ranks := make([]list.Rank, len(targets))
+		for i := range targets {
+			ranks[i] = list.Rank{Index: i}
+		}
+		return ranks
+	}
+	matches := fuzzy.Find(term, targets)
+	ranks := make([]list.Rank, len(matches))
+	for i, m := range matches {
+		ranks[i] = list.Rank{
+			Index:          m.Index,
+			MatchedIndexes: m.MatchedIndexes,
+		}
+	}
+	return ranks
+}
+
+// modelPickerModel is the model selection view.
+type modelPickerModel struct {
+	list           list.Model
+	backend        backend.Backend
+	sessionKey     string
+	currentModelID string
+	loading        bool
+	err            error
+	hideHints      bool
+	activeConn     *config.Connection
+}
+
+func newModelPickerModel(b backend.Backend, sessionKey, currentModelID string, hideHints bool, activeConn *config.Connection, disableExitKeys bool) modelPickerModel {
+	l := list.New(nil, modelDelegate{}, 0, 0)
+	// Title is rendered explicitly above the list (see View) because
+	// bubbles replaces the list's built-in title with the filter
+	// prompt while typing, which would hide the screen name during
+	// the very interaction this view exists for.
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(!hideHints)
+	l.Styles.Title = headerStyle
+	// Live filtering is the whole point of this view — unlike the
+	// other pickers in the codebase, which keep filtering off.
+	l.SetFilteringEnabled(true)
+	l.Filter = fuzzyFilter
+	if disableExitKeys {
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
+
+	return modelPickerModel{
+		list:           l,
+		backend:        b,
+		sessionKey:     sessionKey,
+		currentModelID: currentModelID,
+		loading:        true,
+		hideHints:      hideHints,
+		activeConn:     activeConn,
+	}
+}
+
+func (m modelPickerModel) loadModels() tea.Cmd {
+	b := m.backend
+	return func() tea.Msg {
+		result, err := b.ModelsList(context.Background())
+		if err != nil {
+			return modelsLoadedMsg{err: err}
+		}
+		return modelsLoadedMsg{models: result.Models}
+	}
+}
+
+func (m modelPickerModel) Init() tea.Cmd {
+	return m.loadModels()
+}
+
+func (m modelPickerModel) Update(msg tea.Msg) (modelPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case modelsLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		items := make([]list.Item, len(msg.models))
+		for i, mc := range msg.models {
+			items[i] = modelItem{model: mc}
+		}
+		m.list.SetItems(items)
+		// Pre-select the active model so Enter on an empty filter
+		// picks "the one you already have" rather than a surprising
+		// jump to the top of the list.
+		if m.currentModelID != "" {
+			for idx, mc := range msg.models {
+				if mc.ID == m.currentModelID {
+					m.list.Select(idx)
+					break
+				}
+			}
+		}
+		// Drop straight into filter-typing mode so the user doesn't
+		// have to press `/` first — typing-as-filter is the headline
+		// improvement of this view.
+		m.list.SetFilterState(list.Filtering)
+		return m, nil
+
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m modelPickerModel) handleKey(msg tea.KeyPressMsg) (modelPickerModel, tea.Cmd) {
+	// Enter picks the highlighted model from any filter state. The
+	// bubbles default in Filtering mode is "apply filter" — that
+	// would force a second Enter to actually choose, which is hostile
+	// when the whole point of the view is type-then-pick.
+	if msg.String() == "enter" && !m.loading && m.err == nil {
+		if item, ok := m.list.SelectedItem().(modelItem); ok {
+			modelID := item.model.ID
+			b := m.backend
+			sessionKey := m.sessionKey
+			switchCmd := func() tea.Msg {
+				if err := b.SessionPatchModel(context.Background(), sessionKey, modelID); err != nil {
+					return modelSwitchedMsg{err: err}
+				}
+				return modelSwitchedMsg{modelID: modelID}
+			}
+			backCmd := func() tea.Msg { return goBackFromModelPickerMsg{} }
+			return m, tea.Batch(switchCmd, backCmd)
+		}
+	}
+
+	// While typing in the filter, all other keys (printable chars,
+	// backspace, arrow keys, esc-to-clear) belong to the list
+	// widget so the filter input and highlight track together.
+	if m.list.FilterState() == list.Filtering {
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
+	}
+
+	// Outside filter mode, route discoverable shortcuts through
+	// Actions/TriggerAction so the help line and key dispatch share
+	// a single source of truth.
+	for _, a := range m.Actions() {
+		if a.Key == msg.String() {
+			return m.TriggerAction(a.ID)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// Actions returns the discoverable, view-level commands the model
+// picker exposes. Like sessions.go, intrinsic list controls (filter
+// typing, cursor navigation, enter-to-select) stay implicit; only
+// view-level commands appear here.
+func (m modelPickerModel) Actions() []Action {
+	var actions []Action
+	actions = append(actions, Action{ID: "back", Label: "Back", Key: "esc"})
+	if m.err != nil {
+		actions = append(actions, Action{ID: "retry", Label: "Retry", Key: "r"})
+	}
+	return actions
+}
+
+func (m modelPickerModel) TriggerAction(id string) (modelPickerModel, tea.Cmd) {
+	switch id {
+	case "back":
+		return m, func() tea.Msg { return goBackFromModelPickerMsg{} }
+	case "retry":
+		if m.err == nil {
+			return m, nil
+		}
+		m.loading = true
+		m.err = nil
+		return m, m.loadModels()
+	}
+	return m, nil
+}
+
+func (m modelPickerModel) View() string {
+	if m.loading {
+		return "\n  Loading models...\n"
+	}
+	hints := ""
+	if !m.hideHints {
+		hints = helpStyle.Render(renderActionHints(m.Actions()))
+	}
+	banner := renderConnectionBanner(m.activeConn)
+	if m.err != nil {
+		var b strings.Builder
+		b.WriteString(banner)
+		b.WriteString("\n")
+		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
+		b.WriteString("\n\n")
+		b.WriteString(hints)
+		b.WriteString("\n")
+		return b.String()
+	}
+	header := headerStyle.Render(" Select a model ") + "\n"
+	if len(m.list.Items()) == 0 {
+		var b strings.Builder
+		b.WriteString(banner)
+		b.WriteString("\n")
+		b.WriteString(header)
+		b.WriteString("\n")
+		b.WriteString("  No models available.\n\n")
+		b.WriteString(hints)
+		b.WriteString("\n")
+		return b.String()
+	}
+	return banner + "\n" + header + m.list.View() + "\n" + hints
+}
+
+func (m *modelPickerModel) setSize(w, h int) {
+	// Reserve rows for the explicit header + spacer (see View) on top
+	// of the hint line the other pickers already account for.
+	m.list.SetSize(w, h-4)
+}


### PR DESCRIPTION
Replace the inline `/model` listing with a dedicated picker view that filters models live as the user types.

## Summary

- `/model` (no args) now opens a full-screen picker with fuzzy filtering across model name, ID, and provider, powered by `sahilm/fuzzy`
- Typing is the primary input — the view enters bubbles' `Filtering` state on load, so users don't have to press `/` to start filtering
- Enter on any filter state picks the highlighted model; Esc clears the filter or returns to chat when unfiltered
- The current model is pre-selected so Enter on an empty filter is a safe no-op pick
- `/model <name>` retains its direct-set behaviour for muscle memory and scripting
- Help text and screen header updated to reflect the new flow

## Implementation details

The picker mirrors the existing session-browser pattern (`internal/tui/sessions.go`) but flips `SetFilteringEnabled(true)` and installs a custom `list.FilterFunc` that wraps `fuzzy.Find`. Bubbles replaces the list's built-in title with the filter prompt while typing, so the screen header is rendered explicitly above the list to keep the screen name visible during filtering — `setSize` reserves the extra rows.

Enter is intercepted in `handleKey` regardless of filter state, overriding bubbles' default "apply filter" behaviour so users don't need a second keystroke to confirm a selection. The unused `modelListMsg` and its inline-render handler in `chat.go` are removed; `modelSwitchedMsg` is reused by the picker so the chat-side `m.modelID` update path is unchanged.