### PR TITLE
feat(tui): support mid-message skill autocomplete and envelope format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Tool call cards** — when the agent invokes a tool, an inline card shows what's running, what arguments it got, and whether it succeeded or failed (OpenClaw)
 - **Shell commands** — run locally with `!` or remotely on the gateway with `!!`
 - **Message queueing** so you can keep typing while the agent is responding
-- **Local agent skills** loaded from `~/.agents/skills/` as slash commands
+- **Local agent skills** loaded from `~/.agents/skills/` — invoke as a slash command (`/review`) or drop one mid-message (`use /review on the diff`)
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
 - **Cron browser** — list, edit, run, and create scheduled jobs without leaving the terminal (OpenClaw)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,7 +6,7 @@ Slash commands are local TUI commands that begin with `/`. They are intercepted 
 
 Input that starts with `/` and contains no spaces is matched case-insensitively against a `switch` statement of built-in commands. Commands that accept an argument (e.g. `/model sonnet`, `/think high`) are matched by prefix check after the switch.
 
-Unrecognised slash commands fall through to a skill-name lookup. If no skill matches, an error system message is shown (see [skills.md](skills.md#activation)).
+Slash input that isn't a built-in is checked against the loaded skill names: if the first token (`/foo` from `/foo bar`) matches a skill, `handleSlashCommand` returns `(false, nil)` and lets the regular send path expand it via `expandSkillReferences` — see [skills.md](skills.md#activation). If it matches neither a built-in nor a skill, an error system message is shown.
 
 ## Built-in commands
 
@@ -44,7 +44,9 @@ Stats are loaded asynchronously via `client.SessionUsage()` on chat init and aft
 
 ## Tab completion
 
-`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins. `slashCommandHint()` derives the completion suffix shown greyed-out in the input bar. Pressing Tab inserts the full command via `m.textarea.SetValue(match)` and `CursorEnd()`.
+`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins.
+
+The Tab handler (`chat.go`) operates on the slash token at the cursor — not just at the start of input — so completion works mid-message and within multi-line input. `findSlashTokenAt(value, cursorByte)` walks back from the cursor to a `/` that is at the start of input or preceded by whitespace, requiring the cursor to sit at the end of the token (next character is whitespace or EOF). `setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted completion. `slashCommandHint(value, cursorByte)` returns the typed prefix and the suffix shown greyed-out in the input bar.
 
 ## Confirmation pattern
 

--- a/docs/message-rendering.md
+++ b/docs/message-rendering.md
@@ -10,28 +10,26 @@ Each chat message has a role that determines how it is displayed in the TUI:
 - `separator` — a dim divider row inserted between restored history and a new turn; labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`). The `timestampMs` field on `chatMessage` carries the unix-ms used by `formatSeparatorLabel`.
 - `tool` — inline status card for an in-flight or completed tool call from the agent. See [Tool call cards](#tool-call-cards).
 
-## The System: prefix convention
+## Hiding injected content from history
 
-Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but must not be shown in the local chat history when it is loaded back. The convention is to prefix every such line with `System: `:
+Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but must not be shown in the local chat history when it is loaded back. Lucinate uses two complementary conventions for this.
+
+### System: line prefix
+
+Each line of the block is prefixed with `System: ` (or `System (<qualifier>): ` for gateway-rewritten variants like `System (untrusted):`). `prefixAllLines()` in `internal/tui/skills.go` applies the prefix; `stripSystemLines()` in `internal/tui/history.go` removes matching lines on history reload, and `isSystemLine()` recognises both forms.
+
+This convention is used for the **skill catalog** prepended to the first user message of each session — see [skills.md](skills.md) and [backend_openclaw.md](backend_openclaw.md).
 
 ```
 System: Available agent skills (activate with /skill-name):
 System:   - review: Perform a code review
 ```
 
-`prefixAllLines()` in `internal/tui/skills.go` applies this prefix to a block of text. Content that uses this convention includes:
+### `<local-agent-skill>` envelope
 
-- The skill catalog prepended to the first user message (see [skills.md](skills.md)).
-- Injected skill bodies sent when the user activates a skill.
+When the user invokes a skill (`/review` alone or `use /review on x`), `expandSkillReferences()` in `internal/tui/skills.go` produces a payload prefixed with `Please use the following skill(s):` followed by one or more `<local-agent-skill name="…">…</local-agent-skill>` blocks. `stripLocalAgentSkillBlocks()` in `internal/tui/history.go` elides the preamble line and every block (inclusive) on history reload. See [skills.md](skills.md#activation) for the full payload shape and substitution rules.
 
-## History cleanup
-
-When session history is fetched from the gateway, each user message may contain `System:` prefixed lines that were injected at send time. `stripSystemLines()` in `internal/tui/history.go` removes those lines before the messages are added to the display, so the user only sees what they actually typed.
-
-`isSystemLine()` matches two forms:
-
-- `System: ...` — the standard local prefix.
-- `System (<qualifier>): ...` — a variant the gateway may substitute (e.g. `System (untrusted):`) when rewriting message content for safety reasons.
+Both strippers are applied to user messages on history reload.
 
 ## Markdown rendering
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-Agent skills are locally-stored prompt templates that users can inject into a chat session via slash commands (e.g. `/review`). They allow users to define reusable instructions without modifying gateway configuration.
+Agent skills are locally-stored prompt templates that users can inject into a chat session via slash commands (e.g. `/review`). They allow users to define reusable instructions without modifying gateway configuration. A skill can be invoked on its own (`/review`) or referenced mid-message (`use /review on the diff`) — see [Activation](#activation).
 
 ## Skill file format
 
@@ -32,34 +32,56 @@ Discovery runs as a Bubble Tea command in `chatModel.Init()` and returns a `skil
 
 ## Catalog injection
 
-The agent doesn't receive skill information unless it's explicitly included in a message. On the **first user message** of a session, `withSkillCatalog()` (`chat.go`) prepends a skill listing to the outgoing text before it is sent to the gateway:
+The agent doesn't receive skill information unless it's explicitly included in a message. The chat layer passes the discovered skills through `ChatSendParams.Skills`; the OpenClaw backend's `takePendingCatalog()` (`internal/backend/openclaw/openclaw.go`) prepends a skill listing to the **first user message** of each session:
 
 ```
 System: Available agent skills (activate with /skill-name):
 System:   - review: Perform a code review
 ```
 
-Lines are prefixed with `System: ` using the convention described in [message-rendering.md](message-rendering.md). The catalog is sent only once per session (`skillCatalogSent` flag).
+Lines are prefixed with `System: ` using the convention described in [message-rendering.md](message-rendering.md). The catalog is sent only once per session — a per-session flag, mutex-guarded against concurrent sends, prevents re-emission. See [backend_openclaw.md](backend_openclaw.md) for the backend-side detail.
 
 ## Activation
 
-When the user types `/<name>`, `handleSlashCommand()` (`commands.go`) matches it against loaded skills (case-insensitive). On a match:
+A `/skill-name` token is recognised when it sits at the start of a message *or* mid-prose preceded by whitespace, with token characters `[A-Za-z0-9_-]`. Matching is case-insensitive.
 
-1. The skill body is wrapped with a `[Skill: <name>]` header.
-2. Every line is prefixed with `System: ` (see [message-rendering.md](message-rendering.md)).
-3. The resulting text is sent to the gateway as the message content.
-4. The chat display shows the user message as `/<name>` (not the full body).
+`handleSlashCommand()` (`commands.go`) returns `(false, nil)` for any `/`-prefixed input whose first token names a known skill, deferring to the regular Enter-handler send path. Unknown slashes that aren't built-ins still produce an error system message there.
 
-Unknown slash commands that don't match a built-in or a skill name show an error.
+The send path runs `expandSkillReferences(text, skills)` (`skills.go`) before dispatching. When at least one matched skill is found it produces a payload of the form:
 
-Tab completion (`completeSlashCommand()` in `commands.go`) includes skill names alongside built-in commands.
+```
+Please use the following skill:
+
+<local-agent-skill name="review">
+<skill body>
+</local-agent-skill>
+
+run the "review" skill above on the diff
+```
+
+Rules applied by `expandSkillReferences`:
+
+- Each unique matched skill produces one `<local-agent-skill name="...">…</local-agent-skill>` block. Order follows first-occurrence in the prose.
+- Each `/skill-name` token in the prose is replaced with `the "<canonical-name>" skill above`. The canonical name comes from the skill's frontmatter, regardless of how the user typed it.
+- Multiple distinct skills produce a plural preamble (`Please use the following skills:`) and one envelope per skill.
+- A "bare" message — the entire trimmed input is a single `/skill-name` — collapses the prose to `use the "<name>" skill above immediately`.
+
+The visible chat row shows the user-typed text. On history reload the rendered text reflects the post-substitution payload (the gateway has no record of the original prose) — this is a known cosmetic divergence.
+
+`stripLocalAgentSkillBlocks` (`history.go`) elides the preamble line and every `<local-agent-skill>...</local-agent-skill>` block when restoring user messages from history, alongside the `System:` line strip used for the catalog.
+
+### Tab completion
+
+`completeSlashCommand(prefix)` matches built-in commands and skill names by prefix. The Tab handler in `chat.go` works on the slash token under the cursor — not just at the start of input — so `use /rev<TAB>` completes to `use /review`. `findSlashTokenAt(value, cursorByte)` (`commands.go`) locates the token and `setTextareaToValueWithCursor` performs the in-place replacement, repositioning the cursor at the end of the inserted completion.
+
+Completion only fires when the cursor sits at the end of the slash token (next character is whitespace or end-of-buffer); inserting mid-token would clobber the trailing characters.
 
 ## UI commands
 
 | Command | Behaviour |
 |---|---|
 | `/skills` | Lists all discovered skills with their descriptions |
-| `/<name>` | Activates the named skill |
+| `/<name>` | Activates the named skill (alone or with prose) |
 | `/help` | Mentions how many skills are loaded |
 
 The count of loaded skills also appears in the `/stats` table.

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/viewport"
@@ -18,6 +19,61 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
+
+// textareaCursorByteOffset converts the textarea's (Line, Column) cursor
+// position — which is rune-indexed within a row — to a byte offset against
+// Value(). Returns 0 when the textarea is empty.
+func textareaCursorByteOffset(ta *textarea.Model) int {
+	value := ta.Value()
+	if value == "" {
+		return 0
+	}
+	row := ta.Line()
+	col := ta.Column()
+	// Walk to the start of the target row.
+	offset := 0
+	for r := 0; r < row; r++ {
+		nl := strings.IndexByte(value[offset:], '\n')
+		if nl < 0 {
+			return len(value)
+		}
+		offset += nl + 1
+	}
+	// Advance col runes into the row.
+	rest := value[offset:]
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		rest = rest[:nl]
+	}
+	for i := 0; i < col; i++ {
+		_, size := utf8.DecodeRuneInString(rest)
+		if size == 0 {
+			break
+		}
+		rest = rest[size:]
+		offset += size
+	}
+	return offset
+}
+
+// setTextareaToValueWithCursor replaces the textarea contents with newValue
+// and positions the cursor at byte offset cursorByte.
+func setTextareaToValueWithCursor(ta *textarea.Model, newValue string, cursorByte int) {
+	ta.Reset()
+	ta.SetValue(newValue)
+	if cursorByte > len(newValue) {
+		cursorByte = len(newValue)
+	}
+	targetRow := strings.Count(newValue[:cursorByte], "\n")
+	lineStart := 0
+	if idx := strings.LastIndexByte(newValue[:cursorByte], '\n'); idx >= 0 {
+		lineStart = idx + 1
+	}
+	targetCol := utf8.RuneCountInString(newValue[lineStart:cursorByte])
+	for ta.Line() > targetRow {
+		ta.CursorUp()
+	}
+	ta.SetCursorColumn(targetCol)
+}
 
 // connectionBadge returns a short status string for the chat header when the
 // gateway connection is not in the steady-state Connected condition. Returns
@@ -369,12 +425,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			}
 			return m, nil
 		case "tab":
-			text := m.textarea.Value()
-			if strings.HasPrefix(text, "/") && !strings.Contains(text, " ") {
-				if match := m.completeSlashCommand(text); match != "" {
-					m.textarea.Reset()
-					m.textarea.SetValue(match)
-					m.textarea.CursorEnd()
+			value := m.textarea.Value()
+			cursorByte := textareaCursorByteOffset(&m.textarea)
+			start, prefix, ok := findSlashTokenAt(value, cursorByte)
+			if ok {
+				if match := m.completeSlashCommand(prefix); match != "" && match != strings.ToLower(prefix) {
+					newValue := value[:start] + match + value[cursorByte:]
+					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
 				}
 			}
 			return m, nil
@@ -456,11 +513,17 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 
+			sent := text
+			if len(m.skills) > 0 {
+				if expanded, ok := expandSkillReferences(text, m.skills); ok {
+					sent = expanded
+				}
+			}
 			m.messages = append(m.messages, chatMessage{role: "user", content: text})
 			m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 			m.sending = true
 			m.updateViewport()
-			cmds = append(cmds, m.sendMessage(text), m.ensureSpinnerTicking())
+			cmds = append(cmds, m.sendMessage(sent), m.ensureSpinnerTicking())
 			return m, tea.Batch(cmds...)
 		}
 
@@ -681,10 +744,16 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 		return localExecCommand(command)
 	}
 
+	sent := text
+	if len(m.skills) > 0 {
+		if expanded, ok := expandSkillReferences(text, m.skills); ok {
+			sent = expanded
+		}
+	}
 	m.messages = append(m.messages, chatMessage{role: "user", content: text})
 	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 	m.updateViewport()
-	return tea.Batch(m.sendMessage(text), m.ensureSpinnerTicking())
+	return tea.Batch(m.sendMessage(sent), m.ensureSpinnerTicking())
 }
 
 func (m *chatModel) setSize(w, h int) {
@@ -787,9 +856,9 @@ func (m chatModel) View() string {
 	} else if isLocalExec {
 		help = helpStyle.Render(localExecPrefixStyle.Render(" local command") + " — runs on this machine")
 	} else {
-		hint := m.slashCommandHint(m.textarea.Value())
-		if hint != "" {
-			help = helpStyle.Render(fmt.Sprintf(" %s%s — tab to complete", m.textarea.Value(), hint))
+		token, suffix := m.slashCommandHint(m.textarea.Value(), textareaCursorByteOffset(&m.textarea))
+		if suffix != "" {
+			help = helpStyle.Render(fmt.Sprintf(" %s%s — tab to complete", token, suffix))
 		} else if m.hideInput {
 			help = helpStyle.Render(" /help: commands")
 		} else {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -26,6 +26,35 @@ var slashCommands = []string{"/agents", "/cancel", "/clear", "/commands", "/comp
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
 
+// findSlashTokenAt locates the slash-prefixed token whose end coincides with
+// the cursor at byteOffset in value. Returns ok=false when the cursor is not
+// at the end of a slash token (e.g. mid-token, or no slash preceding the
+// cursor without an intervening word boundary).
+func findSlashTokenAt(value string, byteOffset int) (start int, prefix string, ok bool) {
+	if byteOffset < 0 || byteOffset > len(value) {
+		return 0, "", false
+	}
+	// Cursor must be at a token boundary: next byte must be EOF or whitespace.
+	if byteOffset < len(value) && !isSpaceByte(value[byteOffset]) {
+		return 0, "", false
+	}
+	// Walk backward over slash-token chars.
+	i := byteOffset
+	for i > 0 && isSlashTokenByte(value[i-1]) {
+		i--
+	}
+	// We need a '/' immediately before the run of token chars.
+	if i == 0 || value[i-1] != '/' {
+		return 0, "", false
+	}
+	slashIdx := i - 1
+	// The slash itself must be at BOF or preceded by whitespace.
+	if slashIdx > 0 && !isSpaceByte(value[slashIdx-1]) {
+		return 0, "", false
+	}
+	return slashIdx, value[slashIdx:byteOffset], true
+}
+
 // completeSlashCommand returns the first matching slash command for the given
 // prefix, or "" if no match. Includes skill names as slash commands.
 func (m *chatModel) completeSlashCommand(prefix string) string {
@@ -47,17 +76,20 @@ func (m *chatModel) completeSlashCommand(prefix string) string {
 	return ""
 }
 
-// slashCommandHint returns the completion hint to display after the current
-// input, or "" if no hint applies.
-func (m *chatModel) slashCommandHint(input string) string {
-	if !strings.HasPrefix(input, "/") || strings.Contains(input, " ") || input == "" {
-		return ""
+// slashCommandHint returns the completion hint for the slash token at the
+// given cursor byte offset. token is what the user has typed so far
+// (including the leading '/'), suffix is the remainder that Tab would insert.
+// Both are empty when no hint applies.
+func (m *chatModel) slashCommandHint(value string, cursorByte int) (token, suffix string) {
+	_, prefix, ok := findSlashTokenAt(value, cursorByte)
+	if !ok {
+		return "", ""
 	}
-	match := m.completeSlashCommand(input)
-	if match == "" || match == strings.ToLower(input) {
-		return ""
+	match := m.completeSlashCommand(prefix)
+	if match == "" || match == strings.ToLower(prefix) {
+		return "", ""
 	}
-	return match[len(input):]
+	return prefix, match[len(prefix):]
 }
 
 // handleSlashCommand processes local slash commands. Returns (true, cmd) if
@@ -226,23 +258,25 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return m.handleThinkCommand(text)
 	}
 
-	// Skill activation: /skill-name sends the skill body as a System:-prefixed message.
+	// Slash-prefixed input that isn't a built-in: if the first token names a
+	// known skill, delegate to the regular send path so expandSkillReferences
+	// wraps it in a <local-agent-skill> envelope. Otherwise emit an
+	// unknown-command error.
 	if strings.HasPrefix(command, "/") {
-		skillName := strings.TrimPrefix(command, "/")
+		firstToken := command
+		if idx := strings.IndexByte(command, ' '); idx >= 0 {
+			firstToken = command[:idx]
+		}
+		name := strings.TrimPrefix(firstToken, "/")
 		for _, s := range m.skills {
-			if strings.ToLower(s.Name) == skillName {
-				msg := prefixAllLines(fmt.Sprintf("[Skill: %s]\n%s", s.Name, s.Body))
-				m.messages = append(m.messages, chatMessage{role: "user", content: fmt.Sprintf("/%s", s.Name)})
-				m.sending = true
-				m.updateViewport()
-				return true, m.sendMessage(msg)
+			if strings.EqualFold(s.Name, name) {
+				return false, nil
 			}
 		}
 
-		// Unknown slash command.
 		m.messages = append(m.messages, chatMessage{
 			role:   "system",
-			errMsg: fmt.Sprintf("unknown command: %s (try /help)", command),
+			errMsg: fmt.Sprintf("unknown command: %s (try /help)", firstToken),
 		})
 		m.updateViewport()
 		return true, nil

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -214,27 +214,17 @@ func TestSlashCommand_Model_SwitchReturnsCmd(t *testing.T) {
 	}
 }
 
-func TestSlashCommand_SkillActivation(t *testing.T) {
+func TestSlashCommand_SkillActivation_DelegatesToSendPath(t *testing.T) {
 	m := newSlashTestModel()
 	m.skills = []agentSkill{{Name: "greet", Description: "say hi", Body: "Greet the user warmly."}}
 	initialCount := len(m.messages)
 
 	handled, cmd := m.handleSlashCommand("/greet")
-	if !handled {
-		t.Fatal("expected /greet to be handled as skill activation")
+	if handled || cmd != nil {
+		t.Fatalf("expected /greet to be delegated (false, nil), got handled=%v cmd=%v", handled, cmd)
 	}
-	if cmd == nil {
-		t.Error("expected sendMessage cmd from skill activation")
-	}
-	if !m.sending {
-		t.Error("expected m.sending to be true after skill activation")
-	}
-	if len(m.messages) != initialCount+1 {
-		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
-	}
-	last := m.messages[len(m.messages)-1]
-	if last.role != "user" || last.content != "/greet" {
-		t.Errorf("expected user message %q, got role=%q content=%q", "/greet", last.role, last.content)
+	if len(m.messages) != initialCount {
+		t.Errorf("expected no message changes from delegation, got %d new", len(m.messages)-initialCount)
 	}
 }
 
@@ -243,11 +233,18 @@ func TestSlashCommand_SkillActivation_CaseInsensitive(t *testing.T) {
 	m.skills = []agentSkill{{Name: "Greet", Description: "say hi", Body: "hi"}}
 
 	handled, cmd := m.handleSlashCommand("/GREET")
-	if !handled {
-		t.Fatal("expected skill activation to be case-insensitive")
+	if handled || cmd != nil {
+		t.Fatalf("expected /GREET to be delegated (case-insensitive), got handled=%v cmd=%v", handled, cmd)
 	}
-	if cmd == nil {
-		t.Error("expected a sendMessage cmd")
+}
+
+func TestSlashCommand_SkillWithProse_Delegates(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{{Name: "greet", Description: "say hi", Body: "hi"}}
+
+	handled, cmd := m.handleSlashCommand("/greet user warmly")
+	if handled || cmd != nil {
+		t.Fatalf("expected /greet-with-prose to be delegated, got handled=%v cmd=%v", handled, cmd)
 	}
 }
 
@@ -325,25 +322,31 @@ func TestCompleteSlashCommand(t *testing.T) {
 func TestSlashCommandHint(t *testing.T) {
 	m := newSlashTestModel()
 	tests := []struct {
-		input string
-		want  string
+		name       string
+		input      string
+		cursorByte int
+		wantToken  string
+		wantSuffix string
 	}{
-		{"/h", "elp"},
-		{"/he", "lp"},
-		{"/help", ""},
-		{"/q", "uit"},
-		{"/a", "gents"},
-		{"/agents", ""},
-		{"/z", ""},
-		{"hello", ""},
-		{"/help foo", ""},
-		{"", ""},
+		{"prefix /h", "/h", 2, "/h", "elp"},
+		{"prefix /he", "/he", 3, "/he", "lp"},
+		{"exact /help", "/help", 5, "", ""},
+		{"prefix /q", "/q", 2, "/q", "uit"},
+		{"prefix /a", "/a", 2, "/a", "gents"},
+		{"exact /agents", "/agents", 7, "", ""},
+		{"unknown /z", "/z", 2, "", ""},
+		{"plain text", "hello", 5, "", ""},
+		{"after slash command + space", "/help foo", 9, "", ""},
+		{"empty input", "", 0, "", ""},
+		{"mid-message /h after space", "use /h", 6, "/h", "elp"},
+		{"mid-message cursor in middle of token", "/he abc", 2, "", ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := m.slashCommandHint(tt.input)
-			if got != tt.want {
-				t.Errorf("slashCommandHint(%q) = %q, want %q", tt.input, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			gotToken, gotSuffix := m.slashCommandHint(tt.input, tt.cursorByte)
+			if gotToken != tt.wantToken || gotSuffix != tt.wantSuffix {
+				t.Errorf("slashCommandHint(%q, %d) = (%q, %q), want (%q, %q)",
+					tt.input, tt.cursorByte, gotToken, gotSuffix, tt.wantToken, tt.wantSuffix)
 			}
 		})
 	}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -75,6 +75,7 @@ func fetchHistory(b backend.Backend, sessionKey string, renderer *glamour.TermRe
 			continue
 		}
 		if role == "user" {
+			text = stripLocalAgentSkillBlocks(text)
 			text = stripSystemLines(text)
 			if text == "" {
 				continue
@@ -108,6 +109,50 @@ func stripSystemLines(s string) string {
 		kept = append(kept, line)
 	}
 	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+// stripLocalAgentSkillBlocks removes the <local-agent-skill> envelope so it
+// is hidden from the rendered transcript. Strips the "Please use the following
+// skill(s):" preamble line and every <local-agent-skill ...>...</local-agent-skill>
+// block (inclusive). Collapses runs of blank lines left behind.
+func stripLocalAgentSkillBlocks(s string) string {
+	if s == "" || !strings.Contains(s, "<local-agent-skill") {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	var kept []string
+	inBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inBlock {
+			if strings.Contains(trimmed, "</local-agent-skill>") {
+				inBlock = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "<local-agent-skill") {
+			if !strings.Contains(trimmed, "</local-agent-skill>") {
+				inBlock = true
+			}
+			continue
+		}
+		if trimmed == "Please use the following skill:" || trimmed == "Please use the following skills:" {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	// Collapse runs of blank lines.
+	var out []string
+	prevBlank := false
+	for _, line := range kept {
+		blank := strings.TrimSpace(line) == ""
+		if blank && prevBlank {
+			continue
+		}
+		out = append(out, line)
+		prevBlank = blank
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
 // isSystemLine returns true if the line starts with a System prefix,

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -85,6 +85,54 @@ func TestStripSystemLines_MixedPrefixes(t *testing.T) {
 	}
 }
 
+func TestStripLocalAgentSkillBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no envelope",
+			in:   "just plain text",
+			want: "just plain text",
+		},
+		{
+			name: "single block",
+			in: "Please use the following skill:\n\n" +
+				"<local-agent-skill name=\"foo\">\nbody\n</local-agent-skill>\n\n" +
+				"use the \"foo\" skill above on x",
+			want: "use the \"foo\" skill above on x",
+		},
+		{
+			name: "multi-line body",
+			in: "Please use the following skill:\n\n" +
+				"<local-agent-skill name=\"foo\">\nline1\nline2\nline3\n</local-agent-skill>\n\n" +
+				"trailing prose",
+			want: "trailing prose",
+		},
+		{
+			name: "two blocks",
+			in: "Please use the following skills:\n\n" +
+				"<local-agent-skill name=\"foo\">\nfoo body\n</local-agent-skill>\n\n" +
+				"<local-agent-skill name=\"bar\">\nbar body\n</local-agent-skill>\n\n" +
+				"both above",
+			want: "both above",
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripLocalAgentSkillBlocks(tt.in); got != tt.want {
+				t.Errorf("stripLocalAgentSkillBlocks() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSystemLine(t *testing.T) {
 	tests := []struct {
 		line string

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -127,6 +127,120 @@ func prefixAllLines(text string) string {
 	return strings.Join(lines, "\n")
 }
 
+// expandSkillReferences scans text for /<skill-name> tokens (preceded by BOF
+// or whitespace) that match a known skill, and returns a rewritten payload
+// containing a <local-agent-skill> envelope followed by the prose with each
+// matched token replaced.
+//
+// If text is exactly "/<skill>" (after trimming), the prose collapses to
+// `use the "<name>" skill above immediately`. Otherwise each match is
+// replaced with `the "<name>" skill above`.
+//
+// Returns (text, false) if no skill ref was matched.
+func expandSkillReferences(text string, skills []agentSkill) (string, bool) {
+	if len(skills) == 0 || text == "" {
+		return text, false
+	}
+
+	byName := make(map[string]*agentSkill, len(skills))
+	for i := range skills {
+		byName[strings.ToLower(skills[i].Name)] = &skills[i]
+	}
+
+	var matched []*agentSkill
+	seen := make(map[string]bool)
+	register := func(s *agentSkill) {
+		if seen[s.Name] {
+			return
+		}
+		seen[s.Name] = true
+		matched = append(matched, s)
+	}
+
+	// Bare-command short-circuit: entire trimmed message is a single skill ref.
+	trimmed := strings.TrimSpace(text)
+	var rewritten string
+	if strings.HasPrefix(trimmed, "/") {
+		bareName := strings.ToLower(trimmed[1:])
+		if s, ok := byName[bareName]; ok && bareName != "" && isSlashTokenName(bareName) {
+			register(s)
+			rewritten = fmt.Sprintf("use the %q skill above immediately", s.Name)
+		}
+	}
+
+	if rewritten == "" {
+		var out strings.Builder
+		out.Grow(len(text))
+		i := 0
+		for i < len(text) {
+			c := text[i]
+			if c == '/' && (i == 0 || isSpaceByte(text[i-1])) {
+				j := i + 1
+				for j < len(text) && isSlashTokenByte(text[j]) {
+					j++
+				}
+				name := strings.ToLower(text[i+1 : j])
+				if s, ok := byName[name]; ok && name != "" {
+					register(s)
+					fmt.Fprintf(&out, "the %q skill above", s.Name)
+					i = j
+					continue
+				}
+			}
+			out.WriteByte(c)
+			i++
+		}
+		rewritten = out.String()
+	}
+
+	if len(matched) == 0 {
+		return text, false
+	}
+
+	var prefix strings.Builder
+	if len(matched) == 1 {
+		prefix.WriteString("Please use the following skill:\n\n")
+	} else {
+		prefix.WriteString("Please use the following skills:\n\n")
+	}
+	for idx, s := range matched {
+		fmt.Fprintf(&prefix, "<local-agent-skill name=%q>\n", s.Name)
+		if s.Body != "" {
+			prefix.WriteString(s.Body)
+			if !strings.HasSuffix(s.Body, "\n") {
+				prefix.WriteString("\n")
+			}
+		}
+		prefix.WriteString("</local-agent-skill>")
+		if idx < len(matched)-1 {
+			prefix.WriteString("\n\n")
+		}
+	}
+	prefix.WriteString("\n\n")
+	prefix.WriteString(rewritten)
+	return prefix.String(), true
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f' || b == '\v'
+}
+
+func isSlashTokenByte(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_' || b == '-'
+}
+
+func isSlashTokenName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isSlashTokenByte(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // skillCatalogBlock returns a System: prefixed block listing available skills.
 // This is prepended to the first user message so the agent knows what's available.
 // Every line is prefixed with "System:" so that stripSystemLines removes the

--- a/internal/tui/skills_test.go
+++ b/internal/tui/skills_test.go
@@ -3,8 +3,186 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestExpandSkillReferences(t *testing.T) {
+	skills := []agentSkill{
+		{Name: "foo", Body: "foo instructions"},
+		{Name: "bar", Body: "bar instructions"},
+		{Name: "commit-message", Body: "use conventional commits"},
+		{Name: "Capital", Body: "capital body"},
+	}
+
+	t.Run("empty input", func(t *testing.T) {
+		got, ok := expandSkillReferences("", skills)
+		if got != "" || ok {
+			t.Errorf("got (%q, %v), want (\"\", false)", got, ok)
+		}
+	})
+
+	t.Run("no slash", func(t *testing.T) {
+		got, ok := expandSkillReferences("hello world", skills)
+		if got != "hello world" || ok {
+			t.Errorf("got (%q, %v), want unchanged false", got, ok)
+		}
+	})
+
+	t.Run("bare command", func(t *testing.T) {
+		got, ok := expandSkillReferences("/foo", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.Contains(got, "Please use the following skill:") {
+			t.Errorf("missing singular preamble in: %s", got)
+		}
+		if !strings.Contains(got, "<local-agent-skill name=\"foo\">") {
+			t.Errorf("missing envelope tag in: %s", got)
+		}
+		if !strings.Contains(got, "foo instructions") {
+			t.Errorf("missing body in: %s", got)
+		}
+		if !strings.Contains(got, "use the \"foo\" skill above immediately") {
+			t.Errorf("missing bare-prose in: %s", got)
+		}
+	})
+
+	t.Run("bare command with surrounding whitespace", func(t *testing.T) {
+		got, ok := expandSkillReferences("  /foo  ", skills)
+		if !ok || !strings.Contains(got, "use the \"foo\" skill above immediately") {
+			t.Errorf("expected bare-form expansion, got ok=%v body=%s", ok, got)
+		}
+	})
+
+	t.Run("mid-message", func(t *testing.T) {
+		got, ok := expandSkillReferences("use /foo on x", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.Contains(got, "Please use the following skill:") {
+			t.Errorf("missing singular preamble: %s", got)
+		}
+		if !strings.HasSuffix(got, "use the \"foo\" skill above on x") {
+			t.Errorf("expected trailing prose, got: %s", got)
+		}
+	})
+
+	t.Run("repeated reference", func(t *testing.T) {
+		got, ok := expandSkillReferences("/foo and /foo again", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if c := strings.Count(got, "<local-agent-skill"); c != 1 {
+			t.Errorf("expected one envelope, got %d in: %s", c, got)
+		}
+		if c := strings.Count(got, "the \"foo\" skill above"); c != 2 {
+			t.Errorf("expected two substitutions, got %d in: %s", c, got)
+		}
+	})
+
+	t.Run("multiple skills", func(t *testing.T) {
+		got, ok := expandSkillReferences("use /foo and /bar on x", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.Contains(got, "Please use the following skills:") {
+			t.Errorf("missing plural preamble: %s", got)
+		}
+		fooIdx := strings.Index(got, "name=\"foo\"")
+		barIdx := strings.Index(got, "name=\"bar\"")
+		if fooIdx < 0 || barIdx < 0 || fooIdx >= barIdx {
+			t.Errorf("expected foo before bar in envelope, got: %s", got)
+		}
+		if !strings.HasSuffix(got, "use the \"foo\" skill above and the \"bar\" skill above on x") {
+			t.Errorf("unexpected prose, got: %s", got)
+		}
+	})
+
+	t.Run("unknown ref unchanged", func(t *testing.T) {
+		got, ok := expandSkillReferences("/baz", skills)
+		if got != "/baz" || ok {
+			t.Errorf("got (%q, %v), want unchanged false", got, ok)
+		}
+	})
+
+	t.Run("punctuation after token", func(t *testing.T) {
+		got, ok := expandSkillReferences("use /foo.", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.HasSuffix(got, "use the \"foo\" skill above.") {
+			t.Errorf("punctuation not preserved: %s", got)
+		}
+	})
+
+	t.Run("mid-word slash unchanged", func(t *testing.T) {
+		got, ok := expandSkillReferences("a/foo", skills)
+		if got != "a/foo" || ok {
+			t.Errorf("got (%q, %v), want unchanged false", got, ok)
+		}
+	})
+
+	t.Run("after newline", func(t *testing.T) {
+		got, ok := expandSkillReferences("a\n/foo b", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.HasSuffix(got, "a\nthe \"foo\" skill above b") {
+			t.Errorf("unexpected output: %s", got)
+		}
+	})
+
+	t.Run("hyphenated name", func(t *testing.T) {
+		got, ok := expandSkillReferences("run /commit-message now", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.HasSuffix(got, "run the \"commit-message\" skill above now") {
+			t.Errorf("unexpected: %s", got)
+		}
+	})
+
+	t.Run("canonical-name preserved", func(t *testing.T) {
+		got, ok := expandSkillReferences("hi /capital there", skills)
+		if !ok {
+			t.Fatal("expected expansion")
+		}
+		if !strings.Contains(got, "the \"Capital\" skill above") {
+			t.Errorf("expected canonical 'Capital', got: %s", got)
+		}
+	})
+}
+
+func TestFindSlashTokenAt(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		cursor     int
+		wantStart  int
+		wantPrefix string
+		wantOK     bool
+	}{
+		{"slash only", "/", 1, 0, "/", true},
+		{"slash at start, end of token", "/foo", 4, 0, "/foo", true},
+		{"after space", "use /foo", 8, 4, "/foo", true},
+		{"end-of-token before space", "use /foo bar", 8, 4, "/foo", true},
+		{"cursor mid-token", "use /foo bar", 6, 0, "", false},
+		{"no whitespace before /", "a/foo", 5, 0, "", false},
+		{"empty input", "", 0, 0, "", false},
+		{"multi-line", "hello\n/foo", 10, 6, "/foo", true},
+		{"emoji before slash", "👋 /foo", len("👋 /foo"), len("👋 "), "/foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, prefix, ok := findSlashTokenAt(tt.value, tt.cursor)
+			if ok != tt.wantOK || prefix != tt.wantPrefix || (ok && start != tt.wantStart) {
+				t.Errorf("findSlashTokenAt(%q, %d) = (%d, %q, %v), want (%d, %q, %v)",
+					tt.value, tt.cursor, start, prefix, ok, tt.wantStart, tt.wantPrefix, tt.wantOK)
+			}
+		})
+	}
+}
 
 func TestParseSkillFile(t *testing.T) {
 	content := `---
@@ -139,32 +317,49 @@ func TestSkillSlashCommand(t *testing.T) {
 	}
 
 	// Hint for skill.
-	hint := m.slashCommandHint("/rev")
-	if hint != "iew" {
-		t.Errorf("slashCommandHint(/rev) = %q, want %q", hint, "iew")
+	token, suffix := m.slashCommandHint("/rev", 4)
+	if token != "/rev" || suffix != "iew" {
+		t.Errorf("slashCommandHint(/rev, 4) = (%q, %q), want (%q, %q)", token, suffix, "/rev", "iew")
 	}
 }
 
-func TestSkillActivation(t *testing.T) {
+func TestSkillActivation_DelegatesToSendPath(t *testing.T) {
 	m := newSlashTestModel()
 	m.skills = []agentSkill{
 		{Name: "review", Description: "Code review", Body: "Review the code carefully."},
 	}
 
+	// /skill alone: handleSlashCommand returns (false, nil) so the regular
+	// send path runs expandSkillReferences and produces the envelope, with
+	// a streaming-assistant placeholder appended.
 	handled, cmd := m.handleSlashCommand("/review")
-	if !handled {
-		t.Fatal("expected /review to be handled")
+	if handled || cmd != nil {
+		t.Fatalf("expected /review to be delegated (false, nil), got handled=%v cmd=%v", handled, cmd)
 	}
-	if cmd == nil {
-		t.Fatal("expected a send cmd")
+
+	// /skill with prose: same delegation.
+	handled, cmd = m.handleSlashCommand("/review the diff")
+	if handled || cmd != nil {
+		t.Fatalf("expected /review-with-prose to be delegated, got handled=%v cmd=%v", handled, cmd)
 	}
-	// Verify the user message was added to display.
+}
+
+func TestSkillActivation_UnknownCommandStillErrors(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{
+		{Name: "review", Description: "Code review", Body: "Review the code carefully."},
+	}
+
+	handled, cmd := m.handleSlashCommand("/notaskill")
+	if !handled || cmd != nil {
+		t.Fatalf("expected unknown slash to be handled with no cmd, got handled=%v cmd=%v", handled, cmd)
+	}
+	if len(m.messages) == 0 {
+		t.Fatal("expected an error system message")
+	}
 	last := m.messages[len(m.messages)-1]
-	if last.role != "user" || last.content != "/review" {
-		t.Errorf("expected user message '/review', got role=%q content=%q", last.role, last.content)
-	}
-	if !m.sending {
-		t.Error("expected sending to be true after skill activation")
+	if last.role != "system" || last.errMsg == "" {
+		t.Errorf("expected system error message, got role=%q errMsg=%q", last.role, last.errMsg)
 	}
 }
 
@@ -277,11 +472,8 @@ func TestSkillActivation_CaseInsensitive(t *testing.T) {
 	}
 
 	handled, cmd := m.handleSlashCommand("/review")
-	if !handled {
-		t.Fatal("expected /review to match skill 'Review'")
-	}
-	if cmd == nil {
-		t.Fatal("expected a send cmd")
+	if handled || cmd != nil {
+		t.Fatalf("expected /review (case-insensitive match for 'Review') to be delegated, got handled=%v cmd=%v", handled, cmd)
 	}
 }
 


### PR DESCRIPTION
Tab autocompletes `/skill-name` tokens at the cursor, sent payloads wrap skills in a `<local-agent-skill>` envelope, and skill responses now render live in the same session.

## Summary
- **Mid-message Tab autocomplete.** Completion now operates on the slash token at the cursor, not just at the start of input. `use /rev<TAB>` becomes `use /review`. Multi-line input is supported.
- **`<local-agent-skill>` envelope.** Skill bodies sent to the gateway are wrapped in a `Please use the following skill(s):` preamble plus one `<local-agent-skill name="…">…</local-agent-skill>` block per matched skill. The previous `System: ` line-prefix scheme wasn't being picked up reliably by the model; the catalog block still uses `System:`.
- **`/skill-name` mid-prose substitution.** Each `/skill-name` token in the user's prose is replaced with `the "<canonical-name>" skill above`. Bare `/foo` (entire trimmed input is one ref) collapses to `use the "foo" skill above immediately`.
- **Bug fix: skill responses dropped in-session.** The legacy skill-activation path didn't append the `assistant streaming awaitingDelta: true` placeholder or call `ensureSpinnerTicking()`, so the streaming response wasn't surfaced live — it only appeared after a session reload. Unifying with the regular send path fixes this.
- **History elision.** `stripLocalAgentSkillBlocks` removes the envelope from rendered user messages on history reload, alongside the existing `stripSystemLines`.
- **Docs.** Updated `README.md`, `docs/skills.md`, `docs/message-rendering.md`, and `docs/commands.md` to reflect the new behaviour.

## Implementation details
`handleSlashCommand` no longer carries its own send logic for skills. When the first slash token names a known skill it returns `(false, nil)`, deferring to the Enter-handler send block which runs `expandSkillReferences(text, skills)` and feeds the result into `sendMessage`. The visible chat row keeps the user-typed text; the gateway-side history holds the post-substitution payload, which is a known cosmetic divergence on history reload.

`expandSkillReferences` is a pure function with table-driven coverage for repeated refs, multiple distinct skills, hyphenated names, canonical-name preservation, punctuation, mid-word slashes, newline boundaries, and the bare-command short-circuit.

The Tab handler uses `findSlashTokenAt(value, cursorByte)` to locate the token at the cursor (only when the cursor sits at the end of the token, to avoid clobbering trailing characters) and `setTextareaToValueWithCursor` to perform the in-place replacement. `textareaCursorByteOffset` converts the textarea's rune-indexed `(Line, Column)` to a byte offset against `Value()`. The help-line hint render no longer echoes the entire textarea value — it shows only the typed token plus the suffix completion, which stays sane for multi-line input.

The drain-queue send path also runs expansion at drain time, so a skill body change between queue and drain is reflected.