### PR TITLE
fix(tui): drop tool events scoped to other sessions

### DIFF
--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -92,8 +92,35 @@ func extractTextFromMessage(raw json.RawMessage) string {
 	return string(raw)
 }
 
+// extractEventSessionKey pulls a top-level "sessionKey" string out of any
+// event payload. Returns "" when the payload has no sessionKey, is empty,
+// or fails to parse — those cases must be allowed through (older gateways,
+// non-session-scoped events). This lets a single check at the top of
+// handleEvent cover every event type that carries a sessionKey, instead of
+// repeating ad-hoc filters in each handler — and protects new event types
+// added later without code changes here.
+func extractEventSessionKey(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var probe struct {
+		SessionKey string `json:"sessionKey"`
+	}
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		return ""
+	}
+	return probe.SessionKey
+}
+
 func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 	logEvent("RAW_EVENT name=%s payload_len=%d", ev.EventName, len(ev.Payload))
+
+	// Drop events scoped to a different session before any handler runs.
+	// Events without a sessionKey (or with an empty one) fall through.
+	if key := extractEventSessionKey(ev.Payload); key != "" && key != m.sessionKey {
+		logEvent("  IGNORED (session %q != ours %q)", key, m.sessionKey)
+		return nil
+	}
 
 	// Handle exec events.
 	switch ev.EventName {
@@ -104,11 +131,6 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			return nil
 		}
 		logEvent("EXEC_FINISHED session=%s cmd=%s exit=%v output_len=%d", finished.SessionKey, finished.Command, finished.ExitCode, len(finished.Output))
-		// Ignore exec results from other sessions.
-		if finished.SessionKey != "" && finished.SessionKey != m.sessionKey {
-			logEvent("  EXEC_FINISHED ignored (different session)")
-			return nil
-		}
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
 			if last.role == "system" && last.content == "running on gateway..." {
@@ -153,10 +175,6 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			return nil
 		}
 		logEvent("EXEC_DENIED session=%s reason=%s", denied.SessionKey, denied.Reason)
-		if denied.SessionKey != "" && denied.SessionKey != m.sessionKey {
-			logEvent("  EXEC_DENIED ignored (different session)")
-			return nil
-		}
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
 			if last.role == "system" && last.content == "running on gateway..." {
@@ -182,12 +200,6 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 	}
 
 	logEvent("EVENT state=%s runID=%s seq=%d msgLen=%d sessionKey=%s", chatEv.State, chatEv.RunID, chatEv.Seq, len(chatEv.Message), chatEv.SessionKey)
-
-	// Ignore chat events from other sessions.
-	if chatEv.SessionKey != "" && chatEv.SessionKey != m.sessionKey {
-		logEvent("  CHAT ignored (different session)")
-		return nil
-	}
 
 	switch chatEv.State {
 	case "delta":

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -1462,6 +1462,124 @@ func TestHandleAgentEvent_ToolResultErrorCarriesMessage(t *testing.T) {
 	}
 }
 
+// makeAgentToolEventForSession builds an EventAgent payload carrying a tool
+// event with an explicit top-level sessionKey. The Go SDK's protocol.AgentEvent
+// struct doesn't declare SessionKey, so we hand-build the JSON to match the
+// gateway's actual wire shape (see infra/agent-events.ts AgentEventPayload).
+func makeAgentToolEventForSession(sessionKey, phase, name, toolCallID string) protocol.Event {
+	data := map[string]any{
+		"phase":      phase,
+		"name":       name,
+		"toolCallId": toolCallID,
+	}
+	envelope := map[string]any{
+		"runId":  "run1",
+		"seq":    1,
+		"stream": "tool",
+		"data":   data,
+	}
+	if sessionKey != "" {
+		envelope["sessionKey"] = sessionKey
+	}
+	payload, _ := json.Marshal(envelope)
+	return protocol.Event{EventName: protocol.EventAgent, Payload: payload}
+}
+
+// --- Session-key filtering for tool/agent events ---
+
+// TestHandleAgentEvent_ToolStart_DifferentSession_Ignored verifies that a
+// tool-start event from another session does not append a tool card or freeze
+// the current streaming assistant message.
+func TestHandleAgentEvent_ToolStart_DifferentSession_Ignored(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "thinking", streaming: true},
+	}
+
+	m.handleEvent(makeAgentToolEventForSession("sess-B", "start", "search", "tc-1"))
+
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages (foreign tool dropped), got %d", len(m.messages))
+	}
+	if !m.messages[1].streaming {
+		t.Error("own streaming assistant should not be frozen by a foreign tool start")
+	}
+}
+
+// TestHandleAgentEvent_ToolResult_DifferentSession_Ignored verifies that a
+// tool-result event from another session does not flip the state of an
+// existing tool card belonging to the current session (e.g. when toolCallId
+// values collide across sessions).
+func TestHandleAgentEvent_ToolResult_DifferentSession_Ignored(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+	m.messages = []chatMessage{
+		{role: "tool", toolName: "search", toolCallID: "tc-1", toolState: "running"},
+	}
+
+	m.handleEvent(makeAgentToolEventForSession("sess-B", "result", "search", "tc-1"))
+
+	if m.messages[0].toolState != "running" {
+		t.Errorf("own tool card was modified by foreign session: state=%q", m.messages[0].toolState)
+	}
+}
+
+// TestHandleAgentEvent_ToolStart_MatchingSession_Processed verifies the
+// centralized filter doesn't accidentally drop tool events with a matching
+// sessionKey.
+func TestHandleAgentEvent_ToolStart_MatchingSession_Processed(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+
+	m.handleEvent(makeAgentToolEventForSession("sess-A", "start", "search", "tc-1"))
+
+	if len(m.messages) != 1 || m.messages[0].role != "tool" {
+		t.Fatalf("expected tool card to be appended, got %+v", m.messages)
+	}
+}
+
+// TestHandleAgentEvent_ToolStart_EmptySessionKey_Processed verifies that
+// agent events without a sessionKey (older gateway versions, or events
+// emitted while isControlUiVisible is false) are still processed.
+func TestHandleAgentEvent_ToolStart_EmptySessionKey_Processed(t *testing.T) {
+	m := newTestChatModel()
+	m.sessionKey = "sess-A"
+
+	m.handleEvent(makeAgentToolEventForSession("", "start", "search", "tc-1"))
+
+	if len(m.messages) != 1 || m.messages[0].role != "tool" {
+		t.Fatalf("expected tool card to be appended for empty sessionKey, got %+v", m.messages)
+	}
+}
+
+// --- Centralized session-key filter coverage ---
+
+// TestExtractEventSessionKey_Variants verifies the helper that backs the
+// centralized filter handles every shape we expect on the wire.
+func TestExtractEventSessionKey_Variants(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"empty payload", ``, ""},
+		{"no sessionKey field", `{"foo":"bar"}`, ""},
+		{"explicit empty sessionKey", `{"sessionKey":""}`, ""},
+		{"populated sessionKey", `{"sessionKey":"sess-A","other":1}`, "sess-A"},
+		{"malformed JSON", `not json`, ""},
+		{"sessionKey at nested level only", `{"data":{"sessionKey":"sess-A"}}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractEventSessionKey([]byte(tc.payload)); got != tc.want {
+				t.Errorf("extractEventSessionKey(%q) = %q, want %q", tc.payload, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHandleAgentEvent_NonToolStreamIgnored(t *testing.T) {
 	m := newTestChatModel()
 	m.messages = []chatMessage{


### PR DESCRIPTION
Centralise the per-event sessionKey filter so tool events from other sessions can no longer leak into the active TUI.

## Summary
- Tool events (`agent`/`tool` stream) had no sessionKey filter, so foreign tool start/update/result events appended stray cards or mutated the active card on toolCallId collisions.
- Added a single `extractEventSessionKey` check at the top of `handleEvent` that drops any payload whose top-level `sessionKey` is non-empty and doesn't match the model's session.
- Removed the redundant per-handler filters from the chat, exec.finished, and exec.denied paths now that the centralised check covers them.
- Added unit tests covering tool-event filtering (foreign-session drop, matching-session pass-through, empty-sessionKey back-compat) and a table test for the helper across malformed/missing/nested payloads.

## Implementation details
The Go SDK's `protocol.AgentEvent` struct doesn't declare a `SessionKey` field, even though the gateway emits one at the JSON top level (see `infra/agent-events.ts` `AgentEventPayload`). A typed-struct check on the parsed event would have missed it; the helper unmarshals the raw payload through a minimal probe struct so it works regardless of which event type the SDK has caught up on. As a side effect, any future event type that adds a sessionKey is filtered automatically without touching this file.