### PR TITLE
feat(tui): add /agent and /models commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,20 @@ In the config view, use `Space` to toggle checkboxes and `←`/`→` to adjust n
 
 ## Commands
 
-Type these in the chat input. Tab autocompletes partial commands.
+Type these in the chat input. Tab autocompletes partial commands; after `/agent ` Tab also completes the agent name.
 
 | Command | Action |
 |---------|--------|
 | `/help` | Show available commands |
 | `/agents` | Return to agent picker |
+| `/agent <name>` | Switch to a named agent (fuzzy match) |
 | `/cancel` | Cancel the in-progress response (also: `Esc`) |
 | `/clear` | Clear chat display |
 | `/compact` | Compact session context (with confirmation) — OpenClaw only |
 | `/config` | Open preferences |
 | `/connections` | Switch backend connection |
 | `/crons` | List and manage gateway cron jobs (default: filter by current agent; `/crons all` shows global) — OpenClaw only |
-| `/model` | List available models |
+| `/models` | Open the model picker (filter as you type) |
 | `/model <name>` | Switch model (fuzzy match) |
 | `/reset` | Delete session and start fresh (with confirmation) |
 | `/sessions` | Browse and restore previous sessions |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -16,6 +16,8 @@ If exactly one agent is returned, it is selected automatically without user inte
 
 Pressing Enter on a highlighted agent calls `client.CreateSession(agentID, key)`. On success, `sessionCreatedMsg` carries the new session key and the app transitions to the chat view (`newChatModel(...)`). See [sessions.md](sessions.md) for the session lifecycle from this point.
 
+The `/agent <name>` slash command bypasses the picker entirely and reaches the same `sessionCreatedMsg` path — see [commands.md](commands.md#agent). From the chat input, `/agent ` followed by Tab autocompletes against the cached agent list.
+
 ## Creating an agent
 
 Pressing `n` in the picker switches to a creation form (`subStateCreate`). The form's shape is driven by the active backend's `Capabilities.AgentWorkspace` flag (see `backend.Capabilities`).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,7 +4,7 @@ Slash commands are local TUI commands that begin with `/`. They are intercepted 
 
 ## Dispatch
 
-Input that starts with `/` and contains no spaces is matched case-insensitively against a `switch` statement of built-in commands. Commands that accept an argument (e.g. `/model sonnet`, `/think high`) are matched by prefix check after the switch.
+Input that starts with `/` and contains no spaces is matched case-insensitively against a `switch` statement of built-in commands. Commands that accept an argument (e.g. `/agent foo`, `/model sonnet`, `/think high`) are matched by prefix check after the switch.
 
 Slash input that isn't a built-in is checked against the loaded skill names: if the first token (`/foo` from `/foo bar`) matches a skill, `handleSlashCommand` returns `(false, nil)` and lets the regular send path expand it via `expandSkillReferences` — see [skills.md](skills.md#activation). If it matches neither a built-in nor a skill, an error system message is shown.
 
@@ -12,6 +12,8 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 
 | Command | What it does |
 |---|---|
+| `/agent` | Return to the agent picker (alias for `/agents`) |
+| `/agent <name>` | Switch to a named agent without going through the picker — see below |
 | `/agents` | Return to the agent picker by emitting `goBackMsg{}` |
 | `/cancel` | Cancel the in-progress response (also triggered by Escape) — see [chat-ux.md](chat-ux.md) |
 | `/clear` | Wipe `m.messages` from the local display (does not affect gateway history) |
@@ -22,8 +24,8 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/crons all` | Open the cron browser unfiltered (jobs across all agents) — **OpenClaw only** |
 | `/exit`, `/quit` | Exit via `tea.Quit` |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
-| `/model` | List available models |
 | `/model <name>` | Switch model — see below |
+| `/models` | Open the model picker (filter as you type) |
 | `/reset` | Delete the session and start fresh — see [sessions.md](sessions.md#compact-and-reset) |
 | `/sessions` | Open the session browser — see [sessions.md](sessions.md#session-browser) |
 | `/skills` | List discovered skills — see [skills.md](skills.md) |
@@ -34,9 +36,13 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 
 Backend-only commands render a "not available on this connection" system message on connections that don't support them — see [connections.md](connections.md#capability-negotiation).
 
+### /agent
+
+`handleAgentCommand()` covers both shapes. With no argument it emits `goBackMsg{}`, returning to the agent picker just like `/agents`. With a name it calls `client.ListAgents()`, fuzzy-matches case-insensitively against agent names and IDs (exact match first, then substring), then calls `client.CreateSession(agentID, "main")` and emits the same `sessionCreatedMsg` the picker selection path uses — so the chat view rebuild is identical to picking from the list. Lookup failures (no match, or backend error) are rendered inline as a system message via `agentSwitchFailedMsg` rather than bouncing the user back to the picker.
+
 ### /model
 
-`handleModelCommand()` calls `client.ModelsList()` to retrieve available models from the gateway. When a name argument is given it fuzzy-matches against model IDs and names (exact match first, then substring). On a match it calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header.
+`handleModelCommand()` requires a name argument; bare `/model` emits an inline hint pointing at `/models`. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
 
 ### /stats
 
@@ -44,9 +50,13 @@ Stats are loaded asynchronously via `client.SessionUsage()` on chat init and aft
 
 ## Tab completion
 
-`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins.
+`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins. Order in `slashCommands` is significant where one command is a prefix of another: `/agents` is listed before `/agent` and `/model` before `/models` so that tab-completing `/age` and `/mod` resolves to the longer-established command — extending a completion by one character is cheaper than backspacing.
 
 The Tab handler (`chat.go`) operates on the slash token at the cursor — not just at the start of input — so completion works mid-message and within multi-line input. `findSlashTokenAt(value, cursorByte)` walks back from the cursor to a `/` that is at the start of input or preceded by whitespace, requiring the cursor to sit at the end of the token (next character is whitespace or EOF). `setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted completion. `slashCommandHint(value, cursorByte)` returns the typed prefix and the suffix shown greyed-out in the input bar.
+
+### Agent name completion
+
+After `/agent ` the next token is treated as an agent name and completed against the cached agent list. The chat model fetches the list once on init via `loadAgentNames()` and stores display names in `m.agentNames`; completion silently degrades to no-op if the list hasn't loaded yet or the backend errored. `findAgentArgAt(value, cursorByte)` recognises the argument context only when the cursor sits at end-of-line and the line begins with `/agent ` (single space); the entire tail of the line is the token, so agent names containing spaces are completed in one shot. `completeAgentName` does a case-insensitive prefix match — empty prefix completes to the first known agent. `agentNameHint` mirrors `slashCommandHint` and feeds the same greyed-out hint renderer.
 
 ## Confirmation pattern
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -330,6 +330,11 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.updateViewport()
 		return m, nil
 
+	case agentSwitchFailedMsg:
+		m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+		m.updateViewport()
+		return m, nil
+
 	case modelSwitchedMsg:
 		if msg.err != nil {
 			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -164,6 +164,7 @@ type chatModel struct {
 	stats           *sessionStats
 	modelID         string
 	skills          []agentSkill
+	agentNames      []string // populated asynchronously by loadAgentNames; powers /agent <TAB> completion
 	spinnerFrame    int
 	spinnerTicking  bool
 	prefs           config.Preferences
@@ -261,7 +262,29 @@ func (m chatModel) Init() tea.Cmd {
 		m.loadHistory(),
 		m.loadStats(),
 		func() tea.Msg { return skillsDiscoveredMsg{skills: discoverSkills()} },
+		m.loadAgentNames(),
 	)
+}
+
+func (m chatModel) loadAgentNames() tea.Cmd {
+	b := m.backend
+	return func() tea.Msg {
+		result, err := b.ListAgents(context.Background())
+		if err != nil || result == nil {
+			return chatAgentNamesLoadedMsg{}
+		}
+		names := make([]string, 0, len(result.Agents))
+		for _, a := range result.Agents {
+			n := a.Name
+			if n == "" {
+				n = a.ID
+			}
+			if n != "" {
+				names = append(names, n)
+			}
+		}
+		return chatAgentNamesLoadedMsg{names: names}
+	}
 }
 
 func (m chatModel) loadStats() tea.Cmd {
@@ -403,6 +426,10 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case chatAgentNamesLoadedMsg:
+		m.agentNames = msg.names
+		return m, nil
+
 	case skillsDiscoveredMsg:
 		m.skills = msg.skills
 		if len(m.skills) > 0 {
@@ -432,9 +459,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		case "tab":
 			value := m.textarea.Value()
 			cursorByte := textareaCursorByteOffset(&m.textarea)
-			start, prefix, ok := findSlashTokenAt(value, cursorByte)
-			if ok {
+			if start, prefix, ok := findSlashTokenAt(value, cursorByte); ok {
 				if match := m.completeSlashCommand(prefix); match != "" && match != strings.ToLower(prefix) {
+					newValue := value[:start] + match + value[cursorByte:]
+					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
+				}
+			} else if start, prefix, ok := findAgentArgAt(value, cursorByte); ok {
+				if match := m.completeAgentName(prefix); match != "" && !strings.EqualFold(match, prefix) {
 					newValue := value[:start] + match + value[cursorByte:]
 					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
 				}
@@ -861,7 +892,12 @@ func (m chatModel) View() string {
 	} else if isLocalExec {
 		help = helpStyle.Render(localExecPrefixStyle.Render(" local command") + " — runs on this machine")
 	} else {
-		token, suffix := m.slashCommandHint(m.textarea.Value(), textareaCursorByteOffset(&m.textarea))
+		value := m.textarea.Value()
+		cursorByte := textareaCursorByteOffset(&m.textarea)
+		token, suffix := m.slashCommandHint(value, cursorByte)
+		if suffix == "" {
+			token, suffix = m.agentNameHint(value, cursorByte)
+		}
 		if suffix != "" {
 			help = helpStyle.Render(fmt.Sprintf(" %s%s — tab to complete", token, suffix))
 		} else if m.hideInput {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -21,7 +21,11 @@ type pendingConfirmation struct {
 }
 
 // slashCommands is the list of available slash commands for autocomplete.
-var slashCommands = []string{"/agents", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
+// "/agents" is intentionally listed before "/agent" so tab-completing "/age"
+// resolves to the picker (the more common command) rather than the switcher.
+// "/model" likewise sits before "/models" — typing "s" to extend a completion
+// is cheaper than backspacing one.
+var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/models", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -102,6 +106,15 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, tea.Quit
 	case "/agents":
 		return true, func() tea.Msg { return goBackMsg{} }
+	case "/models":
+		sessionKey := m.sessionKey
+		currentModelID := m.modelID
+		return true, func() tea.Msg {
+			return showModelPickerMsg{
+				sessionKey:     sessionKey,
+				currentModelID: currentModelID,
+			}
+		}
 	case "/cancel":
 		return true, m.cancelTurn()
 	case "/clear":
@@ -196,7 +209,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/model — open model picker (filter as you type)\n/model <name> — switch model directly\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -248,6 +261,11 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, nil
 	}
 
+	// /agent with optional name argument.
+	if command == "/agent" || strings.HasPrefix(command, "/agent ") {
+		return m.handleAgentCommand(text)
+	}
+
 	// /model with optional argument.
 	if command == "/model" || strings.HasPrefix(command, "/model ") {
 		return m.handleModelCommand(text)
@@ -285,18 +303,68 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	return false, nil
 }
 
-// handleModelCommand handles `/model` and `/model <name>`.
-func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
+// handleAgentCommand handles `/agent` and `/agent <name>`. With no argument
+// it returns to the agent picker (same as `/agents`). With a name it resolves
+// the agent and creates a session, mirroring the picker selection path.
+func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
-	if len(parts) == 1 {
-		sessionKey := m.sessionKey
-		currentModelID := m.modelID
-		return true, func() tea.Msg {
-			return showModelPickerMsg{
-				sessionKey:     sessionKey,
-				currentModelID: currentModelID,
+	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
+		return true, func() tea.Msg { return goBackMsg{} }
+	}
+
+	query := strings.ToLower(strings.TrimSpace(parts[1]))
+	b := m.backend
+	return true, func() tea.Msg {
+		ctx := context.Background()
+		result, err := b.ListAgents(ctx)
+		if err != nil {
+			return agentSwitchFailedMsg{err: err}
+		}
+		var match *protocol.AgentSummary
+		for i, a := range result.Agents {
+			lowerName := strings.ToLower(a.Name)
+			lowerID := strings.ToLower(a.ID)
+			if lowerName == query || lowerID == query {
+				match = &result.Agents[i]
+				break
+			}
+			if match == nil && (strings.Contains(lowerName, query) || strings.Contains(lowerID, query)) {
+				match = &result.Agents[i]
 			}
 		}
+		if match == nil {
+			return agentSwitchFailedMsg{err: fmt.Errorf("no agent matching %q", query)}
+		}
+		name := match.Name
+		if name == "" {
+			name = match.ID
+		}
+		modelID := ""
+		if match.Model != nil {
+			modelID = match.Model.Primary
+		}
+		key, err := b.CreateSession(ctx, match.ID, "main")
+		return sessionCreatedMsg{
+			sessionKey: key,
+			agentID:    match.ID,
+			agentName:  name,
+			modelID:    modelID,
+			err:        err,
+		}
+	}
+}
+
+// handleModelCommand handles `/model <name>`. Bare `/model` is an error —
+// `/models` opens the picker.
+func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
+		m.messages = append(m.messages, chatMessage{
+			role:   "system",
+			errMsg: "/model requires a name — use /models to open the picker",
+		})
+		m.updateViewport()
+		return true, nil
 	}
 
 	query := strings.ToLower(strings.TrimSpace(parts[1]))

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -80,6 +80,62 @@ func (m *chatModel) completeSlashCommand(prefix string) string {
 	return ""
 }
 
+// findAgentArgAt detects whether the cursor sits at the end of the argument
+// of `/agent <name>` on the current line. Returns the byte offset where the
+// argument starts and what the user has typed so far. Empty prefix is valid
+// (cursor immediately after `/agent ` triggers a completion to the first
+// known agent).
+func findAgentArgAt(value string, byteOffset int) (start int, prefix string, ok bool) {
+	if byteOffset < 0 || byteOffset > len(value) {
+		return 0, "", false
+	}
+	// Cursor must be at end-of-line or end-of-value. Agent names may
+	// contain spaces, so the whole tail of the line is the arg token.
+	if byteOffset < len(value) && value[byteOffset] != '\n' {
+		return 0, "", false
+	}
+	lineStart := byteOffset
+	for lineStart > 0 && value[lineStart-1] != '\n' {
+		lineStart--
+	}
+	const cmd = "/agent "
+	if byteOffset-lineStart < len(cmd) {
+		return 0, "", false
+	}
+	if !strings.EqualFold(value[lineStart:lineStart+len(cmd)], cmd) {
+		return 0, "", false
+	}
+	argStart := lineStart + len(cmd)
+	return argStart, value[argStart:byteOffset], true
+}
+
+// completeAgentName returns the first known agent name whose lowercased
+// form starts with prefix, preserving the original casing.
+func (m *chatModel) completeAgentName(prefix string) string {
+	lower := strings.ToLower(prefix)
+	for _, n := range m.agentNames {
+		if strings.HasPrefix(strings.ToLower(n), lower) {
+			return n
+		}
+	}
+	return ""
+}
+
+// agentNameHint returns the completion hint for the argument of
+// `/agent <name>` at the given cursor offset. Empty token/suffix when no
+// hint applies (wrong context, agents not yet loaded, or no match).
+func (m *chatModel) agentNameHint(value string, cursorByte int) (token, suffix string) {
+	_, prefix, ok := findAgentArgAt(value, cursorByte)
+	if !ok {
+		return "", ""
+	}
+	match := m.completeAgentName(prefix)
+	if match == "" || strings.EqualFold(match, prefix) {
+		return "", ""
+	}
+	return prefix, match[len(prefix):]
+}
+
 // slashCommandHint returns the completion hint for the slash token at the
 // given cursor byte offset. token is what the user has typed so far
 // (including the leading '/'), suffix is the remainder that Tab would insert.

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -402,6 +402,45 @@ func TestSlashCommandHint(t *testing.T) {
 	}
 }
 
+func TestAgentNameHint(t *testing.T) {
+	m := newSlashTestModel()
+	m.agentNames = []string{"alpha", "Beta", "Gamma Two"}
+	tests := []struct {
+		name       string
+		input      string
+		cursorByte int
+		wantToken  string
+		wantSuffix string
+	}{
+		{"empty arg completes first", "/agent ", 7, "", "alpha"},
+		{"prefix matches", "/agent al", 9, "al", "pha"},
+		{"case-insensitive prefix", "/agent BE", 9, "BE", "ta"},
+		{"matches name with space", "/agent Gam", 10, "Gam", "ma Two"},
+		{"exact match no hint", "/agent alpha", 12, "", ""},
+		{"no match", "/agent zzz", 10, "", ""},
+		{"command without space", "/agent", 6, "", ""},
+		{"unrelated command", "/agents", 7, "", ""},
+		{"cursor mid-line", "/agent al ", 9, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToken, gotSuffix := m.agentNameHint(tt.input, tt.cursorByte)
+			if gotToken != tt.wantToken || gotSuffix != tt.wantSuffix {
+				t.Errorf("agentNameHint(%q, %d) = (%q, %q), want (%q, %q)",
+					tt.input, tt.cursorByte, gotToken, gotSuffix, tt.wantToken, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestAgentNameHint_NoAgentsLoaded(t *testing.T) {
+	m := newSlashTestModel()
+	token, suffix := m.agentNameHint("/agent al", 9)
+	if token != "" || suffix != "" {
+		t.Errorf("expected no hint when agents are unloaded, got (%q, %q)", token, suffix)
+	}
+}
+
 func TestSlashCommand_Config(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/config")

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -60,6 +60,38 @@ func TestSlashCommand_Agents(t *testing.T) {
 	}
 }
 
+func TestSlashCommand_Agent_BareReturnsToAgentPicker(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/agent")
+	if !handled {
+		t.Fatal("expected /agent to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected /agent to return a goBackMsg cmd")
+	}
+	if _, ok := cmd().(goBackMsg); !ok {
+		t.Errorf("expected goBackMsg, got %T", cmd())
+	}
+}
+
+func TestSlashCommand_Agent_NoMatchReturnsFailureMsg(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/agent nope")
+	if !handled {
+		t.Fatal("expected /agent <name> to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected /agent <name> to return a switch cmd")
+	}
+	msg, ok := cmd().(agentSwitchFailedMsg)
+	if !ok {
+		t.Fatalf("expected agentSwitchFailedMsg, got %T", cmd())
+	}
+	if msg.err == nil || !strings.Contains(msg.err.Error(), "no agent matching") {
+		t.Errorf("expected no-match error, got %v", msg.err)
+	}
+}
+
 func TestSlashCommand_Clear(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/clear")
@@ -192,14 +224,32 @@ func TestSlashCommand_Skills_Populated(t *testing.T) {
 	}
 }
 
-func TestSlashCommand_Model_ListReturnsCmd(t *testing.T) {
+func TestSlashCommand_Model_BareEmitsHint(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/model")
 	if !handled {
 		t.Fatal("expected /model to be handled")
 	}
+	if cmd != nil {
+		t.Error("expected bare /model to return no cmd (inline error only)")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || !strings.Contains(last.errMsg, "/models") {
+		t.Errorf("expected hint pointing at /models, got: %+v", last)
+	}
+}
+
+func TestSlashCommand_Models_ReturnsPickerCmd(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/models")
+	if !handled {
+		t.Fatal("expected /models to be handled")
+	}
 	if cmd == nil {
-		t.Error("expected /model to return a list cmd")
+		t.Fatal("expected /models to return a picker cmd")
+	}
+	if _, ok := cmd().(showModelPickerMsg); !ok {
+		t.Errorf("expected showModelPickerMsg, got %T", cmd())
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -135,6 +135,13 @@ type agentSwitchFailedMsg struct {
 	err error
 }
 
+// chatAgentNamesLoadedMsg delivers agent display names to the chat model
+// for `/agent <TAB>` completion. Empty names slice on backend error is
+// acceptable — completion silently degrades.
+type chatAgentNamesLoadedMsg struct {
+	names []string
+}
+
 // skillsDiscoveredMsg is returned when skill discovery completes.
 type skillsDiscoveredMsg struct {
 	skills []agentSkill

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -128,6 +128,13 @@ type sessionCreatedMsg struct {
 	err        error
 }
 
+// agentSwitchFailedMsg signals that `/agent <name>` could not resolve or
+// switch to an agent. Rendered inline in the chat view rather than bouncing
+// the user back to the picker, so a typo doesn't lose chat context.
+type agentSwitchFailedMsg struct {
+	err error
+}
+
 // skillsDiscoveredMsg is returned when skill discovery completes.
 type skillsDiscoveredMsg struct {
 	skills []agentSkill


### PR DESCRIPTION
Add a direct `/agent <name>` switcher mirroring picker selection, and split `/model` into a name-only switch with a new `/models` picker command.

## Summary
- Add `/agent <name>` to switch agent directly without going through the picker; bare `/agent` opens the picker, matching `/agents`.
- Match agent lookups case-insensitively on name or ID, with substring fallback (the same fuzzy strategy as `/model`).
- Render lookup failures inline in the chat view via a new `agentSwitchFailedMsg` so a typo doesn't bounce the user out of their session.
- Add `/models` to open the model picker. Bare `/model` now emits an inline hint pointing at `/models`; `/model <name>` continues to switch directly.
- Update `/help` and the slash-completion list; cover the new behaviour with tests.

## Implementation details
The successful agent-switch path reuses the existing `sessionCreatedMsg` flow that the picker already emits, so the chat view rebuild is identical regardless of how the agent was chosen. Only the failure path needed a new message type, kept narrow so the picker still owns errors that originate from the picker itself.

`/agents` is intentionally listed before `/agent` (and `/model` before `/models`) so existing tab-completion of `/age` and `/mod` still resolves to the longer-established command — extending a completion by one character is cheaper than backspacing.