### PR TITLE
feat(tui): show per-session context usage in chat header

### DIFF
--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -41,9 +41,14 @@ The spinner also appears while the model is thinking before any response deltas 
 The header line shows:
 
 - **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected) · update-available badge (only when `prefs.UpdateChecksEnabled()` and the startup check found a newer release)
-- **Right:** token summary (input / output / cache) · total cost
+- **Right:** context usage (`tokens: 65k/1.0m (7%)  $0.42`) when the gateway has reported a context window for the active session; otherwise the legacy `tokens: 125.5K (2.3K cached)  $0.42` shape.
 
-Stats are loaded on init and refreshed after each message exchange via `loadStats()`. The header is re-rendered on every `statsLoadedMsg`. Token and cost values come from `client.SessionUsage()`.
+Two independent loads feed the right-hand side:
+
+- `loadContextUsage()` populates `m.promptTokens` and `m.contextWindow`. It calls `SessionsList(agentID)`, finds the entry whose `key` matches `m.sessionKey`, and reads `totalTokens` (numerator — a per-turn prompt-token snapshot of `input + cacheRead + cacheWrite`, intentionally excluding output) and `contextTokens` (denominator), falling back to `defaults.contextTokens` when the entry omits the window. This is what makes the percentage scoped to the *current session*; the older approach of calling `SessionUsage("")` returned gateway-wide aggregates and pegged the value at 999%. The cmd refreshes on chat init, on every `historyRefreshMsg` (so the percentage tracks turn-by-turn), and on `modelSwitchedMsg` (a new model can change the window). The handler discards results whose `sessionKey` no longer matches `m.sessionKey` so a navigated-away-and-back race can't apply a stale snapshot.
+- `loadStats()` continues to call `client.SessionUsage()` for the cumulative cost figure shown on the right of the header (and for the `/stats` table). The percentage display falls back to its token+cache layout when `loadContextUsage` hasn't produced a window yet.
+
+The renderer caps the percentage at 999% so a runaway numerator never widens the header past three digits.
 
 The connection-status badge is rendered in the error colour and only appears when the gateway connection is degraded:
 

--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -47,6 +47,12 @@ type fakeBackend struct {
 	// paths without inventing a separate fake.
 	createSessionHook func(ctx context.Context, agentID, key string) (string, error)
 
+	// sessionsListHook, when non-nil, replaces the default empty
+	// SessionsList response so tests of the chat header's
+	// context-usage path can stage a realistic gateway payload (or
+	// an error).
+	sessionsListHook func(ctx context.Context, agentID string) (json.RawMessage, error)
+
 	// Cron RPC seams — tests pre-seed jobs / runs / errors and read
 	// back the recorded calls through these fields.
 	cronJobs        []protocol.CronJob
@@ -97,6 +103,9 @@ func (f *fakeBackend) DeleteAgent(ctx context.Context, params backend.DeleteAgen
 	return f.deleteAgentErr
 }
 func (f *fakeBackend) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
+	if f.sessionsListHook != nil {
+		return f.sessionsListHook(ctx, agentID)
+	}
 	return json.RawMessage(`{"sessions":[]}`), nil
 }
 func (f *fakeBackend) CreateSession(ctx context.Context, agentID, key string) (string, error) {

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -163,6 +163,8 @@ type chatModel struct {
 	renderer        *glamour.TermRenderer
 	stats           *sessionStats
 	modelID         string
+	promptTokens    int // input + cache read + cache write for the latest turn (a per-session snapshot, not cumulative); 0 until first sessions.list refresh
+	contextWindow   int // model context capacity for the active session; 0 when unknown
 	skills          []agentSkill
 	agentNames      []string // populated asynchronously by loadAgentNames; powers /agent <TAB> completion
 	spinnerFrame    int
@@ -261,6 +263,7 @@ func (m chatModel) Init() tea.Cmd {
 		textarea.Blink,
 		m.loadHistory(),
 		m.loadStats(),
+		m.loadContextUsage(),
 		func() tea.Msg { return skillsDiscoveredMsg{skills: discoverSkills()} },
 		m.loadAgentNames(),
 	)
@@ -284,6 +287,65 @@ func (m chatModel) loadAgentNames() tea.Cmd {
 			}
 		}
 		return chatAgentNamesLoadedMsg{names: names}
+	}
+}
+
+// loadContextUsage fetches the per-session context-usage snapshot
+// (numerator and denominator for the header's "N/W (P%)" display)
+// from sessions.list. The gateway emits a totalTokens field per
+// session entry that is the prompt-token snapshot for the latest run
+// (input + cache read + cache write, intentionally excluding output),
+// and a contextTokens field that is the model window for that specific
+// session. Reading both from the same entry keeps the percentage scoped
+// to *this* session rather than a gateway-wide aggregate.
+func (m chatModel) loadContextUsage() tea.Cmd {
+	if m.sessionKey == "" {
+		return func() tea.Msg { return contextUsageLoadedMsg{} }
+	}
+	b := m.backend
+	sessionKey := m.sessionKey
+	agentID := m.agentID
+	return func() tea.Msg {
+		raw, err := b.SessionsList(context.Background(), agentID)
+		if err != nil {
+			return contextUsageLoadedMsg{sessionKey: sessionKey}
+		}
+		var resp struct {
+			Sessions []json.RawMessage `json:"sessions"`
+			Defaults struct {
+				ContextTokens *int `json:"contextTokens"`
+			} `json:"defaults"`
+		}
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			return contextUsageLoadedMsg{sessionKey: sessionKey}
+		}
+		var entry struct {
+			Key           string `json:"key"`
+			TotalTokens   *int   `json:"totalTokens"`
+			ContextTokens *int   `json:"contextTokens"`
+		}
+		for _, rawEntry := range resp.Sessions {
+			var probe struct {
+				Key string `json:"key"`
+			}
+			if err := json.Unmarshal(rawEntry, &probe); err != nil || probe.Key != sessionKey {
+				continue
+			}
+			if err := json.Unmarshal(rawEntry, &entry); err == nil {
+				break
+			}
+		}
+		out := contextUsageLoadedMsg{sessionKey: sessionKey}
+		if entry.TotalTokens != nil {
+			out.promptTokens = *entry.TotalTokens
+		}
+		switch {
+		case entry.ContextTokens != nil:
+			out.contextWindow = *entry.ContextTokens
+		case resp.Defaults.ContextTokens != nil:
+			out.contextWindow = *resp.Defaults.ContextTokens
+		}
+		return out
 	}
 }
 
@@ -369,6 +431,18 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			})
 		}
 		m.updateViewport()
+		// New model means a new context window — refresh the snapshot
+		// so the header doesn't keep showing the previous model's window.
+		return m, m.loadContextUsage()
+
+	case contextUsageLoadedMsg:
+		// Discard if the active session changed mid-flight (e.g. user
+		// navigated away then back) — the snapshot would belong to a
+		// different session.
+		if msg.sessionKey == m.sessionKey {
+			m.promptTokens = msg.promptTokens
+			m.contextWindow = msg.contextWindow
+		}
 		return m, nil
 
 	case gatewayStatusMsg:
@@ -446,7 +520,10 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			m.messages = msg.messages
 			m.updateViewport()
 		}
-		return m, nil
+		// History refresh fires after each completed turn — pull a
+		// fresh prompt-token snapshot so the % keeps up with the
+		// session's current context size.
+		return m, tea.Batch(m.loadStats(), m.loadContextUsage())
 
 	case tea.KeyPressMsg:
 		logEvent("KEY code=%d mod=%v string=%q", msg.Code, msg.Mod, msg.String())
@@ -861,7 +938,21 @@ func (m chatModel) View() string {
 		left += " · " + headerBadgeWarnStyle.Render("↑ "+m.updateLatest)
 	}
 	right := ""
-	if m.stats != nil {
+	if m.contextWindow > 0 && m.promptTokens > 0 {
+		// Per-session prompt-token snapshot from sessions.list — the
+		// "live context" size for the latest turn. Capped at 999% so
+		// a runaway value never widens the header.
+		pct := m.promptTokens * 100 / m.contextWindow
+		if pct > 999 {
+			pct = 999
+		}
+		cost := 0.0
+		if m.stats != nil {
+			cost = m.stats.totalCost
+		}
+		right = fmt.Sprintf("tokens: %s/%s (%d%%)  $%.2f ",
+			formatTokensShort(m.promptTokens), formatTokensShort(m.contextWindow), pct, cost)
+	} else if m.stats != nil {
 		newTokens := m.stats.inputTokens + m.stats.outputTokens
 		right = fmt.Sprintf("tokens: %s (%s cached)  $%.2f ",
 			formatTokens(newTokens), formatTokens(m.stats.cacheRead), m.stats.totalCost)

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -1,0 +1,220 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+)
+
+// newContextUsageTestModel builds a chatModel wired to fakeBackend with
+// a session/agent key set, so the context-usage cmd has somewhere to
+// look up. The fake's SessionsList behaviour is staged per-test via
+// sessionsListHook.
+func newContextUsageTestModel() (*chatModel, *fakeBackend) {
+	fb := newFakeBackend()
+	vp := viewport.New()
+	m := &chatModel{
+		viewport:   vp,
+		backend:    fb,
+		sessionKey: "agent:scout:main",
+		agentID:    "scout",
+		agentName:  "scout",
+		width:      120,
+		height:     40,
+	}
+	return m, fb
+}
+
+func TestLoadContextUsage_ReadsFromMatchingSessionEntry(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		return json.RawMessage(`{
+			"sessions": [
+				{"key": "agent:other:main", "totalTokens": 99999, "contextTokens": 200000},
+				{"key": "agent:scout:main", "totalTokens": 65000, "contextTokens": 1000000}
+			]
+		}`), nil
+	}
+
+	msg, ok := m.loadContextUsage()().(contextUsageLoadedMsg)
+	if !ok {
+		t.Fatalf("expected contextUsageLoadedMsg, got %T", msg)
+	}
+	if msg.sessionKey != "agent:scout:main" {
+		t.Errorf("sessionKey: got %q, want %q", msg.sessionKey, "agent:scout:main")
+	}
+	if msg.promptTokens != 65000 {
+		t.Errorf("promptTokens: got %d, want 65000", msg.promptTokens)
+	}
+	if msg.contextWindow != 1000000 {
+		t.Errorf("contextWindow: got %d, want 1000000", msg.contextWindow)
+	}
+}
+
+func TestLoadContextUsage_FallsBackToDefaultsContextTokens(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		return json.RawMessage(`{
+			"sessions": [
+				{"key": "agent:scout:main", "totalTokens": 12345}
+			],
+			"defaults": {"contextTokens": 500000}
+		}`), nil
+	}
+
+	msg := m.loadContextUsage()().(contextUsageLoadedMsg)
+	if msg.promptTokens != 12345 {
+		t.Errorf("promptTokens: got %d, want 12345", msg.promptTokens)
+	}
+	if msg.contextWindow != 500000 {
+		t.Errorf("contextWindow should fall back to defaults.contextTokens: got %d, want 500000", msg.contextWindow)
+	}
+}
+
+func TestLoadContextUsage_NoMatchingEntryReturnsZeros(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		return json.RawMessage(`{
+			"sessions": [
+				{"key": "agent:other:main", "totalTokens": 100, "contextTokens": 200}
+			]
+		}`), nil
+	}
+
+	msg := m.loadContextUsage()().(contextUsageLoadedMsg)
+	if msg.promptTokens != 0 || msg.contextWindow != 0 {
+		t.Errorf("expected zeros for unmatched session, got prompt=%d window=%d", msg.promptTokens, msg.contextWindow)
+	}
+	if msg.sessionKey != "agent:scout:main" {
+		t.Errorf("sessionKey echoed back so handler can drop stale results: got %q", msg.sessionKey)
+	}
+}
+
+func TestLoadContextUsage_EmptySessionKeyShortCircuits(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	m.sessionKey = ""
+	called := false
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		called = true
+		return json.RawMessage(`{}`), nil
+	}
+
+	msg := m.loadContextUsage()().(contextUsageLoadedMsg)
+	if called {
+		t.Error("SessionsList must not be called when sessionKey is empty")
+	}
+	if msg.promptTokens != 0 || msg.contextWindow != 0 {
+		t.Errorf("expected zeros, got prompt=%d window=%d", msg.promptTokens, msg.contextWindow)
+	}
+}
+
+func TestLoadContextUsage_RPCErrorIsSwallowed(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		return nil, errors.New("gateway down")
+	}
+
+	// The header should never error out the chat view because the
+	// percentage couldn't be loaded — the cmd must still emit a
+	// well-formed (zero-valued) message.
+	msg := m.loadContextUsage()().(contextUsageLoadedMsg)
+	if msg.promptTokens != 0 || msg.contextWindow != 0 {
+		t.Errorf("expected zeros on RPC error, got prompt=%d window=%d", msg.promptTokens, msg.contextWindow)
+	}
+}
+
+func TestContextUsageLoadedMsg_IgnoresStaleSession(t *testing.T) {
+	m, _ := newContextUsageTestModel()
+	m.sessionKey = "agent:scout:main"
+	m.promptTokens = 1
+	m.contextWindow = 2
+
+	updated, _ := m.Update(contextUsageLoadedMsg{
+		sessionKey:    "agent:other:main",
+		promptTokens:  9999,
+		contextWindow: 8888,
+	})
+
+	if updated.promptTokens != 1 || updated.contextWindow != 2 {
+		t.Errorf("stale snapshot should not overwrite live state, got prompt=%d window=%d",
+			updated.promptTokens, updated.contextWindow)
+	}
+}
+
+func TestContextUsageLoadedMsg_AppliesMatchingSession(t *testing.T) {
+	m, _ := newContextUsageTestModel()
+
+	updated, _ := m.Update(contextUsageLoadedMsg{
+		sessionKey:    "agent:scout:main",
+		promptTokens:  4242,
+		contextWindow: 100000,
+	})
+
+	if updated.promptTokens != 4242 {
+		t.Errorf("promptTokens: got %d, want 4242", updated.promptTokens)
+	}
+	if updated.contextWindow != 100000 {
+		t.Errorf("contextWindow: got %d, want 100000", updated.contextWindow)
+	}
+}
+
+func TestModelSwitchedMsg_TriggersContextUsageRefresh(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	called := false
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		called = true
+		return json.RawMessage(`{"sessions":[]}`), nil
+	}
+
+	_, cmd := m.Update(modelSwitchedMsg{modelID: "deepseek/deepseek-v4-flash"})
+	if cmd == nil {
+		t.Fatal("expected a refresh cmd after model switch")
+	}
+	// Drain the returned message — the cmd should hit SessionsList
+	// because a new model can change the session's contextTokens.
+	cmd()
+	if !called {
+		t.Error("model switch must refresh context usage via SessionsList")
+	}
+}
+
+func TestHistoryRefreshMsg_TriggersContextUsageRefresh(t *testing.T) {
+	m, fb := newContextUsageTestModel()
+	called := false
+	fb.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		called = true
+		return json.RawMessage(`{"sessions":[]}`), nil
+	}
+
+	_, cmd := m.Update(historyRefreshMsg{messages: []chatMessage{{role: "assistant", content: "ok"}}})
+	if cmd == nil {
+		t.Fatal("expected a batch cmd that refreshes context usage")
+	}
+	// historyRefreshMsg fires after every completed turn; both
+	// loadStats and loadContextUsage are batched. Run the batch and
+	// fish out the SessionsList call.
+	drainBatch(t, cmd)
+	if !called {
+		t.Error("history refresh must re-pull the context-usage snapshot so the % keeps up per turn")
+	}
+}
+
+// drainBatch executes every leaf cmd produced by tea.Batch so test
+// hooks get hit even when the batch wraps multiple commands.
+func drainBatch(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			drainBatch(t, sub)
+		}
+	}
+}
+

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -86,6 +86,17 @@ type modelSwitchedMsg struct {
 	err     error
 }
 
+// contextUsageLoadedMsg carries a per-session context-usage snapshot
+// (numerator + denominator for the header's "N/W (P%)" display),
+// sourced from the entry in sessions.list that matches the active
+// session key. Both fields are 0 when the entry can't be found or
+// the gateway didn't advertise the values.
+type contextUsageLoadedMsg struct {
+	sessionKey    string
+	promptTokens  int // input + cache read + cache write for the latest turn (no output)
+	contextWindow int
+}
+
 // showModelPickerMsg signals the AppModel to switch to the model picker.
 type showModelPickerMsg struct {
 	sessionKey     string

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -206,6 +206,21 @@ func formatTokens(n int) string {
 	}
 }
 
+// formatTokensShort formats a token count using lowercase k/m suffixes
+// in the "65k/1.0m" style used by the context-usage header. Thousands
+// round to whole units (no decimal) so the figure stays compact in the
+// status bar.
+func formatTokensShort(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fm", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%dk", n/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
 // wordWrap wraps text to the given width, preserving existing newlines.
 // Lines that contain box-drawing characters (table output) are passed through
 // unchanged to preserve column alignment.

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -162,6 +162,39 @@ func TestChatModel_HeaderOmitsConnectionWhenBlank(t *testing.T) {
 	}
 }
 
+// TestRender_ChatView_HeaderShowsContextPercent locks in the
+// context-usage display: when sessions.list has reported a
+// per-session prompt-token snapshot and a context window for the
+// active session, the header renders "tokens N/W (P%)".
+func TestRender_ChatView_HeaderShowsContextPercent(t *testing.T) {
+	adapter := newRenderingChatModel(t, "scout")
+	adapter.inner.promptTokens = 65_000
+	adapter.inner.contextWindow = 1_000_000
+
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
+
+	waitForContains(t, tm.Output(), "65k/1.0m", "(6%)")
+}
+
+// TestRender_ChatView_HeaderFallsBackWithoutContextWindow locks in the
+// fallback when the gateway hasn't advertised a window for the active
+// model — the legacy "tokens: X (Y cached)" form is preserved so the
+// header never shows a misleading 0% or "/0".
+func TestRender_ChatView_HeaderFallsBackWithoutContextWindow(t *testing.T) {
+	adapter := newRenderingChatModel(t, "scout")
+	adapter.inner.stats = &sessionStats{
+		inputTokens:  1_500,
+		outputTokens: 500,
+		cacheRead:    300,
+	}
+
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
+
+	waitForContains(t, tm.Output(), "tokens:", "cached")
+}
+
 func TestRender_ChatView_QueuedCountShownInHelpBar(t *testing.T) {
 	adapter := newRenderingChatModel(t, "main")
 	adapter.inner.sending = true

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -177,6 +177,21 @@ func TestRender_ChatView_HeaderShowsContextPercent(t *testing.T) {
 	waitForContains(t, tm.Output(), "65k/1.0m", "(6%)")
 }
 
+// TestRender_ChatView_HeaderCapsPercentAt999 locks in the safety cap:
+// if the snapshot reports a numerator that vastly exceeds the window
+// (e.g. a corrupt/aggregate value), the header must clamp at 999% so
+// it never widens past three digits and breaks alignment.
+func TestRender_ChatView_HeaderCapsPercentAt999(t *testing.T) {
+	adapter := newRenderingChatModel(t, "scout")
+	adapter.inner.promptTokens = 100_000_000
+	adapter.inner.contextWindow = 1_000
+
+	tm := teatest.NewTestModel(t, adapter, teatest.WithInitialTermSize(120, 40))
+	defer finishProgram(t, tm)
+
+	waitForContains(t, tm.Output(), "(999%)")
+}
+
 // TestRender_ChatView_HeaderFallsBackWithoutContextWindow locks in the
 // fallback when the gateway hasn't advertised a window for the active
 // model — the legacy "tokens: X (Y cached)" form is preserved so the


### PR DESCRIPTION
Replace the chat header's cumulative-token display with a per-session context-usage percentage so the header tracks the live context size for the active session, not gateway-wide totals.

## Summary
- Read the prompt-token snapshot and context window from the active session's entry in `sessions.list` (with `defaults.contextTokens` as a window fallback) instead of `SessionUsage("")`, which returned cross-session aggregates and pegged the percentage at 999%.
- Refresh the snapshot on init, after every completed turn (`historyRefreshMsg`), and after a model switch so the header keeps up as context grows or the window changes.
- Render the new header form `tokens: 65k/1.0m (7%)  $0.42` when both numerator and window are known; fall back to the previous `tokens: X (Y cached)` shape otherwise. Cost continues to come from `SessionUsage`.
- Remove the now-redundant `models.list`-based window lookup and the `contextWindow` plumbing on `modelSwitchedMsg`.

## Implementation details
The numerator deliberately matches the official upstream semantics: `input + cacheRead + cacheWrite` for the latest run, excluding output. That makes the value a "current prompt size" rather than a session-cumulative total, so the percentage stays bounded by the model window during normal use. The renderer still caps at 999% as a safety rail.