### PR TITLE
feat: add one-shot CLI mode via `lucinate send` subcommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ The `docs/` directory contains maintainer-level documentation for the main subsy
 - [agents.md](docs/agents.md) — agent picker, auto-selection, agent creation
 - [sessions.md](docs/sessions.md) — session lifecycle, session browser, compact/reset, message queueing
 - [commands.md](docs/commands.md) — slash command dispatch, all built-in commands, tab completion, confirmation pattern
+- [one-shot.md](docs/one-shot.md) — `lucinate send` lifecycle, default session rule, detach semantics, embedding `app.Send`
 - [shell-execution.md](docs/shell-execution.md) — `!` local and `!!` remote exec, two-phase approval
 - [skills.md](docs/skills.md) — skill file format, discovery, catalog injection, activation
 - [chat-ux.md](docs/chat-ux.md) — input bindings, streaming animation, thinking levels, header bar, history depth

--- a/README.md
+++ b/README.md
@@ -189,6 +189,36 @@ Prefix input with `!!` to run a command on the gateway host. The input border tu
 
 The gateway's exec security policy controls which remote commands are allowed. If a command is denied, you'll see an error message. Configure exec permissions on the gateway host using `openclaw config`.
 
+## One-shot mode
+
+Not every prompt needs a TUI. `lucinate send` dispatches a single message through one of your saved connections, waits for the assistant's first complete reply, and prints it to stdout — nothing else. No streaming, no spinner, no chrome. Safe to capture into a shell variable, pipe into `jq`, or schedule from cron.
+
+```sh
+lucinate send --connection my-con --agent main "summarise this PR description"
+```
+
+| Flag | Description |
+|------|-------------|
+| `--connection` | Saved connection name or ID (case-insensitive on name). Required. |
+| `--agent` | Agent name or ID within the connection (case-insensitive on name). Required. |
+| `--session` | Session key. Defaults to the agent's main session — same default the picker would pick. |
+| `--detach` | Dispatch the message and exit as soon as the gateway accepts the turn. No reply is awaited. |
+
+The reply is written to stdout with a single trailing newline. Errors go to stderr; the exit code is non-zero on failure. Messages that begin with a dash should be preceded by `--` (the standard Unix escape) so the flag parser leaves them alone.
+
+A couple of patterns this enables:
+
+```sh
+# capture a reply into a shell variable
+reply=$(lucinate send --connection my-con --agent main "what's the changelog entry for this commit?")
+echo "$reply" | tee notes.md
+
+# fire-and-forget from cron — the run continues server-side, the next TUI session sees the reply
+lucinate send --connection my-con --agent main --detach "kick off the morning digest"
+```
+
+For the lifecycle, the default-session rule, embedding `app.Send` from Go, and the detach contract, see [docs/one-shot.md](docs/one-shot.md).
+
 ### Command line flags
 
 | Flag | Description |

--- a/app/send.go
+++ b/app/send.go
@@ -1,0 +1,378 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/a3tai/openclaw-go/protocol"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// SendOptions configures a one-shot Send invocation.
+//
+// Send dispatches a single user message through the same connection,
+// backend, and session plumbing the TUI uses, then (when Detach is
+// false) blocks until the assistant's first complete reply arrives. It
+// is the programmatic surface behind the `lucinate send` subcommand —
+// callers that want deeper control should drive a Program directly.
+type SendOptions struct {
+	// Connection identifies the saved connection to dispatch through,
+	// matched first by ID and then case-insensitively by Name. Required.
+	Connection string
+
+	// Agent identifies the destination agent within the connection,
+	// matched first by ID and then case-insensitively by Name.
+	// Required.
+	Agent string
+
+	// Session is the optional session key. When empty Send routes the
+	// message to the agent's main session, mirroring the TUI's pick:
+	// the AgentsListResult.MainKey for the connection's default agent,
+	// or the literal "main" for any other agent. The backend's
+	// CreateSession is responsible for resolving the supplied key into
+	// the wire-level session identifier (the gateway returns its own
+	// canonical key for OpenClaw; OpenAI-compat returns the agent ID).
+	Session string
+
+	// Message is the user input dispatched as the chat turn. Equivalent
+	// to typing the same text into the TUI textarea and pressing
+	// Enter — including any leading slash, which the TUI would
+	// normally route to a command handler. Send does not parse slash
+	// commands; callers wanting that behaviour should use the TUI.
+	// Required (must be non-empty after trimming surrounding
+	// whitespace).
+	Message string
+
+	// Detach makes Send fire-and-forget: the user message is dispatched
+	// and the call returns once the backend's chat-send RPC ack
+	// arrives, without waiting for any streaming events. Useful for
+	// scripted "kick off a turn and walk away" automation. When
+	// false (the default) Send blocks until the run terminates with a
+	// final, error, or aborted chat event.
+	Detach bool
+
+	// Out is where the assistant's final reply is written when Detach
+	// is false. Defaults to os.Stdout. Send writes the reply text once
+	// the run terminates and appends a single trailing newline if the
+	// reply does not already end in one. Streaming deltas, tool
+	// events, and connection chrome are intentionally suppressed so
+	// the output is safe to capture into shell variables or pipe
+	// into another tool.
+	Out io.Writer
+
+	// BackendFactory builds the backend for the resolved connection.
+	// Defaults to DefaultBackendFactory so callers get the same auth
+	// resolution and per-connection secrets store the CLI uses.
+	// Embedders that want to substitute a fake (in tests, say) wire
+	// their own factory in here.
+	BackendFactory BackendFactory
+
+	// ConnectionsStore, when non-nil, is the connection set Send
+	// resolves Connection against. Defaults to LoadConnections() so
+	// the CLI's standard on-disk store is used. Tests inject a
+	// purpose-built store through this field.
+	ConnectionsStore *Connections
+}
+
+// Send is the programmatic entry point for the one-shot CLI mode.
+// See SendOptions for argument semantics.
+//
+// Send's lifecycle on a non-detached call:
+//
+//  1. Resolve the connection and build a fresh backend.
+//  2. Connect, defer Close.
+//  3. Resolve the agent against ListAgents, picking the main session if
+//     the caller did not name one.
+//  4. CreateSession to get the canonical session key.
+//  5. Subscribe to backend events before issuing ChatSend so the final
+//     event cannot race past the consumer.
+//  6. ChatSend, then drain events until a chat event with state
+//     "final", "error", or "aborted" matching the run lands. Write the
+//     reply text to opts.Out and return.
+//
+// In detached mode Send stops at step 5: it drains the ChatSend RPC
+// ack so any synchronous error (auth, validation, no-such-agent)
+// surfaces, and returns nil after the gateway has accepted the turn.
+// The chat run continues server-side and any subsequent reply is
+// rendered the next time the user opens the TUI on the same session.
+func Send(ctx context.Context, opts SendOptions) error {
+	if strings.TrimSpace(opts.Connection) == "" {
+		return errors.New("send: --connection is required")
+	}
+	if strings.TrimSpace(opts.Agent) == "" {
+		return errors.New("send: --agent is required")
+	}
+	if strings.TrimSpace(opts.Message) == "" {
+		return errors.New("send: message is required")
+	}
+
+	factory := opts.BackendFactory
+	if factory == nil {
+		factory = DefaultBackendFactory
+	}
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+
+	var store Connections
+	if opts.ConnectionsStore != nil {
+		store = *opts.ConnectionsStore
+	} else {
+		store = LoadConnections()
+	}
+	conn := resolveSendConnection(&store, opts.Connection)
+	if conn == nil {
+		return fmt.Errorf("send: connection %q not found", opts.Connection)
+	}
+
+	b, err := factory(conn)
+	if err != nil {
+		return fmt.Errorf("send: build backend: %w", err)
+	}
+	if err := b.Connect(ctx); err != nil {
+		_ = b.Close()
+		return fmt.Errorf("send: connect: %w", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	// Mark the connection as last-used so the next CLI launch picks
+	// it by default — same behaviour as a successful TUI connect.
+	store.MarkUsed(conn.ID)
+	if opts.ConnectionsStore == nil {
+		// Best-effort persist; matches CLI's OnConnectionsChanged
+		// callback. A failed write is non-fatal — the message still
+		// goes through.
+		_ = config.SaveConnections(store)
+	}
+
+	agentList, err := b.ListAgents(ctx)
+	if err != nil {
+		return fmt.Errorf("send: list agents: %w", err)
+	}
+	agent := resolveSendAgent(agentList, opts.Agent)
+	if agent == nil {
+		return fmt.Errorf("send: agent %q not found", opts.Agent)
+	}
+
+	createKey := opts.Session
+	if createKey == "" {
+		createKey = defaultSessionKey(agentList, agent)
+	}
+	sessionKey, err := b.CreateSession(ctx, agent.ID, createKey)
+	if err != nil {
+		return fmt.Errorf("send: create session: %w", err)
+	}
+
+	// Subscribe before ChatSend: backends with a single shared events
+	// channel (every concrete backend in this tree) buffer events but
+	// we still want a consumer ready before the run starts so the
+	// final event cannot race past us between RPC ack and the loop.
+	var (
+		collector *replyCollector
+		waitCh    chan error
+		waitCtx   context.Context
+		waitStop  context.CancelFunc
+	)
+	if !opts.Detach {
+		waitCtx, waitStop = context.WithCancel(ctx)
+		defer waitStop()
+		collector = newReplyCollector(sessionKey)
+		waitCh = make(chan error, 1)
+		go collector.run(waitCtx, b.Events(), waitCh)
+	}
+
+	idemKey := fmt.Sprintf("lucinate-send-%d", time.Now().UnixNano())
+	res, err := b.ChatSend(ctx, sessionKey, backend.ChatSendParams{
+		Message:        opts.Message,
+		IdempotencyKey: idemKey,
+	})
+	if err != nil {
+		return fmt.Errorf("send: chat: %w", err)
+	}
+	if opts.Detach {
+		return nil
+	}
+	collector.setRunID(res.RunID)
+
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			return err
+		}
+		text := collector.text()
+		if _, err := io.WriteString(out, text); err != nil {
+			return fmt.Errorf("send: write reply: %w", err)
+		}
+		if !strings.HasSuffix(text, "\n") {
+			if _, err := io.WriteString(out, "\n"); err != nil {
+				return fmt.Errorf("send: write reply: %w", err)
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// resolveSendConnection picks the connection a one-shot Send invocation
+// should use. The user-typed identifier is matched first by ID (so
+// scripts that captured a generated connection ID keep working) and
+// then case-insensitively by Name (the friendly form humans actually
+// type).
+func resolveSendConnection(store *Connections, query string) *Connection {
+	if conn := store.Find(query); conn != nil {
+		return conn
+	}
+	lc := strings.ToLower(query)
+	for i := range store.Connections {
+		if strings.ToLower(store.Connections[i].Name) == lc {
+			return &store.Connections[i]
+		}
+	}
+	return nil
+}
+
+// resolveSendAgent picks the AgentSummary matching the user-typed
+// identifier — same ID-then-name precedence as the connection lookup.
+// Returns nil if no agent matches; the caller surfaces a clear error.
+func resolveSendAgent(list *protocol.AgentsListResult, query string) *protocol.AgentSummary {
+	if list == nil {
+		return nil
+	}
+	for i := range list.Agents {
+		if list.Agents[i].ID == query {
+			return &list.Agents[i]
+		}
+	}
+	lc := strings.ToLower(query)
+	for i := range list.Agents {
+		if strings.ToLower(list.Agents[i].Name) == lc {
+			return &list.Agents[i]
+		}
+	}
+	return nil
+}
+
+// defaultSessionKey mirrors the TUI's "main session" pick from
+// internal/tui/select.go: the AgentsListResult.MainKey when the
+// chosen agent is the connection's default agent, otherwise the
+// literal "main" so backends create a fresh per-agent main session.
+func defaultSessionKey(list *protocol.AgentsListResult, agent *protocol.AgentSummary) string {
+	if list != nil && agent != nil && agent.ID == list.DefaultID && list.MainKey != "" {
+		return list.MainKey
+	}
+	return "main"
+}
+
+// replyCollector consumes backend chat events for a one-shot Send and
+// resolves once the assistant's first turn lands. The latest delta
+// text is buffered so the caller has a usable reply even when the
+// final event's structured Content array is empty (some backends emit
+// the whole body in deltas and only an ack-shaped final).
+type replyCollector struct {
+	sessionKey string
+
+	mu    sync.Mutex
+	runID string
+	body  string
+}
+
+func newReplyCollector(sessionKey string) *replyCollector {
+	return &replyCollector{sessionKey: sessionKey}
+}
+
+// setRunID is called after ChatSend returns its ack so the collector
+// can ignore events from any concurrently-running turn on the same
+// session. Until the ID is known the collector accepts every event
+// matching the session key — the ChatSend ack and the first delta
+// can race in either order.
+func (c *replyCollector) setRunID(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.runID = id
+}
+
+func (c *replyCollector) currentRunID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.runID
+}
+
+func (c *replyCollector) text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.body
+}
+
+func (c *replyCollector) setText(s string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.body = s
+}
+
+// run drains events until the first matching final / error / aborted
+// chat event lands, then signals via done. ctx cancellation and a
+// closed events channel are surfaced as errors so a network drop
+// during the wait turns into a clean Send failure instead of a hang.
+func (c *replyCollector) run(ctx context.Context, events <-chan protocol.Event, done chan<- error) {
+	for {
+		select {
+		case <-ctx.Done():
+			done <- ctx.Err()
+			return
+		case ev, ok := <-events:
+			if !ok {
+				done <- errors.New("send: backend event channel closed before reply")
+				return
+			}
+			if ev.EventName != protocol.EventChat {
+				continue
+			}
+			var chatEv protocol.ChatEvent
+			if err := json.Unmarshal(ev.Payload, &chatEv); err != nil {
+				continue
+			}
+			if chatEv.SessionKey != "" && chatEv.SessionKey != c.sessionKey {
+				continue
+			}
+			// Once we know the run ID, filter strictly to it so a
+			// concurrent turn on the same session can't bleed into
+			// the captured reply.
+			if rid := c.currentRunID(); rid != "" && chatEv.RunID != "" && chatEv.RunID != rid {
+				continue
+			}
+			switch chatEv.State {
+			case "delta":
+				if t := backend.ExtractChatText(chatEv.Message); t != "" {
+					c.setText(t)
+				}
+			case "final":
+				if t := backend.ExtractChatText(chatEv.Message); t != "" {
+					c.setText(t)
+				}
+				done <- nil
+				return
+			case "error":
+				msg := chatEv.ErrorMessage
+				if msg == "" {
+					msg = "chat error"
+				}
+				done <- fmt.Errorf("send: chat: %s", msg)
+				return
+			case "aborted":
+				done <- errors.New("send: chat aborted")
+				return
+			}
+		}
+	}
+}

--- a/app/send_test.go
+++ b/app/send_test.go
@@ -1,0 +1,615 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/a3tai/openclaw-go/protocol"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/client"
+)
+
+// sendFakeBackend is a minimal backend.Backend used to drive the
+// app.Send unit tests. It records the wire-level calls Send performs
+// (CreateSession's session key, ChatSend's message + idempotency key)
+// and lets each test push the chat event sequence the assistant turn
+// should "respond" with through the events channel.
+type sendFakeBackend struct {
+	events chan protocol.Event
+
+	listResult *protocol.AgentsListResult
+	listErr    error
+	connectErr error
+
+	createKey     string
+	createAgentID string
+	createReturn  string
+	createErr     error
+	createCalls   int
+
+	sentParams       backend.ChatSendParams
+	sentSessionKey   string
+	sentRunID        string
+	chatSendErr      error
+	chatSendDispatch func(ev <-chan protocol.Event, sessionKey, runID string)
+
+	closed bool
+	mu     sync.Mutex
+}
+
+func newSendFakeBackend() *sendFakeBackend {
+	return &sendFakeBackend{
+		events:       make(chan protocol.Event, 8),
+		listResult:   &protocol.AgentsListResult{},
+		createReturn: "",
+		sentRunID:    "run-1",
+	}
+}
+
+func (f *sendFakeBackend) Connect(ctx context.Context) error { return f.connectErr }
+func (f *sendFakeBackend) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+func (f *sendFakeBackend) wasClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+func (f *sendFakeBackend) Events() <-chan protocol.Event { return f.events }
+func (f *sendFakeBackend) Supervise(ctx context.Context, notify func(client.ConnState)) {
+	<-ctx.Done()
+}
+func (f *sendFakeBackend) ListAgents(ctx context.Context) (*protocol.AgentsListResult, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResult, nil
+}
+func (f *sendFakeBackend) CreateAgent(ctx context.Context, params backend.CreateAgentParams) error {
+	return nil
+}
+func (f *sendFakeBackend) DeleteAgent(ctx context.Context, params backend.DeleteAgentParams) error {
+	return nil
+}
+func (f *sendFakeBackend) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
+	return json.RawMessage(`{"sessions":[]}`), nil
+}
+func (f *sendFakeBackend) CreateSession(ctx context.Context, agentID, key string) (string, error) {
+	f.createCalls++
+	f.createAgentID = agentID
+	f.createKey = key
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	if f.createReturn != "" {
+		return f.createReturn, nil
+	}
+	return key, nil
+}
+func (f *sendFakeBackend) SessionDelete(ctx context.Context, sessionKey string) error { return nil }
+func (f *sendFakeBackend) ChatSend(ctx context.Context, sessionKey string, params backend.ChatSendParams) (*protocol.ChatSendResult, error) {
+	f.sentParams = params
+	f.sentSessionKey = sessionKey
+	if f.chatSendErr != nil {
+		return nil, f.chatSendErr
+	}
+	if f.chatSendDispatch != nil {
+		go f.chatSendDispatch(f.events, sessionKey, f.sentRunID)
+	}
+	return &protocol.ChatSendResult{RunID: f.sentRunID}, nil
+}
+func (f *sendFakeBackend) ChatAbort(ctx context.Context, sessionKey, runID string) error { return nil }
+func (f *sendFakeBackend) ChatHistory(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
+	return json.RawMessage(`{"messages":[]}`), nil
+}
+func (f *sendFakeBackend) ModelsList(ctx context.Context) (*protocol.ModelsListResult, error) {
+	return &protocol.ModelsListResult{}, nil
+}
+func (f *sendFakeBackend) SessionPatchModel(ctx context.Context, sessionKey, modelID string) error {
+	return nil
+}
+func (f *sendFakeBackend) Capabilities() backend.Capabilities { return backend.Capabilities{} }
+
+var _ backend.Backend = (*sendFakeBackend)(nil)
+
+// emitChatEvent pushes a chat event onto the fake's events channel.
+// Tests use this either inline or from a chatSendDispatch hook to
+// simulate the assistant streaming.
+func emitChatEvent(ch chan<- protocol.Event, sessionKey, runID, state string, message any, errMsg string) {
+	chatEv := protocol.ChatEvent{
+		RunID:        runID,
+		SessionKey:   sessionKey,
+		State:        state,
+		ErrorMessage: errMsg,
+	}
+	if message != nil {
+		raw, _ := json.Marshal(message)
+		chatEv.Message = raw
+	}
+	payload, _ := json.Marshal(chatEv)
+	ch <- protocol.Event{EventName: protocol.EventChat, Payload: payload}
+}
+
+// makeSendStore returns a one-connection store with the supplied
+// connection added under the given name. Send tests don't exercise
+// persistence so the unsaved store is fine.
+func makeSendStore(name string) (*Connections, *Connection) {
+	conn := Connection{
+		ID:   "conn-id",
+		Name: name,
+		Type: ConnTypeOpenAI,
+		URL:  "http://localhost:1234/v1",
+	}
+	return &Connections{Connections: []Connection{conn}}, &conn
+}
+
+// fixedFactory returns a BackendFactory that ignores its argument and
+// always hands back the supplied backend. Lets tests inject the fake
+// backend without going through DefaultBackendFactory's auth wiring.
+func fixedFactory(b backend.Backend) BackendFactory {
+	return func(*Connection) (backend.Backend, error) { return b, nil }
+}
+
+func TestSend_WaitsForFinalAndWritesReply(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		DefaultID: "main",
+		MainKey:   "main",
+		Agents:    []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		// Re-cast — emitChatEvent expects send-only.
+		out := fb.events
+		emitChatEvent(out, sessionKey, runID, "delta", "Hello", "")
+		emitChatEvent(out, sessionKey, runID, "final", map[string]any{
+			"role": "assistant",
+			"content": []map[string]any{
+				{"type": "text", "text": "Hello, world!"},
+			},
+		}, "")
+	}
+
+	store, _ := makeSendStore("openai-local")
+	var buf bytes.Buffer
+	err := Send(context.Background(), SendOptions{
+		Connection:       "openai-local",
+		Agent:            "main",
+		Message:          "hi",
+		Out:              &buf,
+		BackendFactory:   fixedFactory(fb),
+		ConnectionsStore: store,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := buf.String(); got != "Hello, world!\n" {
+		t.Errorf("output = %q, want %q", got, "Hello, world!\n")
+	}
+	if fb.sentParams.Message != "hi" {
+		t.Errorf("ChatSend message = %q, want %q", fb.sentParams.Message, "hi")
+	}
+	if !strings.HasPrefix(fb.sentParams.IdempotencyKey, "lucinate-send-") {
+		t.Errorf("IdempotencyKey = %q, want lucinate-send- prefix", fb.sentParams.IdempotencyKey)
+	}
+	if !fb.wasClosed() {
+		t.Error("backend was not closed after Send returned")
+	}
+}
+
+func TestSend_DefaultsToMainKeyForDefaultAgent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		DefaultID: "default-agent",
+		MainKey:   "main-session-canonical",
+		Agents: []protocol.AgentSummary{
+			{ID: "default-agent", Name: "Default"},
+			{ID: "other-agent", Name: "Other"},
+		},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "default-agent", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if fb.createKey != "main-session-canonical" {
+		t.Errorf("CreateSession key = %q, want %q (MainKey for default agent)", fb.createKey, "main-session-canonical")
+	}
+	if fb.createAgentID != "default-agent" {
+		t.Errorf("CreateSession agent = %q, want default-agent", fb.createAgentID)
+	}
+}
+
+func TestSend_DefaultsToLiteralMainForOtherAgents(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		DefaultID: "default-agent",
+		MainKey:   "main-session-canonical",
+		Agents: []protocol.AgentSummary{
+			{ID: "default-agent", Name: "Default"},
+			{ID: "other-agent", Name: "Other"},
+		},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "other-agent", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if fb.createKey != "main" {
+		t.Errorf("CreateSession key = %q, want %q (literal main for non-default agent)", fb.createKey, "main")
+	}
+}
+
+func TestSend_HonoursExplicitSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		DefaultID: "main",
+		MainKey:   "should-be-ignored",
+		Agents:    []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "main", Session: "scratch-2030", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if fb.createKey != "scratch-2030" {
+		t.Errorf("CreateSession key = %q, want %q", fb.createKey, "scratch-2030")
+	}
+}
+
+func TestSend_DetachReturnsAfterAck(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	// Crucially, do NOT push any final event — Send must not wait for one.
+
+	store, _ := makeSendStore("c")
+	done := make(chan error, 1)
+	go func() {
+		done <- Send(context.Background(), SendOptions{
+			Connection: "c", Agent: "main", Message: "kick off",
+			Detach: true, Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Send (detach): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send (detach) did not return — it appears to be waiting for a reply")
+	}
+	if fb.sentParams.Message != "kick off" {
+		t.Errorf("ChatSend message = %q, want %q", fb.sentParams.Message, "kick off")
+	}
+}
+
+func TestSend_ReturnsErrorOnChatErrorEvent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "error", nil, "model is on fire")
+	}
+
+	store, _ := makeSendStore("c")
+	err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "main", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	})
+	if err == nil || !strings.Contains(err.Error(), "model is on fire") {
+		t.Fatalf("expected chat-error to surface, got %v", err)
+	}
+}
+
+func TestSend_ReturnsErrorOnChatAborted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "aborted", nil, "")
+	}
+
+	store, _ := makeSendStore("c")
+	err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "main", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	})
+	if err == nil || !strings.Contains(err.Error(), "aborted") {
+		t.Fatalf("expected aborted error, got %v", err)
+	}
+}
+
+func TestSend_MatchesConnectionByNameCaseInsensitive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("My-Connection")
+	if err := Send(context.Background(), SendOptions{
+		Connection: "MY-CONNECTION", Agent: "primary", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func TestSend_MatchesAgentByNameCaseInsensitive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "agent-xyz", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "primary", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if fb.createAgentID != "agent-xyz" {
+		t.Errorf("CreateSession agentID = %q, want %q (resolved by name)", fb.createAgentID, "agent-xyz")
+	}
+}
+
+func TestSend_ConnectionNotFound(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, _ := makeSendStore("real")
+	err := Send(context.Background(), SendOptions{
+		Connection: "ghost", Agent: "main", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(newSendFakeBackend()), ConnectionsStore: store,
+	})
+	if err == nil || !strings.Contains(err.Error(), "connection") {
+		t.Fatalf("expected connection-not-found error, got %v", err)
+	}
+}
+
+func TestSend_AgentNotFound(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "real", Name: "Real"}},
+	}
+
+	store, _ := makeSendStore("c")
+	err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "ghost", Message: "hi",
+		Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	})
+	if err == nil || !strings.Contains(err.Error(), "agent") {
+		t.Fatalf("expected agent-not-found error, got %v", err)
+	}
+}
+
+func TestSend_MissingArgumentsRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		opts SendOptions
+		want string
+	}{
+		{"connection", SendOptions{Agent: "a", Message: "m"}, "connection"},
+		{"agent", SendOptions{Connection: "c", Message: "m"}, "agent"},
+		{"message", SendOptions{Connection: "c", Agent: "a"}, "message"},
+		{"whitespace-message", SendOptions{Connection: "c", Agent: "a", Message: "   \n"}, "message"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Send(context.Background(), tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSend_BackendErrorsBubbleUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	t.Run("connect", func(t *testing.T) {
+		fb := newSendFakeBackend()
+		fb.connectErr = errors.New("dial timeout")
+		store, _ := makeSendStore("c")
+		err := Send(context.Background(), SendOptions{
+			Connection: "c", Agent: "main", Message: "hi",
+			Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+		})
+		if err == nil || !strings.Contains(err.Error(), "dial timeout") {
+			t.Fatalf("expected connect error, got %v", err)
+		}
+		if !fb.wasClosed() {
+			t.Error("backend was not closed after Connect failed")
+		}
+	})
+
+	t.Run("list-agents", func(t *testing.T) {
+		fb := newSendFakeBackend()
+		fb.listErr = errors.New("rpc broken")
+		store, _ := makeSendStore("c")
+		err := Send(context.Background(), SendOptions{
+			Connection: "c", Agent: "main", Message: "hi",
+			Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+		})
+		if err == nil || !strings.Contains(err.Error(), "rpc broken") {
+			t.Fatalf("expected list-agents error, got %v", err)
+		}
+	})
+
+	t.Run("chat-send", func(t *testing.T) {
+		fb := newSendFakeBackend()
+		fb.listResult = &protocol.AgentsListResult{
+			Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+		}
+		fb.chatSendErr = errors.New("rate limited")
+		store, _ := makeSendStore("c")
+		err := Send(context.Background(), SendOptions{
+			Connection: "c", Agent: "main", Message: "hi",
+			Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+		})
+		if err == nil || !strings.Contains(err.Error(), "rate limited") {
+			t.Fatalf("expected chat-send error, got %v", err)
+		}
+	})
+}
+
+func TestSend_FallsBackToDeltaTextWhenFinalEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		// Stream cumulative deltas, then close with an ack-shaped final
+		// (no content) — same shape some backends emit on completion.
+		emitChatEvent(fb.events, sessionKey, runID, "delta", "Streaming", "")
+		emitChatEvent(fb.events, sessionKey, runID, "delta", "Streaming reply body", "")
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"role":    "assistant",
+			"content": []map[string]any{},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	var buf bytes.Buffer
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "main", Message: "hi",
+		Out: &buf, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := buf.String(); got != "Streaming reply body\n" {
+		t.Errorf("output = %q, want %q", got, "Streaming reply body\n")
+	}
+}
+
+func TestSend_IgnoresEventsForOtherSessions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		DefaultID: "main",
+		MainKey:   "main",
+		Agents:    []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	fb.createReturn = "session-A"
+	fb.chatSendDispatch = func(ch <-chan protocol.Event, sessionKey, runID string) {
+		// Inject a final event for a different session before the
+		// real one — Send must filter it out.
+		emitChatEvent(fb.events, "session-B", runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "wrong session"}},
+		}, "")
+		emitChatEvent(fb.events, sessionKey, runID, "final", map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "right session"}},
+		}, "")
+	}
+
+	store, _ := makeSendStore("c")
+	var buf bytes.Buffer
+	if err := Send(context.Background(), SendOptions{
+		Connection: "c", Agent: "main", Message: "hi",
+		Out: &buf, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "right session" {
+		t.Errorf("output = %q, want %q", got, "right session")
+	}
+}
+
+func TestSend_ContextCancellationReturns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fb := newSendFakeBackend()
+	fb.listResult = &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "Primary"}},
+	}
+	// chatSendDispatch never emits a final, so the only way out is ctx.
+
+	store, _ := makeSendStore("c")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Send(ctx, SendOptions{
+			Connection: "c", Agent: "main", Message: "hi",
+			Out: &bytes.Buffer{}, BackendFactory: fixedFactory(fb), ConnectionsStore: store,
+		})
+	}()
+	// Give Send a moment to reach the wait, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not return after context cancellation")
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [sessions.md](sessions.md) | Session lifecycle, session browser, compact/reset, message queueing |
 | [crons.md](crons.md) | Gateway cron browser: list/detail/form substates, capability gating, raw-patch edit semantics |
 | [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
+| [one-shot.md](one-shot.md) | One-shot CLI mode: `lucinate send` lifecycle, default session rule, detach semantics, embedding |
 | [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
 | [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -18,6 +18,8 @@ Three backend types ship today; all implement `backend.Backend` (`internal/backe
 
 `AllConnectionTypes` (`internal/config/connections.go`) drives the picker form's type radio. Adding a fourth backend means: implementing `backend.Backend`, extending the enum, dispatching in `DefaultBackendFactory` (`app/factory.go`), adjusting the form's type-conditional rendering, and writing a `backend_<name>.md` doc for it.
 
+`DefaultBackendFactory` has a second consumer: `app.Send` (`lucinate send`) calls it directly to build a backend for one-shot dispatch, so a new connection type that lands in the factory's switch is automatically reachable from the scripted CLI mode without further wiring. See [one-shot.md](one-shot.md).
+
 ## Startup decision tree
 
 `config.ResolveEntryConnection()` (`internal/config/startup.go`) decides what the TUI's entry view is:

--- a/docs/one-shot.md
+++ b/docs/one-shot.md
@@ -1,0 +1,85 @@
+# One-shot mode
+
+`lucinate send` is a non-TUI entry point that dispatches a single chat turn through a stored connection / agent / session and (by default) prints the assistant's first complete reply to stdout. It is the scripting surface alongside the interactive TUI, and it deliberately reuses the TUI's connection store, backend factory, and event channel so retry / auth / capability behaviour stays consistent across both modes.
+
+The user-facing CLI shape is documented in [README.md](../README.md#one-shot-mode). This doc covers the lifecycle, the wire-format edges, and the seams that exist for embedders.
+
+## Lifecycle
+
+`app.Send` (`app/send.go`) runs an eight-step pipeline:
+
+1. **Resolve the connection.** `LoadConnections()` from `internal/config`, then `resolveSendConnection` matches the user-supplied `--connection` first by ID and then case-insensitively by `Name`. A missing connection is a clean error — the resolver does not fall through to the entry-view decision tree (`config.ResolveEntryConnection`), which is TUI-only.
+2. **Build the backend.** `DefaultBackendFactory` (`app/factory.go`) dispatches by `Connection.Type` — same factory the TUI uses, same auth wiring (per-connection secrets store, env-var fallback for OpenAI, etc.).
+3. **Connect.** `backend.Backend.Connect`. A failure tears the backend back down before returning. There is no auth-recovery modal in this mode; an auth error surfaces as a normal error and the process exits non-zero.
+4. **Mark the connection as last-used.** Mirrors the TUI's "last used = default" pattern via `Connections.MarkUsed` + `config.SaveConnections` so the next launch (TUI or `send`) picks the same connection by default.
+5. **List agents and resolve the agent.** `ListAgents`, then `resolveSendAgent` matches first by ID and then by case-insensitive `Name`.
+6. **Default the session key.** `defaultSessionKey` mirrors the TUI's pick in `internal/tui/select.go`: `AgentsListResult.MainKey` when the chosen agent is the default agent (`agent.ID == list.DefaultID`), otherwise the literal string `"main"`. An explicit `--session` flag short-circuits this.
+7. **Create or resume the session.** `CreateSession` round-trips through the backend; the canonical key it returns is what `ChatSend` uses. OpenClaw asks the gateway; OpenAI-compat returns `agentID` (agent ≡ session); Hermes returns the synthetic agent ID.
+8. **Subscribe before send, then dispatch.** A `replyCollector` goroutine starts draining `backend.Events()` *before* `ChatSend` is called so the final event cannot race past the consumer. `ChatSend` returns its RPC ack containing the run ID; the collector is told the run ID after the ack lands so events from concurrent turns on the same session are filtered out.
+
+Detach mode skips step 8's wait: after `ChatSend` returns, `Send` returns nil regardless of subsequent events.
+
+`Send` does not run `Backend.Supervise`. A one-shot turn is short-lived enough that auto-reconnect is dead weight; a dropped socket surfaces as a clean failure ("backend event channel closed before reply") rather than triggering exponential backoff. The TUI's `app.Program` keeps Supervise — the lifetimes are different.
+
+## Default session selection
+
+The default-key rule is shared with the TUI agent picker so `lucinate send` and "select agent → main" land on the same gateway-side session:
+
+| Agent | `--session` unset → key passed to `CreateSession` |
+|-------|---------------------------------------------------|
+| Default agent (`agent.ID == list.DefaultID`) | `list.MainKey` |
+| Any other agent                              | `"main"` (literal)                                |
+
+If the same key already exists on the gateway, `CreateSession` resumes it; if not, the gateway provisions one. From the script's point of view, `lucinate send --connection X --agent Y "hello"` repeats into the same conversation forever unless `--session` is supplied.
+
+The literal-`"main"` fallback for non-default agents matches what the TUI passes when the user picks a non-default agent and accepts the picker's "main" session. Backends that don't keep server-side session state (OpenAI, Hermes) ignore the key shape and route by `agentID` regardless.
+
+## Detach semantics
+
+`--detach` returns as soon as `ChatSend` resolves its RPC ack. That guarantees:
+
+- Validation errors surface synchronously: missing flag, no such agent, no such connection, wire-level rejection (auth, idempotency conflict, malformed input).
+- The gateway has accepted the turn and assigned a run ID.
+
+It does **not** guarantee:
+
+- That the assistant will reply.
+- That a reply, if it arrives, ever reaches stdout — the run continues server-side, and the streaming events are consumed nowhere in detach mode. The reply is rendered the next time the user opens the TUI on that session, just as if a previous TUI window had been closed mid-turn.
+
+Detach is intended for cron-style automation ("nudge the agent at 09:00 to draft the morning digest, render the result on my next browse") and for fire-and-forget shell-pipeline steps that don't care about the response text.
+
+## Embedding `app.Send` from Go
+
+`SendOptions` is the embedder's seam set:
+
+```go
+err := app.Send(ctx, app.SendOptions{
+    Connection:       "my-con",
+    Agent:            "main",
+    Session:          "",       // empty → main-session default
+    Message:          "hello",
+    Detach:           false,
+    Out:              os.Stdout,
+    BackendFactory:   nil,      // nil → DefaultBackendFactory
+    ConnectionsStore: nil,      // nil → LoadConnections()
+})
+```
+
+`Out` is where the reply is written when not detached. `BackendFactory` lets tests substitute a fake backend (see `app/send_test.go` for the pattern) without going through `DefaultBackendFactory`'s auth / secrets wiring. `ConnectionsStore`, when non-nil, suppresses the implicit `SaveConnections` after `MarkUsed` so test runs don't leave a dirty `connections.json` on disk; production callers leave it nil.
+
+The function is single-shot — there is no streaming surface and no incremental callback. Embedders that need to observe deltas, tool events, or thinking blocks should drive `app.Program` directly.
+
+## Reply text extraction
+
+The shared wire-format parser lives at `internal/backend/chatevent.go`:
+
+- `backend.ExtractChatText(raw)` handles the two shapes a chat event's `Message` can take — a plain JSON string (delta) or a `{ content: [{type, text}, ...] }` object (final). Used by the TUI's chat view (`internal/tui/events.go`) and by `app/send.go`'s `replyCollector` so both paths agree on what the visible body is.
+- `backend.ExtractChatThinking(raw)` returns the concatenated `type:"thinking"` blocks from a final event. Currently only the TUI consumes this; `Send` ignores thinking blocks because the contract for `--connection X --agent Y "msg"` is "the assistant's reply on stdout", not the deliberation that led to it.
+
+If a backend ever changes the wire shape, both consumers update together — the parser is the single seam.
+
+## Non-goals
+
+- **Slash-command parsing.** A message body of `/help` is sent verbatim to the agent; the TUI's command dispatcher is intentionally not on this path. Scripts that want a command's effect should call the corresponding RPC directly rather than typing it as chat input.
+- **Skill catalog injection.** The TUI sends `Skills` in `ChatSendParams` so the gateway can advertise local skills to the model; `Send` deliberately omits it. Skills are a TUI-discovery concept (slash-command activation, mid-message expansion); revisit if scripted workflows ever want `lucinate send … "/review the diff"` to expand the same way.
+- **Auth recovery modals.** The TUI routes `token-mismatch` / `401` into modal flows; `Send` lets them bubble. Scripts that need to bootstrap auth should run `lucinate` once interactively and let the TUI's auth flow seed the secrets store.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -4,6 +4,8 @@
 
 A session is created when the user selects an agent in the agent picker (see [agents.md](agents.md)). `client.CreateSession(agentID, key)` is called and the returned `sessionKey` is passed to `newChatModel()`. The session key is deterministic for non-default agents (based on agent ID) so the same session is restored on restart.
 
+The same default-key rule is reused by the one-shot CLI mode: `app.Send` (`lucinate send`) calls `CreateSession` with `MainKey` for the default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the same conversation as "open the picker, pick the agent, hit enter". See [one-shot.md](one-shot.md) for the full lifecycle.
+
 On `chatModel.Init()`, two async commands run in parallel:
 
 - `loadHistory()` — fetches the last N messages from the gateway (`client.SessionHistory()`), strips `System:` lines (see [message-rendering.md](message-rendering.md#history-cleanup)), and populates the viewport.

--- a/internal/backend/chatevent.go
+++ b/internal/backend/chatevent.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// chatFinalContentBlock mirrors the {type, text} shape backends use for
+// the structured Content array of a final chat event. It is duplicated
+// here (rather than shared with the TUI's chatContentBlock) so the
+// helper sits at the wire boundary instead of in the rendering layer.
+type chatFinalContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// chatFinalMessage is the structured shape of a final chat event's
+// Message field: a list of typed content blocks. Delta events instead
+// send a plain JSON string.
+type chatFinalMessage struct {
+	Content []chatFinalContentBlock `json:"content"`
+}
+
+// ExtractChatText parses the Message field of a protocol.ChatEvent and
+// returns the human-readable text. Delta events are encoded as a plain
+// JSON string and are returned verbatim; final events carry a
+// structured object whose text-typed blocks are joined with newlines.
+// An empty raw payload returns "".
+//
+// The helper is shared by every code path that wants the visible body
+// of an assistant turn — the TUI's streaming chat view and the
+// one-shot CLI's Send loop both call it so the wire-format parsing
+// stays in one place.
+func ExtractChatText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var msg chatFinalMessage
+	if json.Unmarshal(raw, &msg) == nil {
+		var parts []string
+		for _, block := range msg.Content {
+			if block.Type == "text" && block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return string(raw)
+}
+
+// ExtractChatThinking returns the concatenated thinking-block text from
+// a final chat event's Message field. Delta events never carry
+// thinking blocks, so a plain-string payload returns "". An empty raw
+// payload returns "" as well.
+func ExtractChatThinking(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var msg chatFinalMessage
+	if json.Unmarshal(raw, &msg) != nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range msg.Content {
+		if block.Type == "thinking" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/backend/chatevent_test.go
+++ b/internal/backend/chatevent_test.go
@@ -1,0 +1,234 @@
+package backend
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+// TestExtractChatText pins the parser against the two wire shapes
+// chat events ship — the plain JSON string used by streaming deltas
+// and the structured {role, content[]} object emitted by final events
+// — plus the malformed/edge-case fallbacks the TUI and the one-shot
+// CLI both depend on for not crashing on a surprise payload.
+func TestExtractChatText(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{
+			name: "nil input",
+			raw:  nil,
+			want: "",
+		},
+		{
+			name: "empty slice",
+			raw:  json.RawMessage{},
+			want: "",
+		},
+		{
+			name: "delta plain string",
+			raw:  json.RawMessage(`"Hello, world!"`),
+			want: "Hello, world!",
+		},
+		{
+			name: "delta empty string",
+			raw:  json.RawMessage(`""`),
+			want: "",
+		},
+		{
+			name: "delta string with embedded JSON characters",
+			raw:  json.RawMessage(`"line one\nline two\t{not parsed}"`),
+			want: "line one\nline two\t{not parsed}",
+		},
+		{
+			name: "final single text block",
+			raw:  json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"Only paragraph."}]}`),
+			want: "Only paragraph.",
+		},
+		{
+			name: "final multiple text blocks joined by newline",
+			raw:  json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"First."},{"type":"text","text":"Second."}]}`),
+			want: "First.\nSecond.",
+		},
+		{
+			name: "final mixed blocks keeps only text type",
+			raw:  json.RawMessage(`{"role":"assistant","content":[{"type":"thinking","text":"hidden"},{"type":"tool_use","text":""},{"type":"text","text":"Visible."}]}`),
+			want: "Visible.",
+		},
+		{
+			name: "final empty content array",
+			raw:  json.RawMessage(`{"role":"assistant","content":[]}`),
+			want: "",
+		},
+		{
+			name: "final text block with empty text is skipped",
+			raw:  json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":""},{"type":"text","text":"After empty."}]}`),
+			want: "After empty.",
+		},
+		{
+			name: "final with no content key",
+			raw:  json.RawMessage(`{"role":"assistant"}`),
+			want: "",
+		},
+		{
+			name: "final preserves text containing newlines",
+			raw:  json.RawMessage(`{"content":[{"type":"text","text":"top\nbottom"}]}`),
+			want: "top\nbottom",
+		},
+		{
+			name: "json number fallback",
+			raw:  json.RawMessage(`12345`),
+			want: "12345",
+		},
+		{
+			name: "json bool fallback",
+			raw:  json.RawMessage(`true`),
+			want: "true",
+		},
+		{
+			name: "json null returns empty",
+			raw:  json.RawMessage(`null`),
+			// json.Unmarshal of `null` into chatFinalMessage succeeds
+			// with a zero-value struct, so the helper takes the
+			// structured branch and returns "" rather than the literal
+			// "null" — semantically a null payload means "no content".
+			want: "",
+		},
+		{
+			name: "malformed json fallback",
+			raw:  json.RawMessage(`{not json`),
+			want: "{not json",
+		},
+		{
+			name: "json array fallback",
+			raw:  json.RawMessage(`["a","b"]`),
+			// arrays do not match chatFinalMessage and are not strings;
+			// returned verbatim so a curious operator can still see the
+			// payload rather than getting a silent "".
+			want: `["a","b"]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractChatText(tc.raw)
+			if got != tc.want {
+				t.Errorf("ExtractChatText(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractChatThinking pins the thinking-block extractor against
+// its narrow contract: only structured final events ever carry
+// thinking blocks, so plain-string delta payloads, empty inputs, and
+// malformed JSON all return "" rather than leaking the raw text into
+// the thinking surface.
+func TestExtractChatThinking(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{
+			name: "nil input",
+			raw:  nil,
+			want: "",
+		},
+		{
+			name: "empty slice",
+			raw:  json.RawMessage{},
+			want: "",
+		},
+		{
+			name: "delta plain string ignored",
+			raw:  json.RawMessage(`"a delta string is never a thinking block"`),
+			want: "",
+		},
+		{
+			name: "single thinking block",
+			raw:  json.RawMessage(`{"content":[{"type":"thinking","text":"reasoning step"}]}`),
+			want: "reasoning step",
+		},
+		{
+			name: "multiple thinking blocks joined by newline",
+			raw:  json.RawMessage(`{"content":[{"type":"thinking","text":"step 1"},{"type":"thinking","text":"step 2"}]}`),
+			want: "step 1\nstep 2",
+		},
+		{
+			name: "mixed blocks keeps only thinking type",
+			raw:  json.RawMessage(`{"content":[{"type":"text","text":"visible"},{"type":"thinking","text":"hidden"},{"type":"tool_use","text":"tool"}]}`),
+			want: "hidden",
+		},
+		{
+			name: "no thinking blocks returns empty",
+			raw:  json.RawMessage(`{"content":[{"type":"text","text":"visible"}]}`),
+			want: "",
+		},
+		{
+			name: "thinking block with empty text skipped",
+			raw:  json.RawMessage(`{"content":[{"type":"thinking","text":""},{"type":"thinking","text":"kept"}]}`),
+			want: "kept",
+		},
+		{
+			name: "empty content array",
+			raw:  json.RawMessage(`{"content":[]}`),
+			want: "",
+		},
+		{
+			name: "json number ignored",
+			raw:  json.RawMessage(`42`),
+			want: "",
+		},
+		{
+			name: "malformed json ignored",
+			raw:  json.RawMessage(`{not json`),
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractChatThinking(tc.raw)
+			if got != tc.want {
+				t.Errorf("ExtractChatThinking(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractChatText_RoundTripsProtocolChatEvent ensures the helper
+// still works when the Message field is produced by marshalling a
+// real protocol.ChatEvent rather than hand-written JSON — guards
+// against drift if the wire format ever sprouts new fields the
+// helper should ignore.
+func TestExtractChatText_RoundTripsProtocolChatEvent(t *testing.T) {
+	finalMsg := map[string]any{
+		"role": "assistant",
+		"content": []map[string]any{
+			{"type": "text", "text": "Round-tripped."},
+		},
+	}
+	rawMsg, err := json.Marshal(finalMsg)
+	if err != nil {
+		t.Fatalf("marshal final message: %v", err)
+	}
+	ev := protocol.ChatEvent{
+		RunID:      "run-x",
+		SessionKey: "sess",
+		State:      "final",
+		Message:    rawMsg,
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal chat event: %v", err)
+	}
+	var decoded protocol.ChatEvent
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal chat event: %v", err)
+	}
+	if got := ExtractChatText(decoded.Message); got != "Round-tripped." {
+		t.Errorf("ExtractChatText after round trip = %q, want %q", got, "Round-tripped.")
+	}
+}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -6,16 +6,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/a3tai/openclaw-go/protocol"
 	tea "charm.land/bubbletea/v2"
+	"github.com/a3tai/openclaw-go/protocol"
+
+	"github.com/lucinate-ai/lucinate/internal/backend"
 )
 
-// chatFinalMessage is the structure of the "message" field in a "final" chat event.
-type chatFinalMessage struct {
-	Role    string             `json:"role"`
-	Content []chatContentBlock `json:"content"`
-}
-
+// chatContentBlock is the {type, text} shape of one entry in the
+// Content array of a chat history message. Defined here (rather than
+// in history.go) because the history fetch code is the single
+// remaining caller — chat-event message parsing now goes through
+// backend.ExtractChatText so the wire format lives in one place.
 type chatContentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
@@ -47,49 +48,13 @@ type toolResultPayload struct {
 // extractThinkingFromMessage parses the Message field and extracts thinking blocks.
 // Only final events carry structured content blocks; delta events are plain strings.
 func extractThinkingFromMessage(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var msg chatFinalMessage
-	if json.Unmarshal(raw, &msg) != nil {
-		return ""
-	}
-	var parts []string
-	for _, block := range msg.Content {
-		if block.Type == "thinking" && block.Text != "" {
-			parts = append(parts, block.Text)
-		}
-	}
-	return strings.Join(parts, "\n")
+	return backend.ExtractChatThinking(raw)
 }
 
 // extractTextFromMessage parses the Message field and extracts readable text.
 // Delta events send a plain JSON string; final events send a structured object.
 func extractTextFromMessage(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-
-	// Try as a plain JSON string first (delta events).
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s
-	}
-
-	// Try as a structured chat message (final events).
-	var msg chatFinalMessage
-	if json.Unmarshal(raw, &msg) == nil {
-		var parts []string
-		for _, block := range msg.Content {
-			if block.Type == "text" && block.Text != "" {
-				parts = append(parts, block.Text)
-			}
-		}
-		return strings.Join(parts, "\n")
-	}
-
-	// Fallback: return raw string.
-	return string(raw)
+	return backend.ExtractChatText(raw)
 }
 
 func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {

--- a/main.go
+++ b/main.go
@@ -2,19 +2,53 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/lucinate-ai/lucinate/app"
 	"github.com/lucinate-ai/lucinate/internal/version"
 )
 
+// errSendUsage is returned by runSend when the user asked for help via
+// `-h` / `--help`. Treated as a clean exit by main so the usage block
+// the flag set already printed is not followed by a redundant
+// "lucinate: flag: help requested" error line.
+var errSendUsage = errors.New("usage")
+
 func main() {
+	args := os.Args[1:]
+
+	// Subcommand dispatch. The "send" subcommand is the one-shot CLI
+	// entry that bypasses the TUI and routes a single message into a
+	// stored connection / agent / session, optionally waiting for the
+	// first complete reply. Subcommands are detected by the first
+	// non-flag argument so the legacy `lucinate -version` invocation
+	// keeps working.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		switch args[0] {
+		case "send":
+			err := runSend(args[1:])
+			if errors.Is(err, errSendUsage) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "lucinate: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		// Unknown subcommand: fall through to flag parsing so a
+		// mistyped subcommand surfaces a clear flag-package error
+		// rather than silently launching the TUI.
+	}
+
 	fs := flag.NewFlagSet("lucinate", flag.ExitOnError)
 	showVersion := fs.Bool("version", false, "print version and exit")
 	fs.BoolVar(showVersion, "v", false, "print version and exit")
-	_ = fs.Parse(os.Args[1:])
+	_ = fs.Parse(args)
 
 	if *showVersion {
 		fmt.Printf("lucinate %s\n", version.Version)
@@ -36,4 +70,55 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// runSend parses the `lucinate send` flag set and dispatches into
+// app.Send. The flag set deliberately stops at the first positional
+// argument so the message body — which may contain text that looks
+// like flags — is taken verbatim from the remaining args. Use `--`
+// before a message that starts with a dash, the standard Unix escape.
+func runSend(args []string) error {
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	var (
+		connection string
+		agent      string
+		session    string
+		detach     bool
+	)
+	fs.StringVar(&connection, "connection", "", "saved connection name or ID (required)")
+	fs.StringVar(&agent, "agent", "", "agent name or ID within the connection (required)")
+	fs.StringVar(&session, "session", "", "session key (defaults to the agent's main session)")
+	fs.BoolVar(&detach, "detach", false, "dispatch the message and exit without waiting for a reply")
+	fs.Usage = func() {
+		out := fs.Output()
+		fmt.Fprintln(out, "Usage: lucinate send --connection <name> --agent <name> [--session <key>] [--detach] <message...>")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Sends a single chat message through a stored connection and prints the")
+		fmt.Fprintln(out, "assistant's first complete reply on stdout. With --detach the call returns")
+		fmt.Fprintln(out, "as soon as the gateway has accepted the turn.")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Flags:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return errSendUsage
+		}
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) == 0 {
+		fs.Usage()
+		return errors.New("send: missing message text")
+	}
+	message := strings.Join(rest, " ")
+	return app.Send(context.Background(), app.SendOptions{
+		Connection:     connection,
+		Agent:          agent,
+		Session:        session,
+		Message:        message,
+		Detach:         detach,
+		Out:            os.Stdout,
+		BackendFactory: app.DefaultBackendFactory,
+	})
 }


### PR DESCRIPTION
This PR adds a new one-shot CLI mode that allows users to send a single message through a stored connection without launching the interactive TUI. The implementation includes a new `lucinate send` subcommand that dispatches a message to a specified agent and optionally waits for the assistant's reply.

## Key Changes

- **New `app.Send()` function**: Programmatic entry point for one-shot message dispatch. Handles connection/agent resolution, session creation, message sending, and reply collection. Supports both blocking (wait for reply) and detached (fire-and-forget) modes.

- **New `lucinate send` subcommand**: CLI interface with flags for `--connection`, `--agent`, `--session`, and `--detach`. Message text is taken from remaining positional arguments, allowing messages that contain flag-like syntax.

- **Reply collection logic**: New `replyCollector` type that consumes backend chat events and buffers the assistant's response. Falls back to delta text when final events lack structured content, handles session/run ID filtering to avoid cross-talk.

- **Chat event text extraction**: Extracted wire-format parsing into `backend.ExtractChatText()` and `backend.ExtractChatThinking()` helpers in a new `internal/backend/chatevent.go` file. These are now shared by both the TUI's streaming view and the one-shot CLI's Send loop.

- **Comprehensive test suite**: Added 615 lines of unit tests covering happy paths (waiting for final events, detached mode), error handling (connection/agent not found, backend errors), session key resolution (default vs. explicit), case-insensitive matching, and edge cases (events for other sessions, context cancellation).

- **Connection tracking**: Send marks the used connection as last-used (same as TUI behavior) and persists it to the config store for CLI consistency.

## Implementation Details

- Connection and agent resolution use ID-first matching (for script stability) followed by case-insensitive name matching (for human usability).
- Session key defaults to `AgentsListResult.MainKey` for the connection's default agent, or literal `"main"` for other agents, mirroring TUI behavior.
- Idempotency keys are generated with nanosecond precision to ensure uniqueness across rapid invocations.
- The reply collector ignores events from other sessions/runs to prevent cross-talk in concurrent scenarios.
- All backend errors (connect, list agents, chat send) bubble up cleanly with context.