### PR TITLE
feat: add 'lucinate chat' subcommand for pre-navigated TUI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,24 @@ lucinate send --connection my-con --agent main --detach "kick off the morning di
 
 For the lifecycle, the default-session rule, embedding `app.Send` from Go, and the detach contract, see [docs/one-shot.md](docs/one-shot.md).
 
+## Skip the pickers
+
+Already know which connection, agent, and session you want? `lucinate chat` drops you straight in — same TUI as the bare invocation, just pre-navigated past the pickers. Hand it a message and it's your first turn, auto-submitted once history loads.
+
+```sh
+lucinate chat --connection my-con --agent main "kick things off"
+```
+
+| Flag | Description |
+|------|-------------|
+| `--connection` | Saved connection name or ID (case-insensitive on name). Optional — defaults to the same auto-pick the bare `lucinate` uses. |
+| `--agent` | Agent name or ID to auto-select. A miss surfaces as an error on the picker rather than silently picking the wrong one. |
+| `--session` | Session key to open. Defaults to the agent's main session — same default the picker would pick. |
+
+Every flag is optional. `lucinate chat` with no flags and no message is functionally identical to bare `lucinate`. Messages that begin with a dash should be preceded by `--`, same Unix escape as `send`.
+
+Unlike `send`, this stays in the TUI — the auto-submitted message is just your opening turn, not a one-shot exit. For the override-plumbing internals, see [docs/chat-launch.md](docs/chat-launch.md).
+
 ### Command line flags
 
 | Flag | Description |

--- a/app/app.go
+++ b/app/app.go
@@ -72,6 +72,33 @@ type RunOptions struct {
 	// connections picker as the entry view.
 	Initial *config.Connection
 
+	// InitialAgent, when non-empty, instructs the TUI to auto-select
+	// the named agent (matched ID-first, then case-insensitive Name)
+	// the first time the agent picker loads its list. A miss surfaces
+	// as an error banner on the picker rather than silently falling
+	// through. Used by `lucinate chat --agent <name>` to drive past
+	// the picker without user interaction. The override is one-shot:
+	// it is consumed on the first transition that would otherwise
+	// have prompted, and cleared on auth-cancel / connect-failure /
+	// `/connections` so a subsequent connection's picker is not
+	// spuriously filtered against a name from a different scope.
+	InitialAgent string
+
+	// InitialSession, when non-empty, overrides the session key the
+	// TUI passes to CreateSession on the first agent selection — the
+	// `--session <key>` knob from `lucinate chat`. An empty value
+	// preserves the existing default ("main", or the connection's
+	// MainKey for its default agent). One-shot, cleared in the same
+	// places as InitialAgent.
+	InitialSession string
+
+	// InitialMessage, when non-empty, is queued as the first user
+	// turn in the chat view and submitted automatically once the
+	// session's history has loaded. The `lucinate chat <text>`
+	// auto-submit. Empty leaves the textarea idle. One-shot, cleared
+	// in the same places as InitialAgent.
+	InitialMessage string
+
 	// BackendFactory builds a fresh, unconnected backend.Backend for
 	// a connection. Required when Store is set.
 	BackendFactory BackendFactory
@@ -290,6 +317,9 @@ func New(opts RunOptions) (*Program, error) {
 		OnFocusedFieldChanged: opts.OnFocusedFieldChanged,
 		Store:                 opts.Store,
 		Initial:               opts.Initial,
+		InitialAgent:          opts.InitialAgent,
+		InitialSession:        opts.InitialSession,
+		InitialMessage:        opts.InitialMessage,
 		BackendFactory:        opts.BackendFactory,
 		OnConnectionsChanged:  opts.OnConnectionsChanged,
 	}

--- a/app/chat.go
+++ b/app/chat.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// ChatOptions configures a `lucinate chat` invocation.
+//
+// Chat is the programmatic entry point behind the `chat` subcommand:
+// it launches the same TUI the bare `lucinate` invocation does, but
+// with optional overrides that drive the connection / agent / session
+// pickers past themselves and (when Message is set) auto-submit a
+// first turn. Every override is optional — an unset field falls back
+// to the same default the TUI uses interactively (single-connection
+// auto-pick, single-agent auto-pick, the agent's main session).
+type ChatOptions struct {
+	// Connection identifies the saved connection to start with,
+	// matched first by ID and then case-insensitively by Name. When
+	// empty Chat falls back to ResolveEntryConnection() — env vars,
+	// stored DefaultID, single-entry auto-pick, and finally the
+	// picker. An explicit value that doesn't match any stored
+	// connection is a hard error so a typo can't silently strand
+	// the user on a stranger's default.
+	Connection string
+
+	// Agent, when non-empty, instructs the TUI's agent picker to
+	// auto-select the named agent (matched ID-first, then
+	// case-insensitive Name) the first time its list loads. A miss
+	// surfaces as an error banner on the picker rather than silently
+	// falling through to the single-agent convenience auto-pick or
+	// the first-in-list. Empty leaves the picker behaving normally.
+	Agent string
+
+	// Session, when non-empty, overrides the session key the TUI
+	// passes to the backend's CreateSession call on the first agent
+	// selection. The backend is responsible for resolving the key
+	// into a wire-level session identifier (creating a new one when
+	// necessary). Empty preserves the existing default ("main", or
+	// the connection's MainKey for its default agent).
+	Session string
+
+	// Message, when non-empty, is queued as the first user turn in
+	// the chat view and submitted automatically once the session's
+	// history has loaded. Equivalent to typing the same text into
+	// the textarea and pressing Enter — including any leading slash,
+	// which the TUI routes to a command handler. Empty leaves the
+	// textarea idle so the user lands at a fresh chat ready to type.
+	Message string
+
+	// BackendFactory builds the backend for the resolved connection.
+	// Defaults to DefaultBackendFactory so callers get the same auth
+	// resolution and per-connection secrets store the rest of the
+	// CLI uses. Tests substitute a fake here.
+	BackendFactory BackendFactory
+
+	// ConnectionsStore, when non-nil, is the connection set Chat
+	// resolves Connection against. Defaults to LoadConnections() so
+	// the CLI's standard on-disk store is used.
+	ConnectionsStore *Connections
+}
+
+// Chat is the programmatic entry point for `lucinate chat`.
+//
+// Chat is a thin pre-flight stage: it resolves Connection (or falls
+// back to ResolveEntryConnection's defaults), packs the agent /
+// session / message overrides into RunOptions, and hands off to Run.
+// The TUI consumes each override at the existing transition that
+// would otherwise have prompted, so all the auth-recovery, single-
+// connection / single-agent auto-pick, and `/connections` machinery
+// keeps working — Chat is just driving past pickers it can answer
+// for the user.
+func Chat(ctx context.Context, opts ChatOptions) error {
+	runOpts, err := resolveChatRunOptions(opts)
+	if err != nil {
+		return err
+	}
+	return Run(ctx, runOpts)
+}
+
+// resolveChatRunOptions does the resolution Chat needs without
+// actually starting the TUI, so it can be exercised in unit tests.
+// Returns RunOptions ready to pass to Run.
+func resolveChatRunOptions(opts ChatOptions) (RunOptions, error) {
+	factory := opts.BackendFactory
+	if factory == nil {
+		factory = DefaultBackendFactory
+	}
+
+	var store Connections
+	if opts.ConnectionsStore != nil {
+		store = *opts.ConnectionsStore
+	} else {
+		store = LoadConnections()
+	}
+
+	var initial *Connection
+	if strings.TrimSpace(opts.Connection) != "" {
+		conn := resolveSendConnection(&store, opts.Connection)
+		if conn == nil {
+			if len(store.Connections) == 0 {
+				return RunOptions{}, fmt.Errorf("chat: no saved connections — run `lucinate` once to create one, then retry with --connection")
+			}
+			return RunOptions{}, fmt.Errorf("chat: connection %q not found", opts.Connection)
+		}
+		initial = conn
+	} else {
+		// No explicit --connection: use the same decision tree the
+		// bare `lucinate` invocation uses. ShowPicker means we leave
+		// Initial nil and let the TUI render the connections picker.
+		entry := config.ResolveEntryConnection()
+		// Replace the local store with the (possibly auto-mutated)
+		// one ResolveEntryConnection produced — env-var auto-add
+		// needs to be visible to the TUI's picker and persistence.
+		store = entry.Store
+		if !entry.ShowPicker {
+			initial = entry.Connection
+		}
+	}
+
+	storeCopy := store
+	return RunOptions{
+		Store:          &storeCopy,
+		Initial:        initial,
+		InitialAgent:   strings.TrimSpace(opts.Agent),
+		InitialSession: strings.TrimSpace(opts.Session),
+		InitialMessage: opts.Message,
+		BackendFactory: factory,
+		OnConnectionsChanged: func(c Connections) {
+			// Best-effort persistence, mirroring main.go's bare-CLI
+			// callback. An error here is non-fatal; the user simply
+			// sees no last-used hint on the next launch.
+			_ = SaveConnections(c)
+		},
+	}, nil
+}
+

--- a/app/chat_test.go
+++ b/app/chat_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// makeStore builds a Connections store with the supplied entries and
+// no DefaultID. Tests that need a default set it after the fact.
+func makeStore(t *testing.T, conns ...config.Connection) Connections {
+	t.Helper()
+	out := Connections{Connections: conns}
+	return out
+}
+
+func TestResolveChatRunOptions_PlumbsExplicitConnection(t *testing.T) {
+	a := config.Connection{ID: "id-a", Name: "alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	b := config.Connection{ID: "id-b", Name: "beta", Type: config.ConnTypeOpenClaw, URL: "ws://b"}
+	store := makeStore(t, a, b)
+
+	opts, err := resolveChatRunOptions(ChatOptions{
+		Connection:       "alpha",
+		ConnectionsStore: &store,
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if opts.Initial == nil {
+		t.Fatal("Initial nil; want alpha")
+	}
+	if opts.Initial.ID != "id-a" {
+		t.Fatalf("Initial.ID = %q, want id-a", opts.Initial.ID)
+	}
+}
+
+func TestResolveChatRunOptions_MatchesByIDAndCaseInsensitiveName(t *testing.T) {
+	a := config.Connection{ID: "id-A", Name: "Alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	store := makeStore(t, a)
+
+	cases := []struct{ name, query string }{
+		{"by ID", "id-A"},
+		{"by lowercase name", "alpha"},
+		{"by mixed-case name", "ALPHA"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store
+			opts, err := resolveChatRunOptions(ChatOptions{
+				Connection:       tc.query,
+				ConnectionsStore: &s,
+			})
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if opts.Initial == nil || opts.Initial.ID != "id-A" {
+				t.Fatalf("Initial = %+v, want id-A", opts.Initial)
+			}
+		})
+	}
+}
+
+func TestResolveChatRunOptions_AutoPicksSingleConnectionWhenUnspecified(t *testing.T) {
+	t.Setenv("OPENCLAW_GATEWAY_URL", "")
+	t.Setenv("LUCINATE_OPENAI_BASE_URL", "")
+	t.Setenv(config.DataDirEnvVar, t.TempDir())
+
+	// ResolveEntryConnection reads from disk via LoadConnections, so
+	// seed the on-disk store explicitly.
+	a := config.Connection{ID: "id-a", Name: "alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	if err := config.SaveConnections(Connections{Connections: []config.Connection{a}}); err != nil {
+		t.Fatalf("SaveConnections: %v", err)
+	}
+
+	opts, err := resolveChatRunOptions(ChatOptions{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if opts.Initial == nil || opts.Initial.ID != "id-a" {
+		t.Fatalf("Initial = %+v, want id-a", opts.Initial)
+	}
+	if opts.Store == nil {
+		t.Fatal("Store nil; managed mode requires a store")
+	}
+}
+
+func TestResolveChatRunOptions_LeavesInitialNil_ForPickerCase(t *testing.T) {
+	t.Setenv("OPENCLAW_GATEWAY_URL", "")
+	t.Setenv("LUCINATE_OPENAI_BASE_URL", "")
+	t.Setenv(config.DataDirEnvVar, t.TempDir())
+
+	// Two connections, no DefaultID — ResolveEntryConnection returns
+	// ShowPicker and we expect Chat to leave Initial nil so the TUI
+	// renders the connections picker.
+	a := config.Connection{ID: "id-a", Name: "alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	b := config.Connection{ID: "id-b", Name: "beta", Type: config.ConnTypeOpenClaw, URL: "ws://b"}
+	if err := config.SaveConnections(Connections{Connections: []config.Connection{a, b}}); err != nil {
+		t.Fatalf("SaveConnections: %v", err)
+	}
+
+	opts, err := resolveChatRunOptions(ChatOptions{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if opts.Initial != nil {
+		t.Fatalf("Initial = %+v, want nil for picker", opts.Initial)
+	}
+	if opts.Store == nil {
+		t.Fatal("Store nil; picker requires a store")
+	}
+}
+
+func TestResolveChatRunOptions_UnknownConnectionErrors(t *testing.T) {
+	a := config.Connection{ID: "id-a", Name: "alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	store := makeStore(t, a)
+
+	_, err := resolveChatRunOptions(ChatOptions{
+		Connection:       "bogus",
+		ConnectionsStore: &store,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown connection, got nil")
+	}
+	if !strings.Contains(err.Error(), `"bogus"`) {
+		t.Fatalf("error %q should name the missing connection", err)
+	}
+}
+
+func TestResolveChatRunOptions_EmptyStoreErrorIsHelpful(t *testing.T) {
+	store := Connections{}
+	_, err := resolveChatRunOptions(ChatOptions{
+		Connection:       "anything",
+		ConnectionsStore: &store,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// First-run hint: tell the user how to populate the store.
+	if !strings.Contains(err.Error(), "no saved connections") {
+		t.Fatalf("error %q should hint at empty-store first-run", err)
+	}
+}
+
+func TestResolveChatRunOptions_PlumbsAgentSessionMessage(t *testing.T) {
+	a := config.Connection{ID: "id-a", Name: "alpha", Type: config.ConnTypeOpenClaw, URL: "ws://a"}
+	store := makeStore(t, a)
+
+	opts, err := resolveChatRunOptions(ChatOptions{
+		Connection:       "alpha",
+		Agent:            "  scout  ",
+		Session:          "  S1  ",
+		Message:          "hello",
+		ConnectionsStore: &store,
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if opts.InitialAgent != "scout" {
+		t.Fatalf("InitialAgent = %q, want %q (trimmed)", opts.InitialAgent, "scout")
+	}
+	if opts.InitialSession != "S1" {
+		t.Fatalf("InitialSession = %q, want %q (trimmed)", opts.InitialSession, "S1")
+	}
+	// Message is intentionally not trimmed — leading/trailing
+	// whitespace is part of what the user typed and the TUI's
+	// regular send path would preserve it.
+	if opts.InitialMessage != "hello" {
+		t.Fatalf("InitialMessage = %q, want %q", opts.InitialMessage, "hello")
+	}
+	if opts.BackendFactory == nil {
+		t.Fatal("BackendFactory nil; should default to DefaultBackendFactory")
+	}
+	if opts.OnConnectionsChanged == nil {
+		t.Fatal("OnConnectionsChanged nil; CLI relies on it for persistence")
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [crons.md](crons.md) | Gateway cron browser: list/detail/form substates, capability gating, raw-patch edit semantics |
 | [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
 | [one-shot.md](one-shot.md) | One-shot CLI mode: `lucinate send` lifecycle, default session rule, detach semantics, embedding |
+| [chat-launch.md](chat-launch.md) | Pre-navigated TUI launch: `lucinate chat` override plumbing, consumption points, stale-clearing rules |
 | [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
 | [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,6 +12,8 @@ Agents come from the active backend (`backend.Backend.ListAgents`). For OpenClaw
 
 If exactly one agent is returned, it is selected automatically without user interaction and a session is created immediately. The same auto-select fires after creating a new agent — the picker bypasses the list and proceeds straight to chat.
 
+`lucinate chat --agent <name>` is a third auto-pick driver: `selectModel.autoPickName` runs an ID-then-case-insensitive-name match on the first `agentsLoadedMsg` and selects the matching agent. It runs **before** the single-agent and post-create branches, so a `--agent` mismatch in a single-agent connection surfaces as an error banner on the picker rather than silently picking the only available agent. The override is one-shot: cleared on consume so a later `agentsLoadedMsg` (e.g. after a user-driven create) doesn't re-fire it. See [chat-launch.md](chat-launch.md) for the full override-consumption story.
+
 ## Selecting an agent
 
 Pressing Enter on a highlighted agent calls `client.CreateSession(agentID, key)`. On success, `sessionCreatedMsg` carries the new session key and the app transitions to the chat view (`newChatModel(...)`). See [sessions.md](sessions.md) for the session lifecycle from this point.

--- a/docs/chat-launch.md
+++ b/docs/chat-launch.md
@@ -1,0 +1,68 @@
+# Pre-navigated launch (`lucinate chat`)
+
+`lucinate chat` is a TUI entry point that accepts the same `--connection` / `--agent` / `--session` overrides as `lucinate send`, but instead of dispatching one turn and exiting it launches the regular interactive program with each override consumed at the transition that would otherwise have prompted the user. An optional positional message is auto-submitted as the first turn once the session's history loads.
+
+The user-facing CLI shape lives in [README.md](../README.md#skip-the-pickers). This doc covers the override plumbing and the seams the TUI uses to consume them safely.
+
+## Why a separate subcommand
+
+`send` is a non-TUI lifecycle (connect → resolve → ChatSend → drain → exit). `chat` is the regular TUI lifecycle with the picker steps short-circuited. Both share connection / agent resolution helpers (`resolveSendConnection`, `resolveSendAgent` in `app/send.go`) but otherwise have nothing in common — `chat` does not call `ChatSend` itself, never owns a `replyCollector`, and never needs `--detach`. Auth-recovery modals, supervisor reconnect, `/connections`, and every other TUI affordance keep working unchanged.
+
+## Lifecycle
+
+`app.Chat` (`app/chat.go`) is a thin pre-flight stage:
+
+1. **Resolve the connection.** When `--connection` is set, `resolveSendConnection` matches by ID then case-insensitive Name; a miss is a clean error that distinguishes the empty-store first-run case from a typo against a populated store. When `--connection` is unset, `config.ResolveEntryConnection()` runs — same env-var / default-id / single-entry decision tree the bare `lucinate` invocation uses, including the `ShowPicker` outcome that lands the user on the connections picker.
+2. **Pack the overrides into `RunOptions`.** `InitialAgent`, `InitialSession`, `InitialMessage` go onto `RunOptions`; the existing `Initial *config.Connection` carries the resolved connection (or nil for the picker). Agent and session strings are trimmed; the message is taken verbatim so leading whitespace inside a quoted argument is preserved.
+3. **Hand off to `Run`.** From here it's the regular TUI. The TUI consumes each override at a defined transition — the resolution logic that would otherwise have prompted runs, then the override is cleared.
+
+`Chat` does not connect, list agents, or create a session itself. It defers all three to the TUI so a typo in `--agent` lands on the existing picker (with an error banner) rather than failing before the user can recover.
+
+## Override consumption
+
+The three overrides live on `AppModel` in `internal/tui/app.go` and are consumed at three different transition points:
+
+| Override | Consumed at | Picker behaviour |
+|---|---|---|
+| `initialAgent` | `handleConnectResult` success branch — passed into `newSelectModel` as `autoPickName`. | The picker's `agentsLoadedMsg` handler (in `internal/tui/select.go`) runs ID-then-case-insensitive-name resolution **before** the existing single-agent auto-pick and post-create branches. A match sets `m.selected = true`; a miss sets `m.err = fmt.Errorf("agent %q not found", query)`. Either way the field is cleared so a second `agentsLoadedMsg` (e.g. after a user-driven agent create) doesn't re-fire. |
+| `initialSession` | `viewSelect` block of `update` — used to override `createKey` before `CreateSession` is invoked. | Beats both `"main"` and the connection's default-agent `MainKey`. Cleared on consume. |
+| `initialMessage` | `sessionCreatedMsg` handler — passed into `newChatModel` as a trailing arg, which appends it to `pendingMessages`. | The chat view's `historyLoadedMsg` handler returns `m.drainQueue()` when `pendingMessages` is non-empty and `!m.sending`, so the user turn lands *after* the history scrollback — matching what a human typing would see. |
+
+The single-agent auto-pick at `select.go` runs only when `autoPickName` was unset on entry — `--agent foo` against a single-agent connection where foo doesn't match must surface the error rather than silently picking the wrong agent. This precedence ordering is the design's load-bearing detail; `TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick` (`internal/tui/select_test.go`) guards it.
+
+## Stale-override clearing
+
+Agent IDs and session keys aren't portable across connections. If the user backs out of a connection the original invocation targeted, applying the original `--agent` against the new connection's agent list would either error spuriously or silently match the wrong agent. The `AppModel.update` method clears all three overrides at the points where the user is signalling a scope change:
+
+- **`authResolvedMsg{cancelled:true}`** — user aborted the auth modal, returns to the connections picker.
+- **`handleConnectResult` unrecoverable-error branch** — connect failed in a way that bounces back to the connections picker with an error banner.
+- **`showConnectionsMsg`** — user invoked `/connections` mid-chat to switch connection.
+
+Successful `authResolvedMsg` retries (token resolved, `cancelled` false) leave the overrides set: the user just resolved the auth they originally intended to use, so the auto-pick should still fire.
+
+`handleConnectResult` success does **not** clear the overrides — it consumes `initialAgent` (passing it into `newSelectModel`), but `initialSession` and `initialMessage` ride through to their later consumption points.
+
+## Embedding `app.Chat` from Go
+
+`ChatOptions` is the embedder seam:
+
+```go
+err := app.Chat(ctx, app.ChatOptions{
+    Connection:       "my-con",   // empty → ResolveEntryConnection
+    Agent:            "main",
+    Session:          "",          // empty → main-session default
+    Message:          "hello",
+    BackendFactory:   nil,         // nil → DefaultBackendFactory
+    ConnectionsStore: nil,         // nil → LoadConnections()
+})
+```
+
+`resolveChatRunOptions` (the unexported core that builds `RunOptions` without spinning up Bubble Tea) is what the unit tests in `app/chat_test.go` exercise; embedders that want to layer additional `RunOptions` fields (`HideInputArea`, `OnActionsChanged`, …) should call `Chat`'s peer logic themselves rather than relying on internals — those callbacks are TUI-host concerns that don't belong in `ChatOptions`.
+
+The function is a single-shot launcher. There is no resume surface and no incremental progress callback — once the TUI is running, embedders interact with it through the `app.Program` API the bare invocation uses.
+
+## Non-goals
+
+- **Pre-flight agent / session validation.** The TUI is the validator. A typo in `--agent` lands on the picker with an error banner; a typo in `--session` reaches the backend's `CreateSession`, which decides whether to create-or-resume. Surfacing those errors before the TUI starts would mean a Connect + ListAgents round-trip from `Chat` itself, duplicating the picker's existing error path.
+- **Multi-turn pre-seeding.** `--message` is a single first-turn override, not a script. Chains of turns belong on the TUI side (the user types follow-ups) or the `send` side (one turn per invocation, optionally `--detach`'d).
+- **Slash-command parsing.** The auto-submit drains through `drainQueue`, not the textarea's Enter handler — `drainQueue` recognises `!` and `!!` exec prefixes and does skill-reference expansion, but it does **not** dispatch slash commands. A message of `/sessions` is sent to the agent as the literal string `/sessions`, not routed to the sessions browser. Scripted workflows that want slash-command effects should call the corresponding RPC directly, same advice as `send`.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -18,7 +18,7 @@ Three backend types ship today; all implement `backend.Backend` (`internal/backe
 
 `AllConnectionTypes` (`internal/config/connections.go`) drives the picker form's type radio. Adding a fourth backend means: implementing `backend.Backend`, extending the enum, dispatching in `DefaultBackendFactory` (`app/factory.go`), adjusting the form's type-conditional rendering, and writing a `backend_<name>.md` doc for it.
 
-`DefaultBackendFactory` has a second consumer: `app.Send` (`lucinate send`) calls it directly to build a backend for one-shot dispatch, so a new connection type that lands in the factory's switch is automatically reachable from the scripted CLI mode without further wiring. See [one-shot.md](one-shot.md).
+`DefaultBackendFactory` has two non-TUI consumers. `app.Send` (`lucinate send`) calls it directly to build a backend for one-shot dispatch — a new connection type that lands in the factory's switch is automatically reachable from the scripted CLI mode without further wiring (see [one-shot.md](one-shot.md)). `app.Chat` (`lucinate chat`) defers all connect / list / create work to the TUI and just packs `Connection` / `Agent` / `Session` / `Message` overrides into `RunOptions`, so a new connection type is reachable there as soon as it works in the regular TUI (see [chat-launch.md](chat-launch.md)).
 
 ## Startup decision tree
 
@@ -31,6 +31,8 @@ Three backend types ship today; all implement `backend.Backend` (`internal/backe
 5. Else → open the connections picker.
 
 Auto-add (steps 1–2) mutates the in-memory store but does **not** persist it until a successful connect, so a typo in the env URL doesn't accumulate ghost entries.
+
+`lucinate chat --connection <name>` short-circuits this tree: the named connection is resolved against the store directly (ID-then-case-insensitive-name) and a miss is a hard error rather than falling through to the env-var / default-id path. With `--connection` unset, `chat` runs the same `ResolveEntryConnection` the bare invocation does. See [chat-launch.md](chat-launch.md) for the override plumbing.
 
 ## Connection lifecycle
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -6,6 +6,8 @@ A session is created when the user selects an agent in the agent picker (see [ag
 
 The same default-key rule is reused by the one-shot CLI mode: `app.Send` (`lucinate send`) calls `CreateSession` with `MainKey` for the default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the same conversation as "open the picker, pick the agent, hit enter". See [one-shot.md](one-shot.md) for the full lifecycle.
 
+`lucinate chat --session <key>` overrides this default at the picker's `CreateSession` site: `AppModel.initialSession` is consumed in the `viewSelect` block of `update`, beating both the literal `"main"` and `MainKey`. The override is one-shot — cleared once consumed so a follow-up agent pick on the same picker doesn't keep landing on the original key. See [chat-launch.md](chat-launch.md).
+
 On `chatModel.Init()`, two async commands run in parallel:
 
 - `loadHistory()` — fetches the last N messages from the gateway (`client.SessionHistory()`), strips `System:` lines (see [message-rendering.md](message-rendering.md#history-cleanup)), and populates the viewport.
@@ -40,3 +42,5 @@ After each response (`drainQueue()` in `chat.go`):
 2. History is refreshed once the queue is fully drained.
 
 Local (`!`) and remote (`!!`) exec results also trigger queue draining. See [shell-execution.md](shell-execution.md) for the exec flow.
+
+`lucinate chat <message>` pre-seeds the same queue: `newChatModel` appends the supplied text to `pendingMessages` at construction time, and the `historyLoadedMsg` handler returns `m.drainQueue()` once the scrollback has rendered — so the user turn appears *after* the loaded history, matching what a human typing the same message would see. See [chat-launch.md](chat-launch.md).

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -106,10 +106,10 @@ func TestConfigModel_Actions(t *testing.T) {
 // don't make the test brittle.
 func TestHideActionHints_Suppresses(t *testing.T) {
 	t.Run("select", func(t *testing.T) {
-		shown := newSelectModel(nil, false, false, nil, false)
+		shown := newSelectModel(nil, false, false, nil, false, "")
 		shown.loading = false
 		shown.allowAgentManagement = true
-		hidden := newSelectModel(nil, true, false, nil, false)
+		hidden := newSelectModel(nil, true, false, nil, false, "")
 		hidden.loading = false
 		hidden.allowAgentManagement = true
 		if !strings.Contains(shown.View(), "n: new agent") {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -52,6 +52,17 @@ type AppOptions struct {
 	// managed mode. A nil Initial drops the user into the picker.
 	Initial *config.Connection
 
+	// InitialAgent / InitialSession / InitialMessage are the
+	// pre-resolution overrides used by `lucinate chat`. See
+	// app.RunOptions for the full rationale; this is the unexported
+	// plumbing. Each is consumed once at the transition that would
+	// otherwise have prompted the user, and the AppModel clears them
+	// on auth-cancel / connect-failure / `/connections` so a different
+	// connection's picker doesn't inherit the original intent.
+	InitialAgent   string
+	InitialSession string
+	InitialMessage string
+
 	// BackendFactory is required in managed mode; it constructs an
 	// unconnected backend for a chosen connection.
 	BackendFactory BackendFactory
@@ -129,6 +140,15 @@ type AppModel struct {
 	updateAvailable bool
 	updateLatest    string
 	updateURL       string
+
+	// One-shot overrides supplied by `lucinate chat`. Consumed at
+	// the first transition that would otherwise have prompted the
+	// user, and cleared on auth-cancel / unrecoverable connect
+	// failure / `/connections` so they don't follow the user across
+	// connection scopes.
+	initialAgent   string
+	initialSession string
+	initialMessage string
 }
 
 // NewApp creates the root application model.
@@ -155,6 +175,9 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		onInputFocusChanged:   opts.OnInputFocusChanged,
 		onActionsChanged:      opts.OnActionsChanged,
 		onFocusedFieldChanged: opts.OnFocusedFieldChanged,
+		initialAgent:          opts.InitialAgent,
+		initialSession:        opts.InitialSession,
+		initialMessage:        opts.InitialMessage,
 	}
 
 	switch {
@@ -162,7 +185,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		// Legacy: jump straight into the agent picker. No active
 		// connection — embedders manage that elsewhere.
 		m.state = viewSelect
-		m.selectModel = newSelectModel(b, opts.HideActionHints, managed, nil, opts.DisableExitKeys)
+		m.selectModel = newSelectModel(b, opts.HideActionHints, managed, nil, opts.DisableExitKeys, "")
 	case opts.Initial != nil:
 		// Managed with an initial pick: try to connect first, surface
 		// errors / auth modals from there.
@@ -494,6 +517,13 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		}
 		m.backend = nil
 		m.activeConn = nil
+		// Clear any one-shot `lucinate chat` overrides — agent IDs
+		// are not portable across connections, and a reconnect via
+		// /connections is exactly the cue that the user has changed
+		// their mind about scope.
+		m.initialAgent = ""
+		m.initialSession = ""
+		m.initialMessage = ""
 		m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 		m.connectionsModel.setSize(m.width, m.height)
 		m.state = viewConnections
@@ -511,6 +541,12 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case authResolvedMsg:
 		if msg.cancelled {
 			// User backed out of the auth modal — return to the picker.
+			// Clear `lucinate chat` overrides: the user just signalled
+			// they don't want this connection, and a different one
+			// won't share the same agent / session keys.
+			m.initialAgent = ""
+			m.initialSession = ""
+			m.initialMessage = ""
 			m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 			m.connectionsModel.setSize(m.width, m.height)
 			m.state = viewConnections
@@ -520,7 +556,9 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			return m, m.connectionsModel.Init()
 		}
 		// Retry connect with the same backend (token has been
-		// stored/cleared as appropriate by the modal).
+		// stored/cleared as appropriate by the modal). Overrides
+		// stay set: a successful retry should still drive the
+		// auto-pick the original invocation requested.
 		return m, m.retryConnect(msg.connection, msg.backend)
 
 	case connectionsChangedMsg:
@@ -574,7 +612,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		if agentID == "" {
 			agentID = m.sessionsModel.agentID
 		}
-		m.chatModel = newChatModel(m.backend, msg.sessionKey, agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn))
+		m.chatModel = newChatModel(m.backend, msg.sessionKey, agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), "")
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -585,7 +623,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.sessionsModel.loading = false
 			return m, nil
 		}
-		m.chatModel = newChatModel(m.backend, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn))
+		m.chatModel = newChatModel(m.backend, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), "")
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -600,7 +638,14 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.state = viewSelect
 			return m, nil
 		}
-		m.chatModel = newChatModel(m.backend, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn))
+		// This is the path the `lucinate chat` auto-pick lands on
+		// (selectModel sets selected=true → viewSelect block fires
+		// CreateSession → sessionCreatedMsg). Consume the one-shot
+		// initial message here so the chat view drains it after
+		// loading history.
+		initialMsg := m.initialMessage
+		m.initialMessage = ""
+		m.chatModel = newChatModel(m.backend, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), initialMsg)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
 		return m, m.chatModel.Init()
@@ -664,6 +709,15 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 				createKey := "main"
 				if item.sessionKey == m.selectModel.mainKey {
 					createKey = item.sessionKey
+				}
+				// Honour an explicit `lucinate chat --session <key>`
+				// override; this beats both the literal "main" and
+				// the connection's default-agent MainKey. One-shot:
+				// cleared so a later selection on the same picker
+				// doesn't keep landing on the original key.
+				if m.initialSession != "" {
+					createKey = m.initialSession
+					m.initialSession = ""
 				}
 				timeout := m.requestTimeoutFromPrefs()
 				return m, func() tea.Msg {
@@ -839,7 +893,13 @@ func (m AppModel) handleConnectResult(msg connectResultMsg) (AppModel, tea.Cmd) 
 			b := msg.backend
 			go cb(b) // blocking send; do off the event loop
 		}
-		m.selectModel = newSelectModel(msg.backend, m.hideActionHints, m.managed, m.activeConn, m.disableExitKeys)
+		// Consume the one-shot --agent override here: the picker will
+		// resolve it on its first agentsLoadedMsg. Cleared so a later
+		// reconnect (auth retry, /connections, etc.) doesn't re-apply
+		// it against an unrelated connection's agent list.
+		autoPick := m.initialAgent
+		m.initialAgent = ""
+		m.selectModel = newSelectModel(msg.backend, m.hideActionHints, m.managed, m.activeConn, m.disableExitKeys, autoPick)
 		m.selectModel.setSize(m.width, m.height)
 		m.state = viewSelect
 		var cmd tea.Cmd = m.selectModel.Init()
@@ -861,6 +921,11 @@ func (m AppModel) handleConnectResult(msg connectResultMsg) (AppModel, tea.Cmd) 
 	}
 
 	// Unrecoverable: bounce back to the picker with the error.
+	// Clear `lucinate chat` overrides — a different connection
+	// from the picker won't share agent / session scope.
+	m.initialAgent = ""
+	m.initialSession = ""
+	m.initialMessage = ""
 	m.connectionsModel = newConnectionsModel(m.store, m.hideActionHints, m.disableExitKeys)
 	m.connectionsModel.setSize(m.width, m.height)
 	if msg.err != nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -323,7 +323,7 @@ func TestAppModel_CreateSessionHonoursRequestTimeout(t *testing.T) {
 		backend: fake,
 		prefs:   config.Preferences{ConnectTimeoutSeconds: 1},
 	}
-	m.selectModel = newSelectModel(fake, true, false, nil, false)
+	m.selectModel = newSelectModel(fake, true, false, nil, false, "")
 	m.selectModel.list.SetItems([]list.Item{
 		agentItem{agent: protocol.AgentSummary{ID: "demo", Name: "demo"}, sessionKey: "demo"},
 	})

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -221,7 +221,7 @@ func (m *chatModel) ensureSpinnerTicking() tea.Cmd {
 	return spinnerTickCmd()
 }
 
-func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID string, prefs config.Preferences, hideInput bool, connName string) chatModel {
+func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID string, prefs config.Preferences, hideInput bool, connName, initialMessage string) chatModel {
 	ta := textarea.New()
 	ta.Placeholder = "Type a message..."
 	ta.Focus()
@@ -240,6 +240,14 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		glamour.WithWordWrap(80), // updated by setSize() when terminal dimensions are known
 	)
 
+	// initialMessage seeds pendingMessages so the first historyLoadedMsg
+	// drains it through the same queue the textarea uses, matching what
+	// a human typing would see (history scrollback, then their message).
+	var pending []string
+	if initialMessage != "" {
+		pending = []string{initialMessage}
+	}
+
 	return chatModel{
 		viewport:        vp,
 		textarea:        ta,
@@ -255,6 +263,7 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		historyLoading:  true,
 		hideInput:       hideInput,
 		terminalFocused: true,
+		pendingMessages: pending,
 	}
 }
 
@@ -413,6 +422,14 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			m.messages = append(hist, m.messages...)
 		}
 		m.updateViewport()
+		// If a caller pre-seeded pendingMessages (e.g. `lucinate chat`
+		// passing an auto-submit message), drain it now so the user
+		// turn is appended *after* the history scrollback — matching
+		// what they'd see typing it themselves.
+		if len(m.pendingMessages) > 0 && !m.sending {
+			m.sending = true
+			return m, m.drainQueue()
+		}
 		return m, nil
 
 	case agentSwitchFailedMsg:

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -8,6 +8,8 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
 )
 
 // newContextUsageTestModel builds a chatModel wired to fakeBackend with
@@ -218,3 +220,76 @@ func drainBatch(t *testing.T, cmd tea.Cmd) {
 	}
 }
 
+
+// TestChatModel_PreloadedPendingMessage_DrainsOnHistoryLoaded verifies
+// the `lucinate chat <message>` auto-submit path: a chatModel
+// constructed with an initialMessage queues it so the first
+// historyLoadedMsg drains it through drainQueue, surfacing the user
+// turn and a streaming assistant placeholder in the visible message
+// list. The pre-history-load delay matches what a human typing would
+// see (history scrollback first, then their message).
+func TestChatModel_PreloadedPendingMessage_DrainsOnHistoryLoaded(t *testing.T) {
+	fb := newFakeBackend()
+	m := newChatModel(fb, "session-key", "agent-id", "test", "", config.DefaultPreferences(), false, "", "hello")
+
+	if len(m.pendingMessages) != 1 || m.pendingMessages[0] != "hello" {
+		t.Fatalf("constructor should have queued initialMessage; pendingMessages=%v", m.pendingMessages)
+	}
+	if m.sending {
+		t.Fatal("should not be sending until history loads")
+	}
+	if len(m.messages) != 0 {
+		t.Fatalf("messages should be empty pre-history-load; got %d", len(m.messages))
+	}
+
+	var cmd tea.Cmd
+	m, cmd = m.Update(historyLoadedMsg{messages: nil, err: nil})
+
+	if cmd == nil {
+		t.Fatal("expected drainQueue cmd after history load with a queued message")
+	}
+	if !m.sending {
+		t.Error("sending must be true after drain so subsequent enters queue rather than fire")
+	}
+	if len(m.pendingMessages) != 0 {
+		t.Errorf("pendingMessages should be drained; got %v", m.pendingMessages)
+	}
+	// drainQueue appends the user turn and a streaming assistant
+	// placeholder. The exact role sequence is what the visible chat
+	// will render.
+	if len(m.messages) != 2 {
+		t.Fatalf("expected 2 messages (user + streaming assistant), got %d: %+v", len(m.messages), m.messages)
+	}
+	if m.messages[0].role != "user" || m.messages[0].content != "hello" {
+		t.Errorf("messages[0] = %+v, want user/hello", m.messages[0])
+	}
+	if m.messages[1].role != "assistant" || !m.messages[1].streaming {
+		t.Errorf("messages[1] = %+v, want streaming assistant placeholder", m.messages[1])
+	}
+}
+
+// TestChatModel_NoInitialMessage_NoDrain verifies the regression
+// case: without a preloaded message, a historyLoadedMsg must not
+// kick a stray drain (which would surface as a confused user turn
+// with no actual content to send).
+func TestChatModel_NoInitialMessage_NoDrain(t *testing.T) {
+	fb := newFakeBackend()
+	m := newChatModel(fb, "session-key", "agent-id", "test", "", config.DefaultPreferences(), false, "", "")
+
+	if len(m.pendingMessages) != 0 {
+		t.Fatalf("no initialMessage must mean empty pendingMessages; got %v", m.pendingMessages)
+	}
+
+	var cmd tea.Cmd
+	m, cmd = m.Update(historyLoadedMsg{messages: nil, err: nil})
+
+	if cmd != nil {
+		t.Errorf("no drain expected when pendingMessages empty; got cmd=%v", cmd)
+	}
+	if m.sending {
+		t.Error("sending must remain false")
+	}
+	if len(m.messages) != 0 {
+		t.Errorf("messages should remain empty; got %+v", m.messages)
+	}
+}

--- a/internal/tui/connbanner_test.go
+++ b/internal/tui/connbanner_test.go
@@ -35,7 +35,7 @@ func TestRenderConnectionBanner(t *testing.T) {
 
 func TestSelectModel_RendersConnectionBanner(t *testing.T) {
 	conn := &config.Connection{Name: "home", Type: config.ConnTypeOpenClaw}
-	m := newSelectModel(newFakeBackend(), false, false, conn, false)
+	m := newSelectModel(newFakeBackend(), false, false, conn, false, "")
 	m.setSize(120, 40)
 	// Move out of the loading state so View() renders the list +
 	// banner rather than the loading placeholder.

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewChatModel_DeleteWordBackwardBinding(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 
 	// ctrl+w should match DeleteWordBackward.
 	ctrlW := tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl}
@@ -34,7 +34,7 @@ func TestNewChatModel_DeleteWordBackwardBinding(t *testing.T) {
 }
 
 func TestNewChatModel_InsertNewlineBinding(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 
 	// Plain enter should NOT match InsertNewline.
 	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
@@ -50,7 +50,7 @@ func TestNewChatModel_InsertNewlineBinding(t *testing.T) {
 }
 
 func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -71,7 +71,7 @@ func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
 }
 
 func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -85,7 +85,7 @@ func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
 }
 
 func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -104,7 +104,7 @@ func TestUpKey_NonEmptyInputDoesNotRecall(t *testing.T) {
 }
 
 func TestUpKey_RecallingOnlyMessageEmptiesQueue(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -122,7 +122,7 @@ func TestUpKey_RecallingOnlyMessageEmptiesQueue(t *testing.T) {
 }
 
 func TestUpKey_SuccessiveRecallsPopInLIFOOrder(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -154,7 +154,7 @@ func TestUpKey_SuccessiveRecallsPopInLIFOOrder(t *testing.T) {
 }
 
 func TestUpKey_RecallThenClearDiscardsMessage(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -173,7 +173,7 @@ func TestUpKey_RecallThenClearDiscardsMessage(t *testing.T) {
 }
 
 func TestUpKey_RecallEditAndRequeueWhileSending(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30
@@ -201,7 +201,7 @@ func TestUpKey_RecallEditAndRequeueWhileSending(t *testing.T) {
 }
 
 func TestView_HelpShowsUpHintWhenQueued(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.setSize(80, 30)
 	m.pendingMessages = []string{"one", "two"}

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -329,7 +329,7 @@ func TestUpdateViewport_PreservesScrollWhenUserScrolledUp(t *testing.T) {
 }
 
 func TestUpdate_MouseWheelScrollSurvivesStreamingDeltas(t *testing.T) {
-	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "")
 	m.viewport = viewport.New()
 	m.width = 80
 	m.height = 30

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -74,7 +74,7 @@ func (a selectModelAdapter) View() tea.View {
 // rendering tests, wrapped in an adapter.
 func newRenderingChatModel(t *testing.T, agentName string) chatModelAdapter {
 	t.Helper()
-	m := newChatModel(nil, "session-key", "", agentName, "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "session-key", "", agentName, "", config.DefaultPreferences(), false, "", "")
 	m.setSize(120, 40)
 	return chatModelAdapter{inner: m}
 }
@@ -135,7 +135,7 @@ func TestRender_ChatView_HeaderShowsAgentName(t *testing.T) {
 // "lucinate · <conn> — <agent>" shape that lets users tell which
 // connection they're chatting against.
 func TestRender_ChatView_HeaderShowsConnectionName(t *testing.T) {
-	m := newChatModel(nil, "session-key", "", "scout", "", config.DefaultPreferences(), false, "ollama-local")
+	m := newChatModel(nil, "session-key", "", "scout", "", config.DefaultPreferences(), false, "ollama-local", "")
 	m.setSize(120, 40)
 	adapter := chatModelAdapter{inner: m}
 
@@ -149,7 +149,7 @@ func TestRender_ChatView_HeaderShowsConnectionName(t *testing.T) {
 // embedders without a connection store still render a clean header
 // — no leading separator, no empty " · " fragment.
 func TestChatModel_HeaderOmitsConnectionWhenBlank(t *testing.T) {
-	m := newChatModel(nil, "session-key", "", "scout", "", config.DefaultPreferences(), false, "")
+	m := newChatModel(nil, "session-key", "", "scout", "", config.DefaultPreferences(), false, "", "")
 	m.setSize(120, 40)
 	out := ansi.Strip(m.View())
 	if strings.Contains(out, " · ") && !strings.Contains(out, "scout · ") {
@@ -339,7 +339,7 @@ func TestRender_ChatView_RemoteExecModeHelpText(t *testing.T) {
 // tests assert against).
 func newLoadedSelectAdapter(t *testing.T, agents ...protocol.AgentSummary) selectModelAdapter {
 	t.Helper()
-	m := newSelectModel(newFakeBackend(), false, false, nil, false)
+	m := newSelectModel(newFakeBackend(), false, false, nil, false, "")
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -376,7 +376,7 @@ func TestRender_SelectView_ShowsCreateHint(t *testing.T) {
 }
 
 func TestRender_SelectView_LoadingState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.setSize(120, 40)
 	adapter := selectModelAdapter{inner: m}
 
@@ -406,7 +406,7 @@ func TestRender_SelectView_CreateFormLabels(t *testing.T) {
 func TestRender_SelectView_CreateFormHidesWorkspaceForLocalBackend(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentWorkspace = false
-	m := newSelectModel(fb, false, false, nil, false)
+	m := newSelectModel(fb, false, false, nil, false, "")
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -435,7 +435,7 @@ func TestRender_SelectView_CreateFormHidesWorkspaceForLocalBackend(t *testing.T)
 func TestSelectModel_LocalBackendCreateFormShape(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentWorkspace = false
-	m := newSelectModel(fb, true, false, nil, false)
+	m := newSelectModel(fb, true, false, nil, false, "")
 	m.initCreateForm()
 	out := m.viewCreateForm()
 	if strings.Contains(out, "Workspace:") {
@@ -453,7 +453,7 @@ func TestSelectModel_LocalBackendCreateFormShape(t *testing.T) {
 }
 
 func TestRender_SelectView_ErrorStateShowsRetryHint(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.setSize(120, 40)
 	m, _ = m.Update(agentsLoadedMsg{err: errString("gateway unreachable")})
 	adapter := selectModelAdapter{inner: m}

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -105,6 +105,15 @@ type selectModel struct {
 	// nil for legacy embedders without a connections store.
 	activeConn *config.Connection
 
+	// autoPickName, when non-empty on the first agentsLoadedMsg,
+	// resolves to an agent (ID first, then case-insensitive Name)
+	// and selects it without user interaction — the mechanism the
+	// `lucinate chat --agent <name>` subcommand uses to drive the
+	// picker past itself. A miss surfaces as a normal err banner so
+	// the user lands on the picker with the reason. Cleared after
+	// the first attempt regardless of outcome.
+	autoPickName string
+
 	// Create-agent form state.
 	subState        selectSubState
 	nameInput       textinput.Model
@@ -152,7 +161,7 @@ type agentDeletedMsg struct {
 // here so the picker doesn't have to keep asking. activeConn (when
 // non-nil) is rendered as a thin status row at the top of the view
 // so the user can see which connection is in scope.
-func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeConn *config.Connection, disableExitKeys bool) selectModel {
+func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeConn *config.Connection, disableExitKeys bool, autoPickName string) selectModel {
 	useWorkspace := false
 	allowAgentMgmt := false
 	if b != nil {
@@ -185,6 +194,7 @@ func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeCo
 		useWorkspace:         useWorkspace,
 		allowAgentManagement: allowAgentMgmt,
 		activeConn:           activeConn,
+		autoPickName:         autoPickName,
 	}
 }
 
@@ -346,6 +356,41 @@ func (m selectModel) Update(msg tea.Msg) (selectModel, tea.Cmd) {
 			items[i] = agentItem{agent: a, sessionKey: sessionKey}
 		}
 		m.list.SetItems(items)
+
+		// Honour an external auto-pick request (e.g. `lucinate chat
+		// --agent foo`) before the convenience auto-pick of a
+		// single-agent list and before the post-create branch — a
+		// caller-supplied name must beat both, so a `--agent`
+		// mismatch surfaces as an error rather than silently
+		// picking the only available agent.
+		if m.autoPickName != "" {
+			query := m.autoPickName
+			m.autoPickName = ""
+			matched := false
+			for i, a := range msg.result.Agents {
+				if a.ID == query {
+					m.list.Select(i)
+					m.selected = true
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				lc := strings.ToLower(query)
+				for i, a := range msg.result.Agents {
+					if strings.ToLower(a.Name) == lc {
+						m.list.Select(i)
+						m.selected = true
+						matched = true
+						break
+					}
+				}
+			}
+			if !matched {
+				m.err = fmt.Errorf("agent %q not found", query)
+			}
+			return m, nil
+		}
 
 		// If we just created an agent, auto-select it.
 		if m.newAgentID != "" {

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -31,7 +31,7 @@ func loadAgents(m selectModel, agents ...protocol.AgentSummary) selectModel {
 }
 
 func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -61,7 +61,7 @@ func TestSelectModel_AutoSelectSingleAgent(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 
 	msg := agentsLoadedMsg{
 		result: &protocol.AgentsListResult{
@@ -82,7 +82,7 @@ func TestSelectModel_NoAutoSelectMultipleAgents(t *testing.T) {
 }
 
 func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 
 	msg := agentsLoadedMsg{
 		err: fmt.Errorf("connection failed"),
@@ -99,7 +99,7 @@ func TestSelectModel_NoAutoSelectOnError(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormActivation(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	// Simulate agents loaded so the list is ready.
 	m.loading = false
 	m.allowAgentManagement = true
@@ -112,7 +112,7 @@ func TestSelectModel_CreateFormActivation(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormCancel(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.loading = false
 	m.allowAgentManagement = true
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
@@ -128,7 +128,7 @@ func TestSelectModel_CreateFormCancel(t *testing.T) {
 }
 
 func TestSelectModel_CreateFormNotActivatedWhileLoading(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	// loading is true by default
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
@@ -181,7 +181,7 @@ func TestValidateName(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -204,7 +204,7 @@ func TestSelectModel_WorkspaceAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.loading = false
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n'})
 
@@ -223,7 +223,7 @@ func TestSelectModel_WorkspaceManualEditStopsAutoSuggest(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -246,7 +246,7 @@ func TestSelectModel_AgentCreatedSuccess(t *testing.T) {
 }
 
 func TestSelectModel_AgentCreatedError(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.subState = subStateCreate
 	m.creating = true
 
@@ -266,7 +266,7 @@ func TestSelectModel_AgentCreatedError(t *testing.T) {
 }
 
 func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.newAgentID = "new-agent"
 
 	m, _ = m.Update(agentsLoadedMsg{
@@ -296,14 +296,14 @@ func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
 }
 
 func TestSelectModel_ConnectionsActionOnlyInManagedMode(t *testing.T) {
-	legacy := newSelectModel(nil, false, false, nil, false)
+	legacy := newSelectModel(nil, false, false, nil, false, "")
 	for _, a := range legacy.Actions() {
 		if a.ID == "connections" {
 			t.Errorf("legacy mode should not expose connections action, got %+v", legacy.Actions())
 		}
 	}
 
-	managed := newSelectModel(nil, false, true, nil, false)
+	managed := newSelectModel(nil, false, true, nil, false, "")
 	// Loaded state — no error — so the new-agent action is also
 	// present. Find the connections action.
 	var found *Action
@@ -333,7 +333,7 @@ func hasAction(m selectModel, id string) bool {
 }
 
 func TestSelectModel_DeleteActionAppearsWhenManagementEnabled(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 
@@ -343,7 +343,7 @@ func TestSelectModel_DeleteActionAppearsWhenManagementEnabled(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenManagementDisabled(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	// allowAgentManagement remains false (Hermes-style)
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 
@@ -353,7 +353,7 @@ func TestSelectModel_DeleteActionHiddenWhenManagementDisabled(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenLoading(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	// loading=true is the initial state — list never received a load msg.
 
@@ -363,7 +363,7 @@ func TestSelectModel_DeleteActionHiddenWhenLoading(t *testing.T) {
 }
 
 func TestSelectModel_DeleteActionHiddenWhenEmptyList(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m) // no agents
 
@@ -373,7 +373,7 @@ func TestSelectModel_DeleteActionHiddenWhenEmptyList(t *testing.T) {
 }
 
 func TestSelectModel_TriggerDeleteEntersConfirmSubstate(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha Agent"})
 
@@ -397,7 +397,7 @@ func TestSelectModel_TriggerDeleteEntersConfirmSubstate(t *testing.T) {
 }
 
 func TestSelectModel_TriggerDeleteUsesIDWhenNameEmpty(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "id-only"})
 
@@ -408,7 +408,7 @@ func TestSelectModel_TriggerDeleteUsesIDWhenNameEmpty(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteRequiresNameMatch(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -429,7 +429,7 @@ func TestSelectModel_ConfirmDeleteRequiresNameMatch(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteCaseInsensitive(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "My Agent"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -446,7 +446,7 @@ func TestSelectModel_ConfirmDeleteCaseInsensitive(t *testing.T) {
 }
 
 func TestSelectModel_ConfirmDeleteEscClearsState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -463,7 +463,7 @@ func TestSelectModel_ConfirmDeleteEscClearsState(t *testing.T) {
 }
 
 func TestSelectModel_ToggleKeepFilesFlipsState(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -530,7 +530,7 @@ func TestSelectModel_FilesModeHighlightMatchesDescription(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newSelectModel(nil, false, false, nil, false)
+			m := newSelectModel(nil, false, false, nil, false, "")
 			m.allowAgentManagement = true
 			m.useWorkspace = true // exercise the gateway-workspace copy path
 			m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
@@ -556,7 +556,7 @@ func TestSelectModel_FilesModeHighlightMatchesDescription(t *testing.T) {
 }
 
 func TestSelectModel_ToggleKeepFilesViaTabKey(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.allowAgentManagement = true
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
@@ -570,7 +570,7 @@ func TestSelectModel_ToggleKeepFilesViaTabKey(t *testing.T) {
 func TestSelectModel_DeleteCmdPassesKeepFilesChoice(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentManagement = true
-	m := newSelectModel(fb, false, false, nil, false)
+	m := newSelectModel(fb, false, false, nil, false, "")
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
 	m.confirmInput.SetValue("Alpha")
@@ -603,7 +603,7 @@ func TestSelectModel_DeleteCmdPassesKeepFilesChoice(t *testing.T) {
 func TestSelectModel_ConfirmDeleteIgnoredWithoutMatch(t *testing.T) {
 	fb := newFakeBackend()
 	fb.caps.AgentManagement = true
-	m := newSelectModel(fb, false, false, nil, false)
+	m := newSelectModel(fb, false, false, nil, false, "")
 	m = loadAgents(m, protocol.AgentSummary{ID: "alpha", Name: "Alpha"})
 	m, _ = m.TriggerAction("delete-agent")
 	m.confirmInput.SetValue("nope")
@@ -618,7 +618,7 @@ func TestSelectModel_ConfirmDeleteIgnoredWithoutMatch(t *testing.T) {
 }
 
 func TestSelectModel_AgentDeletedSuccessReloads(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -641,7 +641,7 @@ func TestSelectModel_AgentDeletedSuccessReloads(t *testing.T) {
 }
 
 func TestSelectModel_AgentDeletedErrorStaysInConfirm(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -666,7 +666,7 @@ func TestSelectModel_AgentDeletedErrorStaysInConfirm(t *testing.T) {
 }
 
 func TestSelectModel_DeletingBlocksKeystrokes(t *testing.T) {
-	m := newSelectModel(nil, false, false, nil, false)
+	m := newSelectModel(nil, false, false, nil, false, "")
 	m.subState = subStateConfirmDelete
 	m.deleting = true
 	m.pendingDeleteID = "alpha"
@@ -684,12 +684,156 @@ func TestSelectModel_DeletingBlocksKeystrokes(t *testing.T) {
 var _ = backend.DeleteAgentParams{}
 
 func TestSelectModel_ConnectionsActionEmitsShowConnections(t *testing.T) {
-	m := newSelectModel(nil, false, true, nil, false)
+	m := newSelectModel(nil, false, true, nil, false, "")
 	_, cmd := m.TriggerAction("connections")
 	if cmd == nil {
 		t.Fatal("expected cmd from connections action")
 	}
 	if _, ok := cmd().(showConnectionsMsg); !ok {
 		t.Errorf("expected showConnectionsMsg, got %T", cmd())
+	}
+}
+
+func TestSelectModel_AutoPickName_MatchesByName(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "Scout")
+
+	msg := agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main",
+			MainKey:   "main",
+			Agents: []protocol.AgentSummary{
+				{ID: "main", Name: "Pilot"},
+				{ID: "id-scout", Name: "Scout"},
+			},
+		},
+	}
+
+	m, _ = m.Update(msg)
+
+	if !m.selected {
+		t.Fatal("expected autoPickName to select an agent")
+	}
+	item, ok := m.selectedAgent()
+	if !ok {
+		t.Fatal("selectedAgent returned !ok")
+	}
+	if item.agent.ID != "id-scout" {
+		t.Errorf("selected agent ID = %q, want id-scout", item.agent.ID)
+	}
+	if m.autoPickName != "" {
+		t.Errorf("autoPickName not cleared after consume: %q", m.autoPickName)
+	}
+}
+
+func TestSelectModel_AutoPickName_MatchesByIDFirst(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "main")
+
+	// "main" matches the first agent's ID exactly. ID-first means we
+	// must not fall through to the second agent whose Name is "main"
+	// (case-insensitive name fallback).
+	msg := agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main",
+			MainKey:   "main",
+			Agents: []protocol.AgentSummary{
+				{ID: "main", Name: "First"},
+				{ID: "id-second", Name: "main"},
+			},
+		},
+	}
+
+	m, _ = m.Update(msg)
+
+	if !m.selected {
+		t.Fatal("expected autoPickName to select an agent")
+	}
+	item, _ := m.selectedAgent()
+	if item.agent.ID != "main" {
+		t.Errorf("selected agent ID = %q, want main (ID match must beat name match)", item.agent.ID)
+	}
+}
+
+func TestSelectModel_AutoPickName_CaseInsensitiveName(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "SCOUT")
+
+	msg := agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main",
+			MainKey:   "main",
+			Agents: []protocol.AgentSummary{
+				{ID: "id-scout", Name: "scout"},
+			},
+		},
+	}
+
+	m, _ = m.Update(msg)
+
+	if !m.selected {
+		t.Fatal("expected case-insensitive match to select")
+	}
+	item, _ := m.selectedAgent()
+	if item.agent.ID != "id-scout" {
+		t.Errorf("selected agent ID = %q, want id-scout", item.agent.ID)
+	}
+}
+
+func TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick(t *testing.T) {
+	// `lucinate chat --agent foo` against a single-agent connection
+	// where foo is not the agent: we want the err to surface, not a
+	// silent auto-pick of the wrong agent. This is the precedence
+	// case the design hinges on.
+	m := newSelectModel(nil, false, false, nil, false, "scout")
+
+	msg := agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main",
+			MainKey:   "main",
+			Agents: []protocol.AgentSummary{
+				{ID: "main", Name: "Pilot"}, // single agent, but not "scout"
+			},
+		},
+	}
+
+	m, _ = m.Update(msg)
+
+	if m.selected {
+		t.Fatal("must not auto-pick when --agent override misses")
+	}
+	if m.err == nil || !strings.Contains(m.err.Error(), `"scout"`) {
+		t.Fatalf("err = %v, want error naming \"scout\"", m.err)
+	}
+	if m.autoPickName != "" {
+		t.Errorf("autoPickName not cleared: %q", m.autoPickName)
+	}
+}
+
+func TestSelectModel_AutoPickName_OneShot(t *testing.T) {
+	// After the autoPickName has been consumed once, a second
+	// agentsLoadedMsg (e.g. agent-create reload) must not re-fire it.
+	m := newSelectModel(nil, false, false, nil, false, "scout")
+	m, _ = m.Update(agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main", MainKey: "main",
+			Agents: []protocol.AgentSummary{{ID: "id-scout", Name: "scout"}},
+		},
+	})
+	if !m.selected {
+		t.Fatal("first consume should have selected")
+	}
+	// Reset selected so the next msg can attempt to set it.
+	m.selected = false
+	m, _ = m.Update(agentsLoadedMsg{
+		result: &protocol.AgentsListResult{
+			DefaultID: "main", MainKey: "main",
+			Agents: []protocol.AgentSummary{
+				{ID: "id-scout", Name: "scout"},
+				{ID: "id-other", Name: "other"},
+			},
+		},
+	})
+	// With two agents and no autoPick, neither single-agent auto-pick
+	// nor the (now-cleared) override should fire.
+	if m.selected {
+		t.Error("autoPickName should be one-shot; second load must not re-pick")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ import (
 // "lucinate: flag: help requested" error line.
 var errSendUsage = errors.New("usage")
 
+// errChatUsage mirrors errSendUsage for the `chat` subcommand.
+var errChatUsage = errors.New("usage")
+
 func main() {
 	args := os.Args[1:]
 
@@ -32,6 +35,16 @@ func main() {
 		case "send":
 			err := runSend(args[1:])
 			if errors.Is(err, errSendUsage) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "lucinate: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "chat":
+			err := runChat(args[1:])
+			if errors.Is(err, errChatUsage) {
 				return
 			}
 			if err != nil {
@@ -119,6 +132,52 @@ func runSend(args []string) error {
 		Message:        message,
 		Detach:         detach,
 		Out:            os.Stdout,
+		BackendFactory: app.DefaultBackendFactory,
+	})
+}
+
+// runChat parses the `lucinate chat` flag set and dispatches into
+// app.Chat. Unlike `send`, every flag is optional and so is the
+// positional message — `lucinate chat` with no args is equivalent
+// to bare `lucinate`. As with `send`, the flag set stops at the
+// first positional argument so message text containing dashes is
+// taken verbatim; use `--` to disambiguate a leading dash.
+func runChat(args []string) error {
+	fs := flag.NewFlagSet("chat", flag.ContinueOnError)
+	var (
+		connection string
+		agent      string
+		session    string
+	)
+	fs.StringVar(&connection, "connection", "", "saved connection name or ID (defaults to the auto-pick)")
+	fs.StringVar(&agent, "agent", "", "agent name or ID to auto-select after connecting")
+	fs.StringVar(&session, "session", "", "session key to open (defaults to the agent's main session)")
+	fs.Usage = func() {
+		out := fs.Output()
+		fmt.Fprintln(out, "Usage: lucinate chat [--connection <name>] [--agent <name>] [--session <key>] [<message...>]")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Launches the TUI pre-navigated to the named connection / agent / session,")
+		fmt.Fprintln(out, "optionally auto-submitting the supplied message as the first turn. Any")
+		fmt.Fprintln(out, "unset flag falls back to the same default the bare `lucinate` invocation")
+		fmt.Fprintln(out, "uses (single-connection auto-pick, single-agent auto-pick, agent's main")
+		fmt.Fprintln(out, "session). Unlike `send`, this stays in the TUI for follow-up interaction.")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Flags:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return errChatUsage
+		}
+		return err
+	}
+	rest := fs.Args()
+	message := strings.Join(rest, " ")
+	return app.Chat(context.Background(), app.ChatOptions{
+		Connection:     connection,
+		Agent:          agent,
+		Session:        session,
+		Message:        message,
 		BackendFactory: app.DefaultBackendFactory,
 	})
 }


### PR DESCRIPTION
Add a `chat` subcommand that launches the regular TUI pre-navigated past the connection / agent / session pickers, optionally auto-submitting a first message.

## Summary

- `lucinate chat [--connection NAME] [--agent NAME] [--session KEY] [MESSAGE...]` — every flag and the message are optional; unset flags fall back to the same defaults the bare `lucinate` invocation uses (single-connection auto-pick, single-agent auto-pick, agent's main session).
- A `--message` (positional) is queued in the chat view's existing `pendingMessages` queue and drained on `historyLoadedMsg`, so the auto-submitted turn lands *after* the loaded scrollback — matching what a human typing the same text would see.
- A `--agent` mismatch in a single-agent connection surfaces an error banner on the picker rather than silently picking the only available agent (precedence ordering guarded by `TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick`).
- One-shot overrides are cleared on auth-cancel, unrecoverable connect failure, and `/connections` so an aborted scope change can't leak the original `--agent` / `--session` against an unrelated connection's list.
- Reuses the existing connection and agent resolvers (`resolveSendConnection`, ID-then-case-insensitive-name) shared with `send`, plus the existing `pendingMessages` queue and `drainQueue` from the chat view; no new submission primitive.
- Documentation: README "Skip the pickers" section, new maintainer-facing `docs/chat-launch.md` parallel to `docs/one-shot.md`, plus cross-references in `agents.md` / `sessions.md` / `connections.md`.

## Implementation details

The design treats `chat` as a thin pre-flight stage on top of the existing TUI startup, with three new one-shot fields plumbed `app.RunOptions` → `tui.AppOptions` → `AppModel.initial{Agent,Session,Message}`. Each is consumed at the existing transition that would otherwise have prompted the user:

- `initialAgent` is passed into `newSelectModel` as `autoPickName` from the connect-success branch; the picker's `agentsLoadedMsg` handler resolves it (ID then case-insensitive name) **before** the existing single-agent and post-create branches.
- `initialSession` is consumed in the `viewSelect` block of `update` to override `createKey` before `CreateSession` runs.
- `initialMessage` is appended to `pendingMessages` in `newChatModel`; the chat view's `historyLoadedMsg` handler returns `m.drainQueue()` when the queue is non-empty and `!m.sending`.

Picker validation stays in the TUI: a typo in `--agent` lands on the picker with an error banner rather than failing before the user can recover. `Chat` deliberately does not run a Connect + ListAgents round-trip itself — that would duplicate the picker's existing error path.

The `app/chat.go` layer is tiny on purpose: `Chat` calls `resolveChatRunOptions` (which is unit-tested without spinning up Bubble Tea) and hands the resulting `RunOptions` to the existing `Run`.