### PR TITLE
fix(tui): rebuild cron transcripts from the run log

### DIFF
--- a/docs/crons.md
+++ b/docs/crons.md
@@ -57,7 +57,15 @@ The list view loads on `Init()` via `loadJobs()`, which calls `CronsList(Enabled
 - Next run, Last run (with status), Payload body
 - Run history table
 
-Actions: `R` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open the most recent run's session in chat (emits `sessionSelectedMsg{sessionKey, agentID}`), `r` refresh, `esc` back to list.
+Actions: `R` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open a read-only transcript reconstructed from the run log (see [Transcript view](#transcript-view)), `r` refresh, `esc` back to list.
+
+### Transcript view
+
+`T` emits `cronTranscriptMsg{job, runs, agentName}`; the AppModel hands it to the chat view with `hideInput=true` and pre-seeds `chatModel.messages` from `buildCronTranscriptMessages` (`internal/tui/history.go`). No `chat.history` round-trip is made — cron runs with `sessionTarget=isolated` don't persist a queryable session entry on the gateway (especially when the run errors before `persistSessionEntry` fires), so the run log itself is the source of truth. The run log is also the same data the detail page's run-history previews already render, so transcript content matches what the previews promise.
+
+The builder walks `m.runs` (newest-first as returned by `cron.runs sortDir=desc`) in reverse and emits, per run: a separator with `RunAtMs`, a user turn with the cron's `payload.Text` / `payload.Message`, and either an assistant turn with `Summary` (Glamour-rendered when it looks like markdown) or an `errMsg` assistant turn with `Error`. Repeating the payload per run is intentional — each run is an independent invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
+
+The action itself is gated by `hasTranscriptContent`: if no run carries a `Summary` or `Error`, the `T` entry is suppressed from `Actions()` so it doesn't dangle on jobs with nothing to show.
 
 ## Form substate
 
@@ -83,3 +91,4 @@ The toggle action (`t` on detail) and the create-form submit use the typed `prot
 - Edit support for `at`/`every` schedules and `systemEvent` payloads.
 - Pagination of run history beyond the most recent 10 entries.
 - Live updates via cron-related gateway events — there is no streaming for cron state changes today, so the user must press `r` to refresh.
+- Replaying a cron run as a live chat session — the transcript is rebuilt from the run log, not from a queryable gateway session, so it's read-only by design.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -617,6 +617,19 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.state = viewChat
 		return m, m.chatModel.Init()
 
+	case cronTranscriptMsg:
+		// Cron-isolated runs don't keep a queryable chat session, so
+		// rebuild the transcript from the run log instead — that's the
+		// same data the run-history previews on the cron-detail page
+		// already use.
+		m.chatModel = newChatModel(m.backend, "", msg.job.AgentID, msg.agentName, "", m.prefs, true, connectionLabel(m.activeConn), "")
+		m.chatModel.setSize(m.width, m.height)
+		m.chatModel.messages = buildCronTranscriptMessages(cronPayloadText(msg.job), msg.runs, m.chatModel.renderer)
+		m.chatModel.historyLoading = false
+		m.chatModel.updateViewport()
+		m.state = viewChat
+		return m, nil
+
 	case newSessionCreatedMsg:
 		if msg.err != nil {
 			m.sessionsModel.err = msg.err

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -416,7 +416,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case historyLoadedMsg:
 		m.historyLoading = false
-		if msg.err == nil && len(msg.messages) > 0 {
+		switch {
+		case msg.err != nil:
+			m.messages = append(m.messages, chatMessage{
+				role:   "system",
+				errMsg: fmt.Sprintf("Could not load conversation history: %v", msg.err),
+			})
+		case len(msg.messages) > 0:
 			lastTs := lastTimestampMs(msg.messages)
 			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
 			m.messages = append(hist, m.messages...)

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -268,6 +268,29 @@ func TestChatModel_PreloadedPendingMessage_DrainsOnHistoryLoaded(t *testing.T) {
 	}
 }
 
+// TestChatModel_HistoryLoadError_ShowsSystemMessage verifies that
+// a failed chat.history fetch (e.g. when the gateway can't resolve a
+// cron-isolated session key) surfaces the error to the user instead
+// of leaving the view silently blank — the original symptom that
+// pressing 'T' on a cron details page produced.
+func TestChatModel_HistoryLoadError_ShowsSystemMessage(t *testing.T) {
+	fb := newFakeBackend()
+	m := newChatModel(fb, "session-key", "agent-id", "test", "", config.DefaultPreferences(), false, "", "")
+
+	loadErr := errors.New("gateway returned ENOENT")
+	m, _ = m.Update(historyLoadedMsg{messages: nil, err: loadErr})
+
+	if m.historyLoading {
+		t.Error("historyLoading should be cleared after the load attempt")
+	}
+	if len(m.messages) != 1 {
+		t.Fatalf("expected a system error message; got %d messages", len(m.messages))
+	}
+	if m.messages[0].role != "system" || m.messages[0].errMsg == "" {
+		t.Errorf("expected system message with errMsg set; got %+v", m.messages[0])
+	}
+}
+
 // TestChatModel_NoInitialMessage_NoDrain verifies the regression
 // case: without a preloaded message, a historyLoadedMsg must not
 // kick a stray drain (which would surface as a confused user turn

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -603,7 +603,7 @@ func (m cronsModel) detailActions() []Action {
 		actions = append(actions, Action{ID: "toggle", Label: toggleLabel, Key: "t"})
 		actions = append(actions, Action{ID: "edit", Label: "Edit", Key: "e"})
 		actions = append(actions, Action{ID: "delete", Label: "Delete", Key: "x"})
-		if transcriptKey := bestTranscriptSessionKey(job, m.runs); transcriptKey != "" {
+		if hasTranscriptContent(job, m.runs) {
 			actions = append(actions, Action{ID: "transcript", Label: "Transcript", Key: "T"})
 		}
 	}
@@ -764,29 +764,41 @@ func (m cronsModel) actionTranscript() (cronsModel, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	sessionKey := bestTranscriptSessionKey(job, m.runs)
-	if sessionKey == "" {
+	if !hasTranscriptContent(job, m.runs) {
 		return m, nil
 	}
+	runs := append([]protocol.CronRunLogEntry(nil), m.runs...)
 	return m, func() tea.Msg {
-		return sessionSelectedMsg{
-			sessionKey: sessionKey,
-			agentID:    job.AgentID,
-			agentName:  job.AgentID, // best-effort label; the chat header re-resolves on first event
+		return cronTranscriptMsg{
+			job:       job,
+			runs:      runs,
+			agentName: job.AgentID,
 		}
 	}
 }
 
-// bestTranscriptSessionKey returns the most useful session key for the
-// "view transcript" action — the most recent run with one wins;
-// otherwise the job's stored sessionKey if any.
-func bestTranscriptSessionKey(job protocol.CronJob, runs []protocol.CronRunLogEntry) string {
+// hasTranscriptContent reports whether the cron has any run-log content
+// worth rendering — a payload alone isn't enough; we want at least one
+// run with a summary or error message to show alongside it.
+func hasTranscriptContent(job protocol.CronJob, runs []protocol.CronRunLogEntry) bool {
+	if cronPayloadText(job) == "" && len(runs) == 0 {
+		return false
+	}
 	for _, r := range runs {
-		if r.SessionKey != "" {
-			return r.SessionKey
+		if r.Summary != "" || r.Error != "" {
+			return true
 		}
 	}
-	return job.SessionKey
+	return false
+}
+
+// cronPayloadText returns the human-authored prompt for an agentTurn
+// cron job, falling back across the union fields the gateway uses.
+func cronPayloadText(job protocol.CronJob) string {
+	if t := strings.TrimSpace(job.Payload.Text); t != "" {
+		return t
+	}
+	return strings.TrimSpace(job.Payload.Message)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -388,29 +388,54 @@ func TestCronsConfirmDelete_NoCancels(t *testing.T) {
 	}
 }
 
-func TestCronsTranscript_PicksMostRecentRunSession(t *testing.T) {
+func TestCronsTranscript_DispatchesRunLogContent(t *testing.T) {
 	m, _ := newTestCronsModel(t)
 	jobs := sampleJobs()
 	m, _ = m.Update(cronsLoadedMsg{jobs: jobs})
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
-	// Seed runs as if loadRuns completed.
+	// Seed runs (newest first, matching cron.runs sortDir=desc) as if
+	// loadRuns completed — including a summary so the transcript action
+	// is offered and dispatched with the run-log payload.
 	m, _ = m.Update(cronRunsLoadedMsg{
-		jobID:   "job-1",
-		entries: []protocol.CronRunLogEntry{{SessionKey: "agent-1:cron:job-1:run-42"}},
+		jobID: "job-1",
+		entries: []protocol.CronRunLogEntry{
+			{Status: "ok", Summary: "Newest run output."},
+			{Status: "error", Error: "boom"},
+		},
 	})
 	_, cmd := m.handleKey(tea.KeyPressMsg{Code: 'T', Text: "T"})
 	if cmd == nil {
 		t.Fatal("expected a cmd from T")
 	}
 	msg := cmd()
-	sel, ok := msg.(sessionSelectedMsg)
+	sel, ok := msg.(cronTranscriptMsg)
 	if !ok {
-		t.Fatalf("expected sessionSelectedMsg, got %T", msg)
+		t.Fatalf("expected cronTranscriptMsg, got %T", msg)
 	}
-	if sel.sessionKey != "agent-1:cron:job-1:run-42" {
-		t.Errorf("sessionKey: %q", sel.sessionKey)
+	if sel.job.ID != "job-1" {
+		t.Errorf("job.ID: %q", sel.job.ID)
 	}
-	if sel.agentID != "agent-1" {
-		t.Errorf("agentID: %q", sel.agentID)
+	if sel.agentName != "agent-1" {
+		t.Errorf("agentName: %q", sel.agentName)
+	}
+	if len(sel.runs) != 2 {
+		t.Errorf("expected 2 runs forwarded, got %d", len(sel.runs))
+	}
+}
+
+func TestCronsTranscript_HiddenWhenNoRunOutput(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	jobs := sampleJobs()
+	m, _ = m.Update(cronsLoadedMsg{jobs: jobs})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	// Runs exist but none carry summary or error — no useful content.
+	m, _ = m.Update(cronRunsLoadedMsg{
+		jobID:   "job-1",
+		entries: []protocol.CronRunLogEntry{{Status: "skipped"}},
+	})
+	for _, a := range m.Actions() {
+		if a.ID == "transcript" {
+			t.Fatalf("transcript action should be hidden when no run carries summary/error; got %+v", a)
+		}
 	}
 }

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/glamour/v2"
+	"github.com/a3tai/openclaw-go/protocol"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 )
@@ -93,6 +94,54 @@ func fetchHistory(b backend.Backend, sessionKey string, renderer *glamour.TermRe
 		msgs = append(msgs, chatMessage{role: role, content: text, raw: raw, thinking: thinking, rendered: rendered, timestampMs: hm.Timestamp})
 	}
 	return msgs, nil
+}
+
+// buildCronTranscriptMessages reconstructs a transcript-style message
+// list from a cron job and its run log. Cron-isolated runs don't keep
+// a queryable chat session, but the payload (the user's prompt) and
+// each run's summary/error are persisted in the run log — which is
+// what the cron-detail run-history previews already display. This
+// surfaces the same content as a normal-looking conversation: each run
+// becomes a separator, a user turn (the payload), and an assistant turn
+// (the summary, or the error if the run failed).
+func buildCronTranscriptMessages(payload string, runs []protocol.CronRunLogEntry, renderer *glamour.TermRenderer) []chatMessage {
+	if len(runs) == 0 {
+		return nil
+	}
+	// Run logs arrive newest-first; render oldest-first so the
+	// transcript reads top-down chronologically like a real chat.
+	ordered := make([]protocol.CronRunLogEntry, len(runs))
+	for i, r := range runs {
+		ordered[len(runs)-1-i] = r
+	}
+	var msgs []chatMessage
+	for _, r := range ordered {
+		var ts int64
+		if r.RunAtMs != nil {
+			ts = *r.RunAtMs
+		}
+		msgs = append(msgs, chatMessage{role: "separator", timestampMs: ts})
+		if payload != "" {
+			msgs = append(msgs, chatMessage{role: "user", content: payload, timestampMs: ts})
+		}
+		switch {
+		case r.Summary != "":
+			content := r.Summary
+			raw := ""
+			rendered := false
+			if renderer != nil && looksLikeMarkdown(content) {
+				if out, err := renderer.Render(content); err == nil {
+					raw = content
+					content = strings.TrimSpace(out)
+					rendered = true
+				}
+			}
+			msgs = append(msgs, chatMessage{role: "assistant", content: content, raw: raw, rendered: rendered, timestampMs: ts})
+		case r.Error != "":
+			msgs = append(msgs, chatMessage{role: "assistant", errMsg: r.Error, timestampMs: ts})
+		}
+	}
+	return msgs
 }
 
 // stripSystemLines removes "System:" prefixed lines and leading whitespace

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -1,6 +1,49 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+func TestBuildCronTranscriptMessages_ChronologicalAndCoversBothOutcomes(t *testing.T) {
+	older := int64(1_000)
+	newer := int64(2_000)
+	// Run logs arrive newest-first.
+	runs := []protocol.CronRunLogEntry{
+		{RunAtMs: &newer, Status: "ok", Summary: "Newer run output."},
+		{RunAtMs: &older, Status: "error", Error: "older run blew up"},
+	}
+
+	msgs := buildCronTranscriptMessages("Check the balance.", runs, nil)
+
+	// Expect oldest first: separator, user payload, assistant error,
+	// separator, user payload, assistant summary.
+	if len(msgs) != 6 {
+		t.Fatalf("expected 6 messages (2 runs × 3), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].role != "separator" || msgs[0].timestampMs != older {
+		t.Errorf("msgs[0] should be older separator; got %+v", msgs[0])
+	}
+	if msgs[1].role != "user" || msgs[1].content != "Check the balance." {
+		t.Errorf("msgs[1] should be user payload for older run; got %+v", msgs[1])
+	}
+	if msgs[2].role != "assistant" || msgs[2].errMsg != "older run blew up" {
+		t.Errorf("msgs[2] should be assistant error for older run; got %+v", msgs[2])
+	}
+	if msgs[3].role != "separator" || msgs[3].timestampMs != newer {
+		t.Errorf("msgs[3] should be newer separator; got %+v", msgs[3])
+	}
+	if msgs[5].role != "assistant" || msgs[5].content != "Newer run output." {
+		t.Errorf("msgs[5] should be assistant summary for newer run; got %+v", msgs[5])
+	}
+}
+
+func TestBuildCronTranscriptMessages_EmptyRunsReturnsNil(t *testing.T) {
+	if msgs := buildCronTranscriptMessages("payload", nil, nil); msgs != nil {
+		t.Errorf("expected nil for empty run log; got %+v", msgs)
+	}
+}
 
 func TestLooksLikeMarkdown(t *testing.T) {
 	tests := []struct {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -178,6 +178,16 @@ type sessionSelectedMsg struct {
 	modelID    string
 }
 
+// cronTranscriptMsg opens a read-only transcript view for a cron job
+// reconstructed from the run log. Distinct from sessionSelectedMsg
+// because cron-isolated runs don't persist a queryable chat session —
+// the run-log payload + summary/error is the source of truth.
+type cronTranscriptMsg struct {
+	job       protocol.CronJob
+	runs      []protocol.CronRunLogEntry
+	agentName string
+}
+
 // goBackFromSessionsMsg signals the AppModel to return to the chat view.
 type goBackFromSessionsMsg struct{}
 

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -15,6 +15,8 @@ func (m *chatModel) updateViewport() {
 
 	if m.historyLoading && len(m.messages) == 0 && len(m.pendingMessages) == 0 {
 		b.WriteString(statusStyle.Render(wordWrap("Loading conversation history…", contentWidth)))
+	} else if !m.historyLoading && len(m.messages) == 0 && len(m.pendingMessages) == 0 {
+		b.WriteString(emptyHistoryStyle.Render(wordWrap("No conversation history for this session.", contentWidth)))
 	}
 
 	for i, msg := range m.messages {

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -274,6 +274,25 @@ func TestUpdateViewport_HistoryLoadingPlaceholder(t *testing.T) {
 	}
 }
 
+func TestUpdateViewport_EmptyHistoryShowsHint(t *testing.T) {
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(20)
+	m := &chatModel{
+		viewport:       vp,
+		width:          80,
+		agentName:      "test",
+		historyLoading: false,
+	}
+
+	m.updateViewport()
+
+	view := ansi.Strip(m.viewport.View())
+	if !strings.Contains(view, "No conversation history for this session.") {
+		t.Errorf("viewport should show empty-state hint when history finished loading with no messages; got %q", view)
+	}
+}
+
 func TestUpdateViewport_PlaceholderYieldsToPendingMessage(t *testing.T) {
 	vp := viewport.New()
 	vp.SetWidth(80)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -47,6 +47,12 @@ var (
 	statusStyle = lipgloss.NewStyle().
 			Foreground(subtle)
 
+	// Empty-history placeholder — brighter than statusStyle so it stands
+	// out against the empty conversation pane.
+	emptyHistoryStyle = lipgloss.NewStyle().
+				Foreground(accent).
+				Italic(true)
+
 	// Error text.
 	errorStyle = lipgloss.NewStyle().
 			Foreground(errClr).


### PR DESCRIPTION
Fix the cron-detail Transcript (T) action so it actually displays the run output, by sourcing it from the run log instead of an unqueryable session.

## Summary
- Cron-isolated runs do not persist a chat session that `chat.history` can return content for, so pressing T opened a blank chat. Rebuild the transcript directly from the run log — the same `Summary` / `Error` already used for the run-history previews.
- Dispatch a new `cronTranscriptMsg` (job + run log) instead of `sessionSelectedMsg`. The AppModel seeds a hide-input chat with messages built from the run log and skips the history fetch.
- Hide the Transcript action when no run carries any summary or error, so it doesn't dangle on jobs with nothing to show.
- Surface `chat.history` errors and an empty-history placeholder in the chat view, so future failures on the regular sessions path aren't silently blank.

## Implementation details
- The transcript builder renders runs oldest-first as separator → user (payload) → assistant (summary or `errMsg`), reusing the existing chat rendering so it looks like a real conversation rather than a bespoke widget. Repeating the payload per run is intentional: each run is an independent invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
- The chat view is opened with `hideInput=true` because the underlying session is dead — there is nowhere to send a follow-up message.