### PR TITLE
feat(tui): surface delivery errors in cron run transcripts

### DIFF
--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -785,7 +785,7 @@ func hasTranscriptContent(job protocol.CronJob, runs []protocol.CronRunLogEntry)
 		return false
 	}
 	for _, r := range runs {
-		if r.Summary != "" || r.Error != "" {
+		if r.Summary != "" || r.Error != "" || r.DeliveryError != "" {
 			return true
 		}
 	}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -102,8 +102,11 @@ func fetchHistory(b backend.Backend, sessionKey string, renderer *glamour.TermRe
 // each run's summary/error are persisted in the run log — which is
 // what the cron-detail run-history previews already display. This
 // surfaces the same content as a normal-looking conversation: each run
-// becomes a separator, a user turn (the payload), and an assistant turn
-// (the summary, or the error if the run failed).
+// becomes a separator, a user turn (the payload), an assistant turn
+// (the summary, or the error if the run produced no output), and a
+// trailing system error note if the run logged an error or delivery
+// failure alongside the summary — the agent's work succeeded but the
+// run was marked failed for an ancillary reason worth surfacing.
 func buildCronTranscriptMessages(payload string, runs []protocol.CronRunLogEntry, renderer *glamour.TermRenderer) []chatMessage {
 	if len(runs) == 0 {
 		return nil
@@ -124,6 +127,7 @@ func buildCronTranscriptMessages(payload string, runs []protocol.CronRunLogEntry
 		if payload != "" {
 			msgs = append(msgs, chatMessage{role: "user", content: payload, timestampMs: ts})
 		}
+		errNote := cronRunErrorNote(r)
 		switch {
 		case r.Summary != "":
 			content := r.Summary
@@ -137,11 +141,33 @@ func buildCronTranscriptMessages(payload string, runs []protocol.CronRunLogEntry
 				}
 			}
 			msgs = append(msgs, chatMessage{role: "assistant", content: content, raw: raw, rendered: rendered, timestampMs: ts})
-		case r.Error != "":
-			msgs = append(msgs, chatMessage{role: "assistant", errMsg: r.Error, timestampMs: ts})
+			if errNote != "" {
+				msgs = append(msgs, chatMessage{role: "system", errMsg: errNote, timestampMs: ts})
+			}
+		case errNote != "":
+			msgs = append(msgs, chatMessage{role: "assistant", errMsg: errNote, timestampMs: ts})
 		}
 	}
 	return msgs
+}
+
+// cronRunErrorNote joins the run-level error and delivery-level error
+// into a single reader-friendly string, deduping when the gateway has
+// echoed the same text into both fields.
+func cronRunErrorNote(r protocol.CronRunLogEntry) string {
+	var parts []string
+	seen := map[string]bool{}
+	add := func(label, val string) {
+		v := strings.TrimSpace(val)
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		parts = append(parts, label+": "+v)
+	}
+	add("Run error", r.Error)
+	add("Delivery error", r.DeliveryError)
+	return strings.Join(parts, "\n")
 }
 
 // stripSystemLines removes "System:" prefixed lines and leading whitespace

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/a3tai/openclaw-go/protocol"
@@ -28,7 +29,7 @@ func TestBuildCronTranscriptMessages_ChronologicalAndCoversBothOutcomes(t *testi
 	if msgs[1].role != "user" || msgs[1].content != "Check the balance." {
 		t.Errorf("msgs[1] should be user payload for older run; got %+v", msgs[1])
 	}
-	if msgs[2].role != "assistant" || msgs[2].errMsg != "older run blew up" {
+	if msgs[2].role != "assistant" || msgs[2].errMsg != "Run error: older run blew up" {
 		t.Errorf("msgs[2] should be assistant error for older run; got %+v", msgs[2])
 	}
 	if msgs[3].role != "separator" || msgs[3].timestampMs != newer {
@@ -42,6 +43,67 @@ func TestBuildCronTranscriptMessages_ChronologicalAndCoversBothOutcomes(t *testi
 func TestBuildCronTranscriptMessages_EmptyRunsReturnsNil(t *testing.T) {
 	if msgs := buildCronTranscriptMessages("payload", nil, nil); msgs != nil {
 		t.Errorf("expected nil for empty run log; got %+v", msgs)
+	}
+}
+
+func TestBuildCronTranscriptMessages_DeliveryErrorAfterSummary(t *testing.T) {
+	// Real-world case: the agent ran fine and produced a summary, but
+	// the gateway couldn't route the announcement so the run was logged
+	// status=error with the actual work intact in Summary. The
+	// transcript must show both — the summary and the delivery failure.
+	ts := int64(1_000)
+	runs := []protocol.CronRunLogEntry{
+		{
+			RunAtMs:       &ts,
+			Status:        "error",
+			Summary:       "Total Balance: $9.12",
+			DeliveryError: "Delivering to Telegram requires target",
+		},
+	}
+
+	msgs := buildCronTranscriptMessages("Check balance.", runs, nil)
+
+	if len(msgs) != 4 {
+		t.Fatalf("expected separator+user+assistant+system note, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[2].role != "assistant" || msgs[2].content != "Total Balance: $9.12" {
+		t.Errorf("msgs[2] should carry the assistant summary; got %+v", msgs[2])
+	}
+	if msgs[3].role != "system" || !strings.Contains(msgs[3].errMsg, "Delivery error: Delivering to Telegram requires target") {
+		t.Errorf("msgs[3] should be a system note carrying the delivery error; got %+v", msgs[3])
+	}
+}
+
+func TestBuildCronTranscriptMessages_RunErrorOnlyStaysOnAssistantTurn(t *testing.T) {
+	ts := int64(1_000)
+	runs := []protocol.CronRunLogEntry{
+		{RunAtMs: &ts, Status: "error", Error: "boom"},
+	}
+
+	msgs := buildCronTranscriptMessages("Check.", runs, nil)
+
+	if len(msgs) != 3 {
+		t.Fatalf("expected separator+user+assistant, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[2].role != "assistant" || msgs[2].errMsg != "Run error: boom" {
+		t.Errorf("msgs[2] should carry the run error as assistant errMsg; got %+v", msgs[2])
+	}
+}
+
+func TestBuildCronTranscriptMessages_DedupesIdenticalRunAndDeliveryError(t *testing.T) {
+	ts := int64(1_000)
+	runs := []protocol.CronRunLogEntry{
+		{RunAtMs: &ts, Status: "error", Error: "boom", DeliveryError: "boom"},
+	}
+
+	msgs := buildCronTranscriptMessages("Check.", runs, nil)
+
+	// One assistant turn carrying the dedup'd note — not two of the same line.
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if got := msgs[2].errMsg; got != "Run error: boom" {
+		t.Errorf("expected dedup'd 'Run error: boom'; got %q", got)
 	}
 }
 


### PR DESCRIPTION
Show ancillary run-log errors (delivery failures, top-level errors) in the cron transcript so a run that produced output but failed to deliver no longer hides the agent's actual work.

## Summary
- Cron runs whose work succeeded but whose delivery failed (e.g. announce → Telegram with no chat ID linked) were logged as \`status=error\` with a populated \`Summary\` and \`DeliveryError\`. The transcript previously chose one or the other and surfaced only the assistant turn — never the delivery failure.
- After a run's assistant turn, append a system-styled error note with \`Run error:\` and/or \`Delivery error:\` lines whenever the run log carries them. Agent output stays in place; the failure context follows it.
- When the run produced no summary, the same note becomes the assistant's \`errMsg\` (existing behaviour, just now also covering \`DeliveryError\`).
- Identical strings in \`Error\` and \`DeliveryError\` are deduped so the same line isn't shown twice.
- The Transcript action's gate (\`hasTranscriptContent\`) now also fires on \`DeliveryError\`, so runs that failed only on delivery (no summary, no top-level error) still surface a transcript.

## Implementation details
The note is rendered via the existing \`system\` + \`errMsg\` chat-message shape so it picks up \`errorStyle\` (red, bold) and contrasts with the assistant turn above it. Splitting the run failure into its own message rather than overloading the assistant's content keeps the agent's actual output rendered as a normal markdown response — important when the summary is the useful part of the run and the failure is incidental.