### PR TITLE
feat(cli): add short flag aliases for chat and send subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,18 +200,18 @@ lucinate send --connection my-con --agent main "summarise this PR description"
 
 | Flag | Description |
 |------|-------------|
-| `--connection` | Saved connection name or ID (case-insensitive on name). Required. |
-| `--agent` | Agent name or ID within the connection (case-insensitive on name). Required. |
-| `--session` | Session key. Defaults to the agent's main session — same default the picker would pick. |
-| `--detach` | Dispatch the message and exit as soon as the gateway accepts the turn. No reply is awaited. |
+| `--connection`, `-c` | Saved connection name or ID (case-insensitive on name). Required. |
+| `--agent`, `-a` | Agent name or ID within the connection (case-insensitive on name). Required. |
+| `--session`, `-s` | Session key. Defaults to the agent's main session — same default the picker would pick. |
+| `--detach`, `-d` | Dispatch the message and exit as soon as the gateway accepts the turn. No reply is awaited. |
 
 The reply is written to stdout with a single trailing newline. Errors go to stderr; the exit code is non-zero on failure. Messages that begin with a dash should be preceded by `--` (the standard Unix escape) so the flag parser leaves them alone.
 
 A couple of patterns this enables:
 
 ```sh
-# capture a reply into a shell variable
-reply=$(lucinate send --connection my-con --agent main "what's the changelog entry for this commit?")
+# capture a reply into a shell variable (short flags work too)
+reply=$(lucinate send -c my-con -a main "what's the changelog entry for this commit?")
 echo "$reply" | tee notes.md
 
 # fire-and-forget from cron — the run continues server-side, the next TUI session sees the reply
@@ -230,9 +230,9 @@ lucinate chat --connection my-con --agent main "kick things off"
 
 | Flag | Description |
 |------|-------------|
-| `--connection` | Saved connection name or ID (case-insensitive on name). Optional — defaults to the same auto-pick the bare `lucinate` uses. |
-| `--agent` | Agent name or ID to auto-select. A miss surfaces as an error on the picker rather than silently picking the wrong one. |
-| `--session` | Session key to open. Defaults to the agent's main session — same default the picker would pick. |
+| `--connection`, `-c` | Saved connection name or ID (case-insensitive on name). Optional — defaults to the same auto-pick the bare `lucinate` uses. |
+| `--agent`, `-a` | Agent name or ID to auto-select. A miss surfaces as an error on the picker rather than silently picking the wrong one. |
+| `--session`, `-s` | Session key to open. Defaults to the agent's main session — same default the picker would pick. |
 
 Every flag is optional. `lucinate chat` with no flags and no message is functionally identical to bare `lucinate`. Messages that begin with a dash should be preceded by `--`, same Unix escape as `send`.
 

--- a/main.go
+++ b/main.go
@@ -99,12 +99,16 @@ func runSend(args []string) error {
 		detach     bool
 	)
 	fs.StringVar(&connection, "connection", "", "saved connection name or ID (required)")
+	fs.StringVar(&connection, "c", "", "short for --connection")
 	fs.StringVar(&agent, "agent", "", "agent name or ID within the connection (required)")
+	fs.StringVar(&agent, "a", "", "short for --agent")
 	fs.StringVar(&session, "session", "", "session key (defaults to the agent's main session)")
+	fs.StringVar(&session, "s", "", "short for --session")
 	fs.BoolVar(&detach, "detach", false, "dispatch the message and exit without waiting for a reply")
+	fs.BoolVar(&detach, "d", false, "short for --detach")
 	fs.Usage = func() {
 		out := fs.Output()
-		fmt.Fprintln(out, "Usage: lucinate send --connection <name> --agent <name> [--session <key>] [--detach] <message...>")
+		fmt.Fprintln(out, "Usage: lucinate send (--connection|-c) <name> (--agent|-a) <name> [(--session|-s) <key>] [--detach|-d] <message...>")
 		fmt.Fprintln(out, "")
 		fmt.Fprintln(out, "Sends a single chat message through a stored connection and prints the")
 		fmt.Fprintln(out, "assistant's first complete reply on stdout. With --detach the call returns")
@@ -150,11 +154,14 @@ func runChat(args []string) error {
 		session    string
 	)
 	fs.StringVar(&connection, "connection", "", "saved connection name or ID (defaults to the auto-pick)")
+	fs.StringVar(&connection, "c", "", "short for --connection")
 	fs.StringVar(&agent, "agent", "", "agent name or ID to auto-select after connecting")
+	fs.StringVar(&agent, "a", "", "short for --agent")
 	fs.StringVar(&session, "session", "", "session key to open (defaults to the agent's main session)")
+	fs.StringVar(&session, "s", "", "short for --session")
 	fs.Usage = func() {
 		out := fs.Output()
-		fmt.Fprintln(out, "Usage: lucinate chat [--connection <name>] [--agent <name>] [--session <key>] [<message...>]")
+		fmt.Fprintln(out, "Usage: lucinate chat [(--connection|-c) <name>] [(--agent|-a) <name>] [(--session|-s) <key>] [<message...>]")
 		fmt.Fprintln(out, "")
 		fmt.Fprintln(out, "Launches the TUI pre-navigated to the named connection / agent / session,")
 		fmt.Fprintln(out, "optionally auto-submitting the supplied message as the first turn. Any")


### PR DESCRIPTION
Adds single-character aliases for the existing `chat` and `send` flags so scripted invocations and quick one-shots can be terser.

## Summary
- `send` gains `-c`, `-a`, `-s`, `-d` as aliases for `--connection`, `--agent`, `--session`, `--detach`
- `chat` gains `-c`, `-a`, `-s` as aliases for `--connection`, `--agent`, `--session`
- Usage strings on both subcommands now show both forms (e.g. `(--connection|-c)`)
- README flag tables updated; example tweaked to demonstrate the short forms

## Implementation details
Each short flag is registered against the same backing variable as its long counterpart via paired `fs.StringVar` / `fs.BoolVar` calls — the same pattern already used for `--version` / `-v` in `main.go`. No resolution behaviour changes, so the maintainer docs under `docs/` did not need updating.