### PR TITLE
feat(crons): add duplicate action to cron job list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Local agent skills** loaded from `~/.agents/skills/` — invoke as a slash command (`/review`) or drop one mid-message (`use /review on the diff`)
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
-- **Cron browser** — list, edit, run, and create scheduled jobs without leaving the terminal (OpenClaw)
+- **Cron browser** — list, edit, run, create, and duplicate scheduled jobs without leaving the terminal (OpenClaw)
 
 ## Install
 

--- a/docs/crons.md
+++ b/docs/crons.md
@@ -45,7 +45,7 @@ The list view loads on `Init()` via `loadJobs()`, which calls `CronsList(Enabled
 - **Line 1**: bold name + dim relative-time chip (`in 8h`, `due`, `—`).
 - **Line 2**: chips for session target (`main`/`isolated`), wake mode (`now`/`heartbeat`), agent ID, and a status badge (`ok`/`error`/`disabled`/`idle`).
 
-`enter` opens detail; `r` refreshes; `n` opens the create form; `esc` emits `goBackFromCronsMsg{}` to return to chat.
+`enter` opens detail; `r` refreshes; `n` opens the create form; `d` opens the create form pre-populated from the highlighted job (the duplicate flow — see [Duplicate flow](#duplicate-flow)); `esc` emits `goBackFromCronsMsg{}` to return to chat.
 
 ## Detail substate
 
@@ -80,6 +80,10 @@ The create and edit form share `cronForm` and the `cronFormField` enum (12 field
 The save path is suppressed in this state — we surface the brittleness rather than silently round-trip a truncated representation.
 
 Tab/Shift+Tab navigates fields. Space toggles the cycle/checkbox controls (`sessionTarget`, `wakeMode`, `deliveryMode`, `enabled`). Inside the payload `textarea`, Enter inserts a newline; Ctrl+S (or Alt+Enter) saves from anywhere; Esc cancels and returns to whichever substate opened the form.
+
+### Duplicate flow
+
+`d` on the list substate opens the same form as `n`, but pre-populated from the highlighted job. The form stays in `mode=create` with `editingID=""`, so submission goes through `CronAdd` (not `CronUpdateRaw`) and produces a brand-new job rather than mutating the source. The name is prefixed with `Copy of ` so the duplicate is visually distinguishable in the list before the user edits it; every other field — schedule, timezone, agent, model, payload, session/wake, delivery, enabled — is copied verbatim. `populateFormFromJob` is shared with `newEditForm` so the two flows can't drift in which fields they carry over. Duplicating a job whose schedule kind is anything other than `cron` (or whose payload kind is anything other than `agentTurn`) is refused with the same banner the edit flow shows, for the same reason: the TUI form would silently truncate the unmodelled union fields.
 
 ### Raw-patch edit semantics
 

--- a/docs/crons.md
+++ b/docs/crons.md
@@ -89,6 +89,10 @@ Tab/Shift+Tab navigates fields. Space toggles the cycle/checkbox controls (`sess
 
 The toggle action (`t` on detail) and the create-form submit use the typed `protocol.CronUpdateParams`/`CronAddParams`. The **edit-form submit goes through `CronUpdateRaw(jobID, patch map[string]any)` instead**, because every string field on `protocol.CronJobPatch` and `CronPayload` is tagged `json:",omitempty"` — once Go marshals an empty value, the field is dropped from the JSON, and the gateway can't distinguish "user cleared this field" from "user didn't touch this field" (it keeps the prior value). The map-based path emits empty strings verbatim (see `buildJobPatchMap`) so clearing model, description, or delivery actually persists. Toggle stays on the typed path because it only mutates a `*bool`, which doesn't have the omitempty problem.
 
+### Payload field mapping (`message` vs `text`)
+
+`protocol.CronPayload` exposes both `Text` and `Message` because the gateway's payload schema is a union. For `agentTurn` the prompt travels in `message` (the `agentTurn` schema declares `additionalProperties: false` and rejects `text`); for `systemEvent` it travels in `text`. The TUI form models `agentTurn` only, so `buildAddParams` and `buildJobPatchMap` populate `message` and never emit `text`. On the read side, `populateFormFromJob` and `cronPayloadText` prefer `Message` and fall back to `Text` only for historical jobs that may still carry the prompt under the systemEvent-style field.
+
 ## Confirm-delete substate
 
 `x` on detail transitions to a y/n prompt. `y` calls `CronRemove(jobID)` and refreshes the list (returning to `cronSubList`). `n` or `esc` returns to detail without action.

--- a/internal/tui/connections.go
+++ b/internal/tui/connections.go
@@ -673,7 +673,7 @@ func (m connectionsModel) viewList() string {
 	var b strings.Builder
 	if m.lastErr != nil {
 		b.WriteString("\n")
-		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.lastErr)))
+		b.WriteString(renderErrorLine(m.lastErr.Error(), m.width))
 		b.WriteString("\n")
 	}
 	if m.store == nil || len(m.store.Connections) == 0 {

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -592,6 +592,9 @@ func (m cronsModel) listActions() []Action {
 	var actions []Action
 	if !m.loading && m.err == nil {
 		actions = append(actions, Action{ID: "new", Label: "New job", Key: "n"})
+		if len(m.list.Items()) > 0 {
+			actions = append(actions, Action{ID: "duplicate", Label: "Duplicate", Key: "d"})
+		}
 	}
 	if m.filterAgentID != "" {
 		label := "Show all agents"
@@ -655,6 +658,8 @@ func (m cronsModel) TriggerAction(id string) (cronsModel, tea.Cmd) {
 		m.sizePayloadTextarea()
 		m.subset = cronSubForm
 		return m, m.form.name.Focus()
+	case "duplicate":
+		return m.actionDuplicate()
 	case "run":
 		return m.actionRun()
 	case "toggle":
@@ -762,6 +767,26 @@ func (m cronsModel) actionEdit() (cronsModel, tea.Cmd) {
 		// Render the form anyway so the user sees the explanation; the
 		// save action is suppressed while the unsupported banner is up.
 		form.unsupported = err
+	}
+	m.form = form
+	m.sizePayloadTextarea()
+	m.subset = cronSubForm
+	return m, m.form.name.Focus()
+}
+
+// actionDuplicate opens the form pre-populated from the highlighted
+// list item, but in create mode so submission goes through CronAdd.
+// Triggered from the list substate ("d"); the source job is read from
+// m.list.SelectedItem rather than m.selectedID, which is only set
+// after entering the detail view.
+func (m cronsModel) actionDuplicate() (cronsModel, tea.Cmd) {
+	item, ok := m.list.SelectedItem().(cronItem)
+	if !ok {
+		return m, nil
+	}
+	form, banner := newDuplicateForm(item.job)
+	if banner != "" {
+		form.unsupported = banner
 	}
 	m.form = form
 	m.sizePayloadTextarea()
@@ -877,10 +902,39 @@ func newCreateForm() cronForm {
 // returned banner string is non-empty and the caller should disable the
 // save path.
 func newEditForm(job protocol.CronJob) (cronForm, string) {
-	f := newCreateForm()
+	f, unsupported := populateFormFromJob(job)
 	f.mode = "edit"
 	f.editingID = job.ID
 	f.name.SetValue(job.Name)
+	if unsupported != "" {
+		unsupported = strings.Replace(unsupported, "{action}", "Edit", 1)
+	}
+	return f, unsupported
+}
+
+// newDuplicateForm pre-populates a create-mode form from an existing
+// job. Like the edit form it copies every field the TUI models, but
+// leaves editingID empty so submission goes through CronAdd rather than
+// CronUpdate. The name is prefixed with "Copy of " so the duplicate is
+// distinguishable in the list before the user edits it.
+func newDuplicateForm(job protocol.CronJob) (cronForm, string) {
+	f, unsupported := populateFormFromJob(job)
+	// mode stays "create" and editingID stays "" so submitForm -> CronAdd.
+	f.name.SetValue(duplicateName(job.Name))
+	if unsupported != "" {
+		unsupported = strings.Replace(unsupported, "{action}", "Duplicate", 1)
+	}
+	return f, unsupported
+}
+
+// populateFormFromJob copies every form-modelled field off a job into a
+// fresh create-mode form. Shared between the edit and duplicate flows
+// because the only differences between them are mode/editingID and the
+// name handling. The unsupported banner uses a "{action}" placeholder
+// the caller swaps in so the wording matches whichever flow opened the
+// form.
+func populateFormFromJob(job protocol.CronJob) (cronForm, string) {
+	f := newCreateForm()
 	f.description.SetValue(job.Description)
 	f.cronExpr.SetValue(job.Schedule.Expr)
 	f.timezone.SetValue(job.Schedule.Tz)
@@ -909,12 +963,22 @@ func newEditForm(job protocol.CronJob) (cronForm, string) {
 
 	var unsupported string
 	if job.Schedule.Kind != "" && job.Schedule.Kind != "cron" {
-		unsupported = fmt.Sprintf("Edit not supported for schedule kind %q. Use the openclaw CLI.", job.Schedule.Kind)
+		unsupported = fmt.Sprintf("{action} not supported for schedule kind %q. Use the openclaw CLI.", job.Schedule.Kind)
 	}
 	if job.Payload.Kind != "" && job.Payload.Kind != "agentTurn" && unsupported == "" {
-		unsupported = fmt.Sprintf("Edit not supported for payload kind %q. Use the openclaw CLI.", job.Payload.Kind)
+		unsupported = fmt.Sprintf("{action} not supported for payload kind %q. Use the openclaw CLI.", job.Payload.Kind)
 	}
 	return f, unsupported
+}
+
+// duplicateName builds the cloned job's name. Empty names are passed
+// through so the form-level "name is required" validation catches the
+// case rather than producing a spurious "Copy of " placeholder.
+func duplicateName(original string) string {
+	if original == "" {
+		return ""
+	}
+	return "Copy of " + original
 }
 
 func (m cronsModel) handleFormKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -851,11 +851,14 @@ func hasTranscriptContent(job protocol.CronJob, runs []protocol.CronRunLogEntry)
 
 // cronPayloadText returns the human-authored prompt for an agentTurn
 // cron job, falling back across the union fields the gateway uses.
+// Message is the canonical field for agentTurn; Text remains as a
+// fallback for historical jobs (and is the canonical field for the
+// systemEvent kind, which the form does not surface).
 func cronPayloadText(job protocol.CronJob) string {
-	if t := strings.TrimSpace(job.Payload.Text); t != "" {
-		return t
+	if m := strings.TrimSpace(job.Payload.Message); m != "" {
+		return m
 	}
-	return strings.TrimSpace(job.Payload.Message)
+	return strings.TrimSpace(job.Payload.Text)
 }
 
 // -----------------------------------------------------------------------------
@@ -940,9 +943,13 @@ func populateFormFromJob(job protocol.CronJob) (cronForm, string) {
 	f.timezone.SetValue(job.Schedule.Tz)
 	f.agentID.SetValue(job.AgentID)
 	f.model.SetValue(job.Payload.Model)
-	f.payloadText.SetValue(job.Payload.Text)
+	// Prefer Message because it is the canonical agentTurn prompt field
+	// (the gateway schema only accepts `message` for that kind). Text is
+	// left as a fallback for any historical jobs that still carry the
+	// prompt in the systemEvent-style `text` field.
+	f.payloadText.SetValue(job.Payload.Message)
 	if f.payloadText.Value() == "" {
-		f.payloadText.SetValue(job.Payload.Message)
+		f.payloadText.SetValue(job.Payload.Text)
 	}
 	if job.SessionTarget != "" {
 		f.sessionTarget = job.SessionTarget
@@ -1117,6 +1124,10 @@ func (m cronsModel) submitForm() (cronsModel, tea.Cmd) {
 		m.form.err = fmt.Errorf("cron expression is required")
 		return m, nil
 	}
+	if m.form.payloadText.Value() == "" {
+		m.form.err = fmt.Errorf("payload text is required")
+		return m, nil
+	}
 	m.form.err = nil
 	m.form.saving = true
 	cron := m.cron
@@ -1150,9 +1161,13 @@ func buildAddParams(f cronForm) protocol.CronAddParams {
 			Tz:   f.timezone.Value(),
 		},
 		Payload: protocol.CronPayload{
-			Kind:  "agentTurn",
-			Text:  f.payloadText.Value(),
-			Model: f.model.Value(),
+			Kind: "agentTurn",
+			// agentTurn carries the prompt in `message`. The schema's
+			// `additionalProperties: false` rejects `text` (which is the
+			// systemEvent payload's prompt field), so use the wire-correct
+			// field for this kind.
+			Message: f.payloadText.Value(),
+			Model:   f.model.Value(),
 		},
 		Delivery: buildDelivery(f),
 	}
@@ -1182,9 +1197,11 @@ func buildJobPatchMap(f cronForm) map[string]any {
 			"tz":   f.timezone.Value(),
 		},
 		"payload": map[string]any{
-			"kind":  "agentTurn",
-			"text":  f.payloadText.Value(),
-			"model": f.model.Value(),
+			"kind": "agentTurn",
+			// See buildAddParams for the kind/field-name rationale: agentTurn
+			// schemas reject `text` outright, so we send `message`.
+			"message": f.payloadText.Value(),
+			"model":   f.model.Value(),
 		},
 		"agentId": f.agentID.Value(),
 		"enabled": f.enabled,
@@ -1251,7 +1268,7 @@ func (m cronsModel) viewList() string {
 	if m.err != nil {
 		var b strings.Builder
 		b.WriteString("\n")
-		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.err)))
+		b.WriteString(renderErrorLine(m.err.Error(), m.width))
 		b.WriteString("\n\n")
 		b.WriteString(hints)
 		b.WriteString("\n")
@@ -1327,10 +1344,7 @@ func (m cronsModel) viewDetail() string {
 	}
 	b.WriteString("\n")
 	b.WriteString("  Payload:\n")
-	payload := job.Payload.Text
-	if payload == "" {
-		payload = job.Payload.Message
-	}
+	payload := cronPayloadText(job)
 	if payload == "" {
 		payload = "—"
 	}
@@ -1345,7 +1359,7 @@ func (m cronsModel) viewDetail() string {
 	case m.runsLoading:
 		b.WriteString("  Loading...\n")
 	case m.runsErr != nil:
-		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.runsErr)))
+		b.WriteString(renderErrorLine(m.runsErr.Error(), m.width))
 		b.WriteString("\n")
 	case len(m.runs) == 0:
 		b.WriteString("  No run log entries yet.\n")
@@ -1372,7 +1386,8 @@ func (m cronsModel) viewForm() string {
 	b.WriteString("\n\n")
 
 	if m.form.unsupported != "" {
-		b.WriteString(errorStyle.Render("  " + m.form.unsupported))
+		wrapped := wordWrap("  "+m.form.unsupported, m.width)
+		b.WriteString(errorStyle.Render(indentMultiline(wrapped, "  ")))
 		b.WriteString("\n\n")
 	}
 
@@ -1404,7 +1419,7 @@ func (m cronsModel) viewForm() string {
 	}
 
 	if m.form.err != nil {
-		b.WriteString(errorStyle.Render(fmt.Sprintf("  Error: %v", m.form.err)))
+		b.WriteString(renderErrorLine(m.form.err.Error(), m.width))
 		b.WriteString("\n\n")
 	}
 	if m.form.saving {

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -349,6 +349,154 @@ func TestCronsForm_PrePopulatesModelAndDelivery(t *testing.T) {
 	}
 }
 
+func TestCronsDuplicate_FormPrePopulatesFromJob(t *testing.T) {
+	job := protocol.CronJob{
+		ID:            "job-1",
+		Name:          "Daily report",
+		Description:   "Generate today's report",
+		AgentID:       "agent-1",
+		Enabled:       true,
+		SessionTarget: "main",
+		WakeMode:      "now",
+		Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "0 9 * * *", Tz: "Europe/London"},
+		Payload:       protocol.CronPayload{Kind: "agentTurn", Text: "Generate report.", Model: "claude-opus-4-7"},
+		Delivery:      &protocol.CronDelivery{Mode: "announce", Channel: "slack:#alerts"},
+	}
+	form, banner := newDuplicateForm(job)
+	if banner != "" {
+		t.Fatalf("unexpected unsupported banner: %q", banner)
+	}
+	if form.mode != "create" {
+		t.Errorf("expected duplicate to stay in create mode, got %q", form.mode)
+	}
+	if form.editingID != "" {
+		t.Errorf("expected empty editingID so submit goes through CronAdd, got %q", form.editingID)
+	}
+	if got, want := form.name.Value(), "Copy of Daily report"; got != want {
+		t.Errorf("name: got %q, want %q", got, want)
+	}
+	if got := form.description.Value(); got != "Generate today's report" {
+		t.Errorf("description: %q", got)
+	}
+	if got := form.cronExpr.Value(); got != "0 9 * * *" {
+		t.Errorf("cronExpr: %q", got)
+	}
+	if got := form.timezone.Value(); got != "Europe/London" {
+		t.Errorf("timezone: %q", got)
+	}
+	if got := form.agentID.Value(); got != "agent-1" {
+		t.Errorf("agentID: %q", got)
+	}
+	if got := form.model.Value(); got != "claude-opus-4-7" {
+		t.Errorf("model: %q", got)
+	}
+	if got := form.payloadText.Value(); got != "Generate report." {
+		t.Errorf("payloadText: %q", got)
+	}
+	if form.sessionTarget != "main" {
+		t.Errorf("sessionTarget: %q", form.sessionTarget)
+	}
+	if form.wakeMode != "now" {
+		t.Errorf("wakeMode: %q", form.wakeMode)
+	}
+	if form.deliveryMode != "announce" {
+		t.Errorf("deliveryMode: %q", form.deliveryMode)
+	}
+	if got := form.deliveryTarget.Value(); got != "slack:#alerts" {
+		t.Errorf("deliveryTarget: %q", got)
+	}
+	if !form.enabled {
+		t.Error("enabled should be carried over")
+	}
+}
+
+func TestCronsDuplicate_RefusesUnsupportedScheduleKind(t *testing.T) {
+	job := protocol.CronJob{
+		ID:       "weird",
+		Name:     "Weird",
+		AgentID:  "agent-1",
+		Enabled:  true,
+		Schedule: protocol.CronSchedule{Kind: "every"},
+		Payload:  protocol.CronPayload{Kind: "agentTurn", Text: "X"},
+	}
+	_, banner := newDuplicateForm(job)
+	if banner == "" {
+		t.Fatal("expected unsupported banner for schedule.kind=every")
+	}
+	if !strings.Contains(banner, "Duplicate") {
+		t.Errorf("expected banner to mention Duplicate, got %q", banner)
+	}
+}
+
+func TestCronsKey_D_FromList_OpensDuplicateForm(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if m.subset != cronSubForm {
+		t.Fatalf("expected substate=form after d, got %v", m.subset)
+	}
+	if m.form.mode != "create" {
+		t.Errorf("expected create mode for duplicate, got %q", m.form.mode)
+	}
+	if m.form.editingID != "" {
+		t.Errorf("expected empty editingID, got %q", m.form.editingID)
+	}
+	if got := m.form.name.Value(); got != "Copy of Daily report" {
+		t.Errorf("name: %q", got)
+	}
+}
+
+func TestCronsDuplicate_SubmitDispatchesCronAdd(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if m.subset != cronSubForm {
+		t.Fatalf("expected form substate, got %v", m.subset)
+	}
+	_, cmd := m.submitForm()
+	if cmd == nil {
+		t.Fatal("expected a save cmd")
+	}
+	cmd()
+
+	if fake.lastCronAdd == nil {
+		t.Fatal("expected CronAdd to be invoked")
+	}
+	if fake.lastCronUpdateID != "" || fake.lastCronUpdateRaw != nil {
+		t.Errorf("expected duplicate to bypass CronUpdate path, got id=%q raw=%+v",
+			fake.lastCronUpdateID, fake.lastCronUpdateRaw)
+	}
+	if fake.lastCronAdd.Name != "Copy of Daily report" {
+		t.Errorf("CronAdd.Name: %q", fake.lastCronAdd.Name)
+	}
+	if fake.lastCronAdd.Schedule.Expr != "0 9 * * *" {
+		t.Errorf("CronAdd.Schedule.Expr: %q", fake.lastCronAdd.Schedule.Expr)
+	}
+}
+
+func TestCronsDuplicate_EscFromFormReturnsToList(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if m.subset != cronSubForm {
+		t.Fatalf("expected form substate, got %v", m.subset)
+	}
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.subset != cronSubList {
+		t.Errorf("expected esc from duplicate form to return to list, got %v", m.subset)
+	}
+}
+
+func TestCronsListActions_DuplicateHiddenWhenEmpty(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: nil})
+	for _, a := range m.Actions() {
+		if a.ID == "duplicate" {
+			t.Fatalf("duplicate action should be hidden when list is empty; got %+v", a)
+		}
+	}
+}
+
 func TestCronsConfirmDelete_YesDispatchesRemove(t *testing.T) {
 	m, fake := newTestCronsModel(t)
 	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/a3tai/openclaw-go/protocol"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func newTestCronsModel(t *testing.T) (cronsModel, *fakeBackend) {
@@ -206,8 +207,13 @@ func TestCronsForm_BuildsCronAddParams(t *testing.T) {
 	if params.Schedule.Kind != "cron" || params.Schedule.Expr != "0 9 * * *" || params.Schedule.Tz != "Europe/London" {
 		t.Errorf("Schedule: %+v", params.Schedule)
 	}
-	if params.Payload.Kind != "agentTurn" || params.Payload.Text != "Please generate today's report." {
+	if params.Payload.Kind != "agentTurn" || params.Payload.Message != "Please generate today's report." {
 		t.Errorf("Payload: %+v", params.Payload)
+	}
+	// agentTurn schemas reject `text` (additionalProperties=false), so the
+	// prompt must travel as `message` and `text` must remain empty.
+	if params.Payload.Text != "" {
+		t.Errorf("Payload.Text should be empty for agentTurn, got %q", params.Payload.Text)
 	}
 	if params.Payload.Model != "claude-opus-4-7" {
 		t.Errorf("Payload.Model: %q", params.Payload.Model)
@@ -484,6 +490,96 @@ func TestCronsDuplicate_EscFromFormReturnsToList(t *testing.T) {
 	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.subset != cronSubList {
 		t.Errorf("expected esc from duplicate form to return to list, got %v", m.subset)
+	}
+}
+
+func TestCronsForm_AgentTurnPayloadUsesMessageNotText(t *testing.T) {
+	// Regression: agentTurn schema requires `message` and rejects `text`
+	// (additionalProperties=false). buildAddParams and buildJobPatchMap
+	// must put the prompt in message.
+	f := newCreateForm()
+	f.name.SetValue("Daily report")
+	f.cronExpr.SetValue("0 9 * * *")
+	f.payloadText.SetValue("Generate today's report.")
+
+	params := buildAddParams(f)
+	if params.Payload.Message != "Generate today's report." {
+		t.Errorf("CronAdd Payload.Message: got %q, want %q",
+			params.Payload.Message, "Generate today's report.")
+	}
+	if params.Payload.Text != "" {
+		t.Errorf("CronAdd Payload.Text should be empty for agentTurn, got %q",
+			params.Payload.Text)
+	}
+
+	f.editingID = "job-1"
+	f.mode = "edit"
+	patch := buildJobPatchMap(f)
+	payload := patch["payload"].(map[string]any)
+	if payload["message"] != "Generate today's report." {
+		t.Errorf("patch payload.message: got %#v", payload["message"])
+	}
+	if _, present := payload["text"]; present {
+		t.Errorf("patch payload should not include `text` for agentTurn, got %#v", payload)
+	}
+}
+
+func TestCronsForm_PrePopulatesFromMessageField(t *testing.T) {
+	// Jobs created via gateway/CLI carry the agentTurn prompt in
+	// Payload.Message — the form must pick that up so duplicate/edit
+	// don't show an empty payload field.
+	job := protocol.CronJob{
+		ID:            "job-1",
+		Name:          "Daily",
+		AgentID:       "agent-1",
+		Enabled:       true,
+		SessionTarget: "isolated",
+		WakeMode:      "now",
+		Schedule:      protocol.CronSchedule{Kind: "cron", Expr: "0 9 * * *"},
+		Payload:       protocol.CronPayload{Kind: "agentTurn", Message: "from gateway"},
+	}
+	form, _ := newDuplicateForm(job)
+	if got := form.payloadText.Value(); got != "from gateway" {
+		t.Errorf("payloadText: got %q, want %q", got, "from gateway")
+	}
+}
+
+func TestCronsForm_RefusesEmptyPayload(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleListKey(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m.form.payloadText.SetValue("")
+
+	m, cmd := m.submitForm()
+	if cmd != nil {
+		t.Fatal("expected submit to be refused with empty payload")
+	}
+	if m.form.err == nil || !strings.Contains(m.form.err.Error(), "payload") {
+		t.Errorf("expected payload-required error, got %v", m.form.err)
+	}
+	if fake.lastCronAdd != nil {
+		t.Errorf("CronAdd should not have been invoked, got %+v", fake.lastCronAdd)
+	}
+}
+
+func TestRenderErrorLine_WrapsLongMessage(t *testing.T) {
+	long := "cron.add: INVALID_REQUEST: invalid cron.add params: at /payload: must have required property 'text'; at /payload/kind: must be equal to constant"
+	out := renderErrorLine(long, 60)
+	for _, line := range strings.Split(out, "\n") {
+		stripped := ansi.Strip(line)
+		if len(stripped) > 60 {
+			t.Errorf("line exceeded width 60 (len=%d): %q", len(stripped), stripped)
+		}
+	}
+	if !strings.Contains(out, "Error:") {
+		t.Errorf("expected Error: prefix, got %q", out)
+	}
+}
+
+func TestRenderErrorLine_ZeroWidthPassesThrough(t *testing.T) {
+	out := renderErrorLine("boom", 0)
+	if !strings.Contains(out, "Error: boom") {
+		t.Errorf("expected unwrapped output to contain 'Error: boom', got %q", out)
 	}
 }
 

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -257,6 +257,23 @@ func wordWrap(s string, width int) string {
 	return b.String()
 }
 
+// renderErrorLine formats an error message as a single styled paragraph
+// that wraps cleanly within the given viewport width. The "  Error: "
+// prefix is included and continuation lines are indented to match, so
+// long gateway error strings (like the JSON-schema validator's
+// multi-clause messages) don't run off the side of the terminal.
+//
+// Pass width=0 to disable wrapping (useful when the caller doesn't have
+// a width to hand, e.g. in fixed-width contexts).
+func renderErrorLine(msg string, width int) string {
+	const prefix = "  Error: "
+	body := prefix + msg
+	if width > 0 {
+		body = indentMultiline(wordWrap(body, width), "  ")
+	}
+	return errorStyle.Render(body)
+}
+
 // indentMultiline indents every line after the first by the given prefix.
 func indentMultiline(s, indent string) string {
 	if indent == "" || !strings.Contains(s, "\n") {


### PR DESCRIPTION
Add the ability to duplicate an existing cron job from the list, opening the same form as the create flow with every modelled field pre-populated from the source job.

## Summary

- Press `d` on a highlighted entry in the cron browser list to open the create form pre-filled from that job — name is prefixed with `Copy of ` so the duplicate is distinguishable; schedule, timezone, agent, model, payload, session/wake, delivery and enabled all carry over verbatim.
- Form stays in `mode=create` with `editingID=""` so submission goes through `CronAdd` and produces a brand-new job rather than mutating the source.
- Refused with the same banner the edit flow shows when the source job has a non-`cron` schedule kind or non-`agentTurn` payload kind, so we don't silently truncate union fields the TUI does not model.

## Implementation details

`newEditForm` and the new `newDuplicateForm` now share `populateFormFromJob`, so the two flows can't drift in which fields they carry over. The unsupported-kind banner uses an `{action}` placeholder the caller swaps in (`Edit` / `Duplicate`) so the wording matches the flow that opened the form. The duplicate action lives on the list substate (not detail) because that's where the user identifies which job they want to clone before any drill-down.