### PR TITLE
fix(tui): improve cron detail UX for run-now and transcript

### DIFF
--- a/docs/crons.md
+++ b/docs/crons.md
@@ -57,7 +57,9 @@ The list view loads on `Init()` via `loadJobs()`, which calls `CronsList(Enabled
 - Next run, Last run (with status), Payload body
 - Run history table
 
-Actions: `R` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open a read-only transcript reconstructed from the run log (see [Transcript view](#transcript-view)), `r` refresh, `esc` back to list.
+Actions: `!` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open a read-only transcript reconstructed from the run log (see [Transcript view](#transcript-view)), `r` refresh, `esc` back to list.
+
+Run-now is bound to `!` rather than the more obvious `R` because the case-sensitive pair (`R` run vs. `r` refresh) was a misfire trap on terminals that don't preserve shift on letter keys. The detail view renders a transient `Triggering run...` banner the moment `!` fires, replaced by `Run triggered.` (or `Run failed: <err>`) once `cronJobRanMsg` arrives — a `running` flag on `cronsModel` gates duplicate keystrokes while the request is in flight.
 
 ### Transcript view
 
@@ -66,6 +68,8 @@ Actions: `R` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm subst
 The builder walks `m.runs` (newest-first as returned by `cron.runs sortDir=desc`) in reverse and emits, per run: a separator with `RunAtMs`, a user turn with the cron's `payload.Text` / `payload.Message`, and either an assistant turn with `Summary` (Glamour-rendered when it looks like markdown) or an `errMsg` assistant turn with `Error`. Repeating the payload per run is intentional — each run is an independent invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
 
 The action itself is gated by `hasTranscriptContent`: if no run carries a `Summary` or `Error`, the `T` entry is suppressed from `Actions()` so it doesn't dangle on jobs with nothing to show.
+
+The transcript chat view sets `chatModel.transcript = true`. With no input box to consume it, `Esc` would otherwise be a no-op, so the chat key handler emits `goBackFromCronTranscriptMsg` when the flag is set; `AppModel` switches state back to `viewCrons`, where `cronsModel.subset`/`selectedID` are preserved across the transcript hop, so the user lands back on the originating detail page.
 
 ## Form substate
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -634,8 +634,13 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.chatModel.setSize(m.width, m.height)
 		m.chatModel.messages = buildCronTranscriptMessages(cronPayloadText(msg.job), msg.runs, m.chatModel.renderer)
 		m.chatModel.historyLoading = false
+		m.chatModel.transcript = true
 		m.chatModel.updateViewport()
 		m.state = viewChat
+		return m, nil
+
+	case goBackFromCronTranscriptMsg:
+		m.state = viewCrons
 		return m, nil
 
 	case newSessionCreatedMsg:

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -176,6 +176,7 @@ type chatModel struct {
 	thinkingLevel   string // current thinking level; "" means not set / using gateway default
 	connState       ConnStateMsg
 	hideInput       bool   // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
+	transcript      bool   // true when the model is rendering a cron run-log transcript: read-only, esc returns to the cron detail view that opened it
 	terminalFocused bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
 	updateLatest    string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
 }
@@ -579,6 +580,9 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		case "esc":
 			if m.sending {
 				return m, m.cancelTurn()
+			}
+			if m.transcript {
+				return m, func() tea.Msg { return goBackFromCronTranscriptMsg{} }
 			}
 			return m, nil
 		case "tab":

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -318,6 +318,34 @@ func TestChatModel_NoInitialMessage_NoDrain(t *testing.T) {
 	}
 }
 
+func TestChatModel_TranscriptEsc_ReturnsToCronDetail(t *testing.T) {
+	fb := newFakeBackend()
+	m := newChatModel(fb, "", "agent-id", "agent-id", "", config.DefaultPreferences(), true, "", "", false)
+	m.transcript = true
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected esc on transcript chat to emit a back cmd")
+	}
+	if _, ok := cmd().(goBackFromCronTranscriptMsg); !ok {
+		t.Errorf("expected goBackFromCronTranscriptMsg, got %T", cmd())
+	}
+}
+
+func TestChatModel_NonTranscriptEsc_DoesNothingWhenIdle(t *testing.T) {
+	fb := newFakeBackend()
+	m := newChatModel(fb, "session-key", "agent-id", "agent-id", "", config.DefaultPreferences(), false, "", "", false)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd != nil {
+		// A regular chat must not bubble a back signal on esc — that path
+		// is reserved for the transcript-mode model.
+		if _, ok := cmd().(goBackFromCronTranscriptMsg); ok {
+			t.Errorf("non-transcript esc must not emit goBackFromCronTranscriptMsg")
+		}
+	}
+}
+
 // TestNewChatModel_DefaultCursorMatchesBubblesPalette guards the
 // default branch of the gate: when the embedder hasn't asked for a
 // bright cursor (the desktop CLI case), the textarea is left on

--- a/internal/tui/crons.go
+++ b/internal/tui/crons.go
@@ -256,6 +256,16 @@ type cronsModel struct {
 	runs        []protocol.CronRunLogEntry
 	runsLoading bool
 	runsErr     error
+	// running is set the moment "Run now" is triggered and cleared when
+	// the gateway acknowledges. It exists so the detail view can render
+	// a "triggering..." banner immediately, before the round-trip
+	// completes — without it the user has no signal the keystroke landed.
+	running bool
+	// runStatus is a transient one-line ack rendered in the detail view
+	// after cronJobRanMsg arrives ("Run triggered." / error). It is
+	// cleared on the next refresh / navigation.
+	runStatus string
+	runFailed bool
 
 	// Form substate.
 	form cronForm
@@ -426,10 +436,14 @@ func (m cronsModel) Update(msg tea.Msg) (cronsModel, tea.Cmd) {
 		return m, m.loadJobs()
 
 	case cronJobRanMsg:
+		m.running = false
 		if msg.err != nil {
-			m.err = msg.err
+			m.runFailed = true
+			m.runStatus = fmt.Sprintf("Run failed: %v", msg.err)
 			return m, nil
 		}
+		m.runFailed = false
+		m.runStatus = "Run triggered."
 		m.runsLoading = true
 		var refreshRuns tea.Cmd
 		if m.selectedID != "" {
@@ -506,6 +520,9 @@ func (m cronsModel) handleListKey(msg tea.KeyPressMsg) (cronsModel, tea.Cmd) {
 		m.runs = nil
 		m.runsErr = nil
 		m.runsLoading = true
+		m.runStatus = ""
+		m.runFailed = false
+		m.running = false
 		return m, m.loadRuns(item.job.ID)
 	}
 	for _, a := range m.Actions() {
@@ -595,7 +612,11 @@ func (m cronsModel) detailActions() []Action {
 	job, ok := m.findJob(m.selectedID)
 	var actions []Action
 	if ok {
-		actions = append(actions, Action{ID: "run", Label: "Run now", Key: "R"})
+		// Bound to "!" rather than "R" because the case-sensitive pair
+		// (R=run, r=refresh) was easy to misfire — terminals that
+		// don't report shift on letter keys would land on refresh
+		// when the user expected run.
+		actions = append(actions, Action{ID: "run", Label: "Run now", Key: "!"})
 		toggleLabel := "Disable"
 		if !job.Enabled {
 			toggleLabel = "Enable"
@@ -683,6 +704,8 @@ func (m cronsModel) actionRefresh() (cronsModel, tea.Cmd) {
 		}
 		m.runsLoading = true
 		m.loading = true
+		m.runStatus = ""
+		m.runFailed = false
 		return m, tea.Batch(m.loadJobs(), m.loadRuns(m.selectedID))
 	}
 	return m, nil
@@ -693,6 +716,15 @@ func (m cronsModel) actionRun() (cronsModel, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	if m.running {
+		// Swallow repeat presses while the previous trigger is still
+		// in flight — otherwise the gateway would receive duplicate
+		// run-now requests for a single keystroke burst.
+		return m, nil
+	}
+	m.running = true
+	m.runStatus = ""
+	m.runFailed = false
 	cron := m.cron
 	id := job.ID
 	return m, func() tea.Msg {
@@ -1202,6 +1234,18 @@ func (m cronsModel) viewDetail() string {
 		b.WriteString(cronStatusDisabledStyle.Render("disabled"))
 	}
 	b.WriteString("\n\n")
+
+	switch {
+	case m.running:
+		b.WriteString(statusStyle.Render("  Triggering run..."))
+		b.WriteString("\n\n")
+	case m.runFailed && m.runStatus != "":
+		b.WriteString(errorStyle.Render("  " + m.runStatus))
+		b.WriteString("\n\n")
+	case m.runStatus != "":
+		b.WriteString(statusStyle.Render("  " + m.runStatus))
+		b.WriteString("\n\n")
+	}
 
 	rows := [][2]string{
 		{"Schedule", formatSchedule(job.Schedule)},

--- a/internal/tui/crons_test.go
+++ b/internal/tui/crons_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -420,6 +421,85 @@ func TestCronsTranscript_DispatchesRunLogContent(t *testing.T) {
 	}
 	if len(sel.runs) != 2 {
 		t.Errorf("expected 2 runs forwarded, got %d", len(sel.runs))
+	}
+}
+
+func TestCronsRunNow_KeyTriggersRunAndAcknowledges(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.subset != cronSubDetail {
+		t.Fatal("setup: expected detail substate")
+	}
+
+	// "!" is the unambiguous run-now binding (replaced "R" to avoid the
+	// case-collision with refresh).
+	m, cmd := m.handleKey(tea.KeyPressMsg{Code: '!', Text: "!"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from !")
+	}
+	if !m.running {
+		t.Error("expected m.running=true while the run-now request is in flight")
+	}
+	view := m.View()
+	if !strings.Contains(view, "Triggering run...") {
+		t.Errorf("expected detail view to show Triggering banner, got:\n%s", view)
+	}
+
+	msg := cmd()
+	if _, ok := msg.(cronJobRanMsg); !ok {
+		t.Fatalf("expected cronJobRanMsg, got %T", msg)
+	}
+	if fake.lastCronRunID != "job-1" {
+		t.Errorf("expected CronRun on job-1, got %q", fake.lastCronRunID)
+	}
+
+	m, _ = m.Update(cronJobRanMsg{})
+	if m.running {
+		t.Error("expected m.running=false after ack")
+	}
+	if m.runStatus != "Run triggered." {
+		t.Errorf("expected runStatus ack, got %q", m.runStatus)
+	}
+	view = m.View()
+	if !strings.Contains(view, "Run triggered.") {
+		t.Errorf("expected detail view to show ack, got:\n%s", view)
+	}
+}
+
+func TestCronsRunNow_LowercaseRStillTriggersRefresh(t *testing.T) {
+	m, fake := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	// Drain the initial loadRuns so we can detect the refresh-triggered one.
+	m, _ = m.Update(cronRunsLoadedMsg{jobID: "job-1"})
+	fake.lastCronRunID = ""
+
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from r (refresh)")
+	}
+	if fake.lastCronRunID != "" {
+		t.Errorf("lowercase r must not trigger CronRun, got %q", fake.lastCronRunID)
+	}
+}
+
+func TestCronsRunNow_AckClearedOnNavigation(t *testing.T) {
+	m, _ := newTestCronsModel(t)
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: '!', Text: "!"})
+	m, _ = m.Update(cronJobRanMsg{})
+	if m.runStatus == "" {
+		t.Fatal("setup: expected runStatus to be set")
+	}
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	// The ack handler sets loading=true to drive a refresh; let that
+	// settle so the list's enter handler isn't gated on loading.
+	m, _ = m.Update(cronsLoadedMsg{jobs: sampleJobs()})
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.runStatus != "" {
+		t.Errorf("expected runStatus cleared on re-entering detail, got %q", m.runStatus)
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -315,6 +315,13 @@ type showCronsMsg struct {
 // goBackFromCronsMsg signals the AppModel to return from the cron view.
 type goBackFromCronsMsg struct{}
 
+// goBackFromCronTranscriptMsg signals the AppModel to return from the
+// read-only cron transcript view (a chat model with transcript=true)
+// to the cron detail screen that opened it. The cronsModel's subset/
+// selectedID is preserved across the transcript hop, so resuming
+// viewCrons drops back into the right detail page.
+type goBackFromCronTranscriptMsg struct{}
+
 // cronsLoadedMsg is returned when the cron job list is fetched.
 type cronsLoadedMsg struct {
 	jobs []protocol.CronJob


### PR DESCRIPTION
Tighten two confusing keybindings on the cron browser's detail and transcript views.

## Summary
- Rebind "Run now" from `R` to `!` so it no longer collides with the case-sensitive `r` (refresh) on terminals that don't preserve shift on letter keys.
- Show a transient "Triggering run..." banner in the cron detail view as soon as run-now is requested, replaced by "Run triggered." (or an error) once the gateway acknowledges, so the user has immediate feedback.
- Esc on the read-only cron transcript view now returns to the originating cron detail screen instead of being a no-op.

## Implementation details
- Repeat run-now presses while a request is in flight are swallowed to avoid duplicate gateway calls. The ack is cleared on navigation or refresh so it doesn't go stale.
- Transcript-mode is marked with a new `transcript` flag on `chatModel`; AppModel sets it when handling `cronTranscriptMsg` and routes the new `goBackFromCronTranscriptMsg` back to `viewCrons`. The cron model's subset/`selectedID` are preserved across the transcript hop, so the user lands on the exact detail page they came from.