### PR TITLE
feat(tui): show slash-command menu and extend Tab to longest common prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ In the config view, use `Space` to toggle checkboxes and `←`/`→` to adjust n
 
 ## Commands
 
-Type these in the chat input. As soon as you type `/`, a menu shows every matching command and skill. Tab extends the input to the longest common prefix; press it again at the prefix to cycle through candidates (Shift+Tab to cycle back). After `/agent ` Tab still completes the agent name inline.
+Type these in the chat input. As soon as you type `/`, a menu shows every matching command and skill. Tab extends the input to the longest common prefix; press it again at the prefix to cycle through candidates (Shift+Tab to cycle back). The same menu and Tab cycling apply to agent names after `/agent `.
 
 | Command | Action |
 |---------|--------|

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Select an agent from the list to start chatting.
 | `Alt+Enter` | Insert newline |
 | `Ctrl+W` | Delete word |
 | `PgUp` / `PgDn` | Scroll chat history |
-| `Tab` | Autocomplete slash command |
+| `Tab` | Show slash-command menu, extend to common prefix, then cycle |
+| `Shift+Tab` | Cycle backward through matches |
 | `Esc` | Back to agent list |
 | `Ctrl+C` | Quit |
 
@@ -142,7 +143,7 @@ In the config view, use `Space` to toggle checkboxes and `←`/`→` to adjust n
 
 ## Commands
 
-Type these in the chat input. Tab autocompletes partial commands; after `/agent ` Tab also completes the agent name.
+Type these in the chat input. As soon as you type `/`, a menu shows every matching command and skill. Tab extends the input to the longest common prefix; press it again at the prefix to cycle through candidates (Shift+Tab to cycle back). After `/agent ` Tab still completes the agent name inline.
 
 | Command | Action |
 |---------|--------|

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -8,7 +8,8 @@
 | Alt+Enter | Insert newline |
 | Ctrl+W | Delete word backward |
 | Up arrow (empty input) | Recall last sent message for editing |
-| Tab | Complete slash command or skill name |
+| Tab | Open slash menu, extend to longest common prefix, then cycle |
+| Shift+Tab | Cycle backward through slash-menu candidates |
 | Page Up / Page Down | Scroll message history |
 | Esc | Cancel in-progress response |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,27 +50,34 @@ Stats are loaded asynchronously via `client.SessionUsage()` on chat init and aft
 
 ## Tab completion
 
-A live menu (rendered between the conversation viewport and the input) appears as soon as the cursor sits at the end of a slash token with at least one matching candidate. Built-ins from the static `slashCommands` slice come first in their curated order, followed by skill names; `matchingSlashCommands(prefix)` (`completion.go`) builds the deduped, ordered list of every prefix match.
+A live menu (rendered between the conversation viewport and the input) appears as soon as the cursor sits at the end of a completable token with at least one matching candidate. Two sources feed the same menu and the same Tab/Shift+Tab semantics:
 
-Tab applies bash-style menu-complete semantics from `handleSlashTab(value, start, cursorByte, prefix)`:
+- **Slash commands and skills** — `matchingSlashCommands(prefix)` (`completion.go`) returns built-ins from the static `slashCommands` slice in their curated order, followed by skill names. Source detection: `findSlashTokenAt(value, cursorByte)`.
+- **Agent names** — the argument of `/agent <name>`. `matchingAgentNames(prefix)` returns every loaded agent whose lowercased form has the prefix as a prefix, preserving each agent's original casing. Source detection: `findAgentArgAt(value, cursorByte)`, which treats the entire tail of the line after `/agent ` as the token (so names with spaces complete in one shot).
+
+`completionAtCursor()` resolves the active source — slash commands take priority — and returns a `completionContext{start, cursorByte, prefix, candidates}`. The Tab handler dispatches a single `handleCompletionTab(ctx)` over this context, applying bash-style menu-complete semantics:
 
 - One match → full completion in place.
-- Multiple matches with a longest common prefix beyond what the user typed → the input is extended up to that LCP. `longestCommonPrefix(strs)` (`completion.go`) computes it byte-wise (callers pass already-lowercased candidates).
+- Multiple matches with a longest common prefix beyond what the user typed → the input is extended up to that LCP. `longestCommonPrefixFold(strs)` computes a case-insensitive LCP using the first candidate's casing — agent names like `Main` and `Mail` collapse to `Mai`, slash candidates (already lowercase) behave identically to the byte-wise variant.
 - Multiple matches at the LCP → enter cycle mode. The first Tab snapshots the candidate list into `m.completion.cycleCandidates`, sets `cycleIndex = 0`, and replaces the input with the first candidate. Subsequent Tab presses advance the index modulo the snapshot length; Shift+Tab decrements with the same wraparound. The snapshot persists across presses because Tab returns early before `refreshCompletionMenu` runs.
 
-Any non-Tab keystroke routes through `refreshCompletionMenu`, which clears `cycling` and recomputes `candidates` from the current textarea contents. The menu auto-hides when `findSlashTokenAt` fails (whitespace breaks the token, the input is cleared, or the message is sent — `Reset()` calls in the Enter handler explicitly invoke `refreshCompletionMenu` so the menu doesn't outlive the input).
+Any non-Tab keystroke routes through `refreshCompletionMenu`, which clears `cycling` and recomputes `candidates` from the current textarea contents via `completionAtCursor()`. The menu auto-hides when no source applies (whitespace breaks a slash token, cursor leaves end-of-line in the agent-arg context, the input is cleared, or the message is sent — `Reset()` calls in the Enter handler explicitly invoke `refreshCompletionMenu` so the menu doesn't outlive the input).
 
 The curated order in `slashCommands` (e.g. `/agents` before `/agent`, `/model` before `/models`) now only breaks ties for the inline ghost-hint and the legacy `completeSlashCommand` callers — Tab uses LCP, so the order no longer steers it.
 
-The Tab handler operates on the slash token at the cursor, not just at the start of input, so completion works mid-message and within multi-line input. `findSlashTokenAt(value, cursorByte)` walks back from the cursor to a `/` that is at the start of input or preceded by whitespace, requiring the cursor to sit at the end of the token (next character is whitespace or EOF). `setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted completion.
+`setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted text.
+
+### Inline ghost-hint fallback
+
+`slashCommandHint` and `agentNameHint` still drive a single-line greyed-out hint in the help bar — but only as a fallback for short terminals where the menu can't render. With the menu visible, the help line switches to `Tab: extend · Shift+Tab: back · N matches`.
 
 ### Layout
 
 `chatModel.baseViewportHeight` records the viewport height with the menu hidden; `applyLayout()` shrinks the viewport by `menuRowsToRender()` whenever menu state changes, so the conversation pane reflows cleanly. The menu suppresses itself entirely when the baseline cannot leave at least `completionMenuViewportFloor` rows for the conversation — Tab still does LCP extension on the underlying state. Candidate counts above `completionMenuMaxRows` collapse the tail into a `+N more` line.
 
-### Agent name completion
+### Agent name source
 
-After `/agent ` the next token is treated as an agent name and completed against the cached agent list. The chat model fetches the list once on init via `loadAgentNames()` and stores display names in `m.agentNames`; completion silently degrades to no-op if the list hasn't loaded yet or the backend errored. `findAgentArgAt(value, cursorByte)` recognises the argument context only when the cursor sits at end-of-line and the line begins with `/agent ` (single space); the entire tail of the line is the token, so agent names containing spaces are completed in one shot. `completeAgentName` does a case-insensitive prefix match — empty prefix completes to the first known agent. `agentNameHint` mirrors `slashCommandHint` and feeds the same greyed-out hint renderer.
+The chat model fetches the agent list once on init via `loadAgentNames()` and stores display names in `m.agentNames`; completion silently degrades to a no-op when the list hasn't loaded yet or the backend errored (`matchingAgentNames` returns nil, so `completionAtCursor` reports an empty candidate list and the menu stays hidden). `findAgentArgAt` recognises the argument context only when the cursor sits at end-of-line and the line begins with `/agent ` (single space). Empty prefix matches every agent — Tab on `/agent ` opens the menu listing the full roster, with the LCP/cycle flow taking over from there.
 
 ## Confirmation pattern
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,9 +50,23 @@ Stats are loaded asynchronously via `client.SessionUsage()` on chat init and aft
 
 ## Tab completion
 
-`completeSlashCommand(prefix)` iterates the static `slashCommands` slice and then the loaded skill names. The first prefix match wins. Order in `slashCommands` is significant where one command is a prefix of another: `/agents` is listed before `/agent` and `/model` before `/models` so that tab-completing `/age` and `/mod` resolves to the longer-established command — extending a completion by one character is cheaper than backspacing.
+A live menu (rendered between the conversation viewport and the input) appears as soon as the cursor sits at the end of a slash token with at least one matching candidate. Built-ins from the static `slashCommands` slice come first in their curated order, followed by skill names; `matchingSlashCommands(prefix)` (`completion.go`) builds the deduped, ordered list of every prefix match.
 
-The Tab handler (`chat.go`) operates on the slash token at the cursor — not just at the start of input — so completion works mid-message and within multi-line input. `findSlashTokenAt(value, cursorByte)` walks back from the cursor to a `/` that is at the start of input or preceded by whitespace, requiring the cursor to sit at the end of the token (next character is whitespace or EOF). `setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted completion. `slashCommandHint(value, cursorByte)` returns the typed prefix and the suffix shown greyed-out in the input bar.
+Tab applies bash-style menu-complete semantics from `handleSlashTab(value, start, cursorByte, prefix)`:
+
+- One match → full completion in place.
+- Multiple matches with a longest common prefix beyond what the user typed → the input is extended up to that LCP. `longestCommonPrefix(strs)` (`completion.go`) computes it byte-wise (callers pass already-lowercased candidates).
+- Multiple matches at the LCP → enter cycle mode. The first Tab snapshots the candidate list into `m.completion.cycleCandidates`, sets `cycleIndex = 0`, and replaces the input with the first candidate. Subsequent Tab presses advance the index modulo the snapshot length; Shift+Tab decrements with the same wraparound. The snapshot persists across presses because Tab returns early before `refreshCompletionMenu` runs.
+
+Any non-Tab keystroke routes through `refreshCompletionMenu`, which clears `cycling` and recomputes `candidates` from the current textarea contents. The menu auto-hides when `findSlashTokenAt` fails (whitespace breaks the token, the input is cleared, or the message is sent — `Reset()` calls in the Enter handler explicitly invoke `refreshCompletionMenu` so the menu doesn't outlive the input).
+
+The curated order in `slashCommands` (e.g. `/agents` before `/agent`, `/model` before `/models`) now only breaks ties for the inline ghost-hint and the legacy `completeSlashCommand` callers — Tab uses LCP, so the order no longer steers it.
+
+The Tab handler operates on the slash token at the cursor, not just at the start of input, so completion works mid-message and within multi-line input. `findSlashTokenAt(value, cursorByte)` walks back from the cursor to a `/` that is at the start of input or preceded by whitespace, requiring the cursor to sit at the end of the token (next character is whitespace or EOF). `setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted completion.
+
+### Layout
+
+`chatModel.baseViewportHeight` records the viewport height with the menu hidden; `applyLayout()` shrinks the viewport by `menuRowsToRender()` whenever menu state changes, so the conversation pane reflows cleanly. The menu suppresses itself entirely when the baseline cannot leave at least `completionMenuViewportFloor` rows for the conversation — Tab still does LCP extension on the underlying state. Candidate counts above `completionMenuMaxRows` collapse the tail into a `+N more` line.
 
 ### Agent name completion
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -72,9 +72,9 @@ The visible chat row shows the user-typed text. On history reload the rendered t
 
 ### Tab completion
 
-`completeSlashCommand(prefix)` matches built-in commands and skill names by prefix. The Tab handler in `chat.go` works on the slash token under the cursor — not just at the start of input — so `use /rev<TAB>` completes to `use /review`. `findSlashTokenAt(value, cursorByte)` (`commands.go`) locates the token and `setTextareaToValueWithCursor` performs the in-place replacement, repositioning the cursor at the end of the inserted completion.
+Skill names participate in the same completion menu as built-in slash commands. `matchingSlashCommands(prefix)` (`completion.go`) returns every match for the current prefix — built-ins in curated order, then skills — and the menu rendered between the viewport and input lists them all. Tab extends the input to the longest common prefix; if multiple skills share a prefix, repeated Tab cycles them (Shift+Tab cycles back). Mid-message completion still works: `use /rev<TAB>` resolves the slash token under the cursor regardless of position. See [commands.md → Tab completion](commands.md#tab-completion) for the cycle/LCP machinery.
 
-Completion only fires when the cursor sits at the end of the slash token (next character is whitespace or end-of-buffer); inserting mid-token would clobber the trailing characters.
+Completion only fires when the cursor sits at the end of the slash token (next character is whitespace or end-of-buffer); inserting mid-token would clobber the trailing characters and `findSlashTokenAt` returns ok=false.
 
 ## UI commands
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -147,38 +147,40 @@ const spinnerInterval = 120 * time.Millisecond
 
 // chatModel is the chat view.
 type chatModel struct {
-	viewport        viewport.Model
-	textarea        textarea.Model
-	messages        []chatMessage
-	backend         backend.Backend
-	connName        string // active connection name, rendered in the header bar
-	sessionKey      string
-	agentID         string
-	agentName       string
-	sending         bool
-	runID           string // active run ID for cancellation
-	pendingMessages []string
-	width           int
-	height          int
-	renderer        *glamour.TermRenderer
-	stats           *sessionStats
-	modelID         string
-	promptTokens    int // input + cache read + cache write for the latest turn (a per-session snapshot, not cumulative); 0 until first sessions.list refresh
-	contextWindow   int // model context capacity for the active session; 0 when unknown
-	skills          []agentSkill
-	agentNames      []string // populated asynchronously by loadAgentNames; powers /agent <TAB> completion
-	spinnerFrame    int
-	spinnerTicking  bool
-	prefs           config.Preferences
-	pendingConfirm  *pendingConfirmation
-	historyLimit    int
-	historyLoading  bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
-	thinkingLevel   string // current thinking level; "" means not set / using gateway default
-	connState       ConnStateMsg
-	hideInput       bool   // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
-	transcript      bool   // true when the model is rendering a cron run-log transcript: read-only, esc returns to the cron detail view that opened it
-	terminalFocused bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
-	updateLatest    string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
+	viewport           viewport.Model
+	textarea           textarea.Model
+	messages           []chatMessage
+	backend            backend.Backend
+	connName           string // active connection name, rendered in the header bar
+	sessionKey         string
+	agentID            string
+	agentName          string
+	sending            bool
+	runID              string // active run ID for cancellation
+	pendingMessages    []string
+	width              int
+	height             int
+	renderer           *glamour.TermRenderer
+	stats              *sessionStats
+	modelID            string
+	promptTokens       int // input + cache read + cache write for the latest turn (a per-session snapshot, not cumulative); 0 until first sessions.list refresh
+	contextWindow      int // model context capacity for the active session; 0 when unknown
+	skills             []agentSkill
+	agentNames         []string // populated asynchronously by loadAgentNames; powers /agent <TAB> completion
+	completion         completionMenuState
+	baseViewportHeight int // viewport height with the completion menu hidden; setSize updates it, applyLayout subtracts the menu's footprint when visible
+	spinnerFrame       int
+	spinnerTicking     bool
+	prefs              config.Preferences
+	pendingConfirm     *pendingConfirmation
+	historyLimit       int
+	historyLoading     bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
+	thinkingLevel      string // current thinking level; "" means not set / using gateway default
+	connState          ConnStateMsg
+	hideInput          bool   // when true, the textarea + help line are not rendered; the textarea model still receives input bytes
+	transcript         bool   // true when the model is rendering a cron run-log transcript: read-only, esc returns to the cron detail view that opened it
+	terminalFocused    bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
+	updateLatest       string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -611,14 +613,26 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			value := m.textarea.Value()
 			cursorByte := textareaCursorByteOffset(&m.textarea)
 			if start, prefix, ok := findSlashTokenAt(value, cursorByte); ok {
-				if match := m.completeSlashCommand(prefix); match != "" && match != strings.ToLower(prefix) {
-					newValue := value[:start] + match + value[cursorByte:]
-					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
-				}
-			} else if start, prefix, ok := findAgentArgAt(value, cursorByte); ok {
+				m.handleSlashTab(value, start, cursorByte, prefix)
+				return m, nil
+			}
+			if start, prefix, ok := findAgentArgAt(value, cursorByte); ok {
 				if match := m.completeAgentName(prefix); match != "" && !strings.EqualFold(match, prefix) {
 					newValue := value[:start] + match + value[cursorByte:]
 					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
+				}
+			}
+			return m, nil
+		case "shift+tab":
+			if m.completion.cycling && len(m.completion.cycleCandidates) > 0 {
+				value := m.textarea.Value()
+				cursorByte := textareaCursorByteOffset(&m.textarea)
+				if start, _, ok := findSlashTokenAt(value, cursorByte); ok {
+					n := len(m.completion.cycleCandidates)
+					m.completion.cycleIndex = (m.completion.cycleIndex - 1 + n) % n
+					pick := m.completion.cycleCandidates[m.completion.cycleIndex]
+					newValue := value[:start] + pick + value[cursorByte:]
+					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
 				}
 			}
 			return m, nil
@@ -633,6 +647,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.textarea.Reset()
 				m.textarea.SetValue(text)
 				m.textarea.CursorEnd()
+				m.refreshCompletionMenu()
 				m.updateViewport()
 				return m, nil
 			}
@@ -645,6 +660,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			// Resolve a pending confirmation prompt.
 			if m.pendingConfirm != nil {
 				m.textarea.Reset()
+				m.refreshCompletionMenu()
 				confirm := m.pendingConfirm
 				m.pendingConfirm = nil
 				lower := strings.ToLower(text)
@@ -670,18 +686,21 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			// Slash commands are local — handle immediately even while sending.
 			if handled, cmd := m.handleSlashCommand(text); handled {
 				m.textarea.Reset()
+				m.refreshCompletionMenu()
 				return m, cmd
 			}
 
 			if m.sending {
 				// Queue the message for later delivery.
 				m.textarea.Reset()
+				m.refreshCompletionMenu()
 				m.pendingMessages = append(m.pendingMessages, text)
 				m.updateViewport()
 				return m, nil
 			}
 
 			m.textarea.Reset()
+			m.refreshCompletionMenu()
 
 			if strings.HasPrefix(text, "!!") {
 				command := strings.TrimSpace(text[2:])
@@ -802,6 +821,14 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	m.textarea, cmd = m.textarea.Update(msg)
 	if cmd != nil {
 		cmds = append(cmds, cmd)
+	}
+
+	// Refresh the slash-command completion menu after the textarea has
+	// consumed a keystroke. Tab/Shift+Tab return early above so this only
+	// fires for keys that may have changed the input (typing, backspace,
+	// arrow keys that move the cursor in/out of a slash token).
+	if _, ok := msg.(tea.KeyPressMsg); ok {
+		m.refreshCompletionMenu()
 	}
 
 	passToViewport := true
@@ -992,7 +1019,8 @@ func (m *chatModel) setSize(w, h int) {
 	}
 
 	m.viewport.SetWidth(w)
-	m.viewport.SetHeight(vpHeight)
+	m.baseViewportHeight = vpHeight
+	m.applyLayout()
 
 	m.textarea.SetWidth(w - 7)
 	m.updateViewport()
@@ -1060,11 +1088,18 @@ func (m chatModel) View() string {
 		borderStyle = localExecBorderStyle
 	}
 
+	var menu string
+	if !m.hideInput {
+		menu, _ = m.renderCompletionMenu()
+	}
+
 	var help string
 	if isRemoteExec {
 		help = helpStyle.Render(execPrefixStyle.Render(" remote command") + " — runs on gateway host")
 	} else if isLocalExec {
 		help = helpStyle.Render(localExecPrefixStyle.Render(" local command") + " — runs on this machine")
+	} else if menu != "" {
+		help = helpStyle.Render(fmt.Sprintf(" Tab: extend · Shift+Tab: back · %d matches", len(m.completion.candidates)))
 	} else {
 		value := m.textarea.Value()
 		cursorByte := textareaCursorByteOffset(&m.textarea)
@@ -1098,11 +1133,10 @@ func (m chatModel) View() string {
 		Width(m.width - 4).
 		Render(m.textarea.View())
 
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		header,
-		m.viewport.View(),
-		input,
-		help,
-	)
+	parts := []string{header, m.viewport.View()}
+	if menu != "" {
+		parts = append(parts, menu)
+	}
+	parts = append(parts, input, help)
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -610,29 +610,19 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			}
 			return m, nil
 		case "tab":
-			value := m.textarea.Value()
-			cursorByte := textareaCursorByteOffset(&m.textarea)
-			if start, prefix, ok := findSlashTokenAt(value, cursorByte); ok {
-				m.handleSlashTab(value, start, cursorByte, prefix)
-				return m, nil
-			}
-			if start, prefix, ok := findAgentArgAt(value, cursorByte); ok {
-				if match := m.completeAgentName(prefix); match != "" && !strings.EqualFold(match, prefix) {
-					newValue := value[:start] + match + value[cursorByte:]
-					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(match))
-				}
+			if ctx, ok := m.completionAtCursor(); ok {
+				m.handleCompletionTab(ctx)
 			}
 			return m, nil
 		case "shift+tab":
 			if m.completion.cycling && len(m.completion.cycleCandidates) > 0 {
-				value := m.textarea.Value()
-				cursorByte := textareaCursorByteOffset(&m.textarea)
-				if start, _, ok := findSlashTokenAt(value, cursorByte); ok {
+				if ctx, ok := m.completionAtCursor(); ok {
+					value := m.textarea.Value()
 					n := len(m.completion.cycleCandidates)
 					m.completion.cycleIndex = (m.completion.cycleIndex - 1 + n) % n
 					pick := m.completion.cycleCandidates[m.completion.cycleIndex]
-					newValue := value[:start] + pick + value[cursorByte:]
-					setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
+					newValue := value[:ctx.start] + pick + value[ctx.cursorByte:]
+					setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(pick))
 				}
 			}
 			return m, nil

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -30,10 +30,11 @@ type pendingConfirmation struct {
 }
 
 // slashCommands is the list of available slash commands for autocomplete.
-// "/agents" is intentionally listed before "/agent" so tab-completing "/age"
-// resolves to the picker (the more common command) rather than the switcher.
-// "/model" likewise sits before "/models" — typing "s" to extend a completion
-// is cheaper than backspacing one.
+// Ordering breaks ties only for the inline ghost-hint and the legacy
+// completeSlashCommand callers — "/agents" appears before "/agent" so the
+// hint surfaces the picker first, "/model" before "/models" likewise.
+// Tab now extends to the longest common prefix and the completion menu
+// shows every candidate, so the curated order no longer rules Tab.
 var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/models", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 )
@@ -20,6 +21,26 @@ func newSlashTestModel() *chatModel {
 			{role: "user", content: "hello"},
 			{role: "assistant", content: "hi there"},
 		},
+	}
+}
+
+// newSlashTabTestModel produces a chatModel with a real textarea so the
+// completion-menu Tab tests can drive Update with key events. The
+// baseline newSlashTestModel leaves textarea zero-valued, which is fine
+// for the slash-command dispatch tests but not for cursor-aware code.
+func newSlashTabTestModel() *chatModel {
+	ta := textarea.New()
+	ta.Focus()
+	ta.SetWidth(80)
+	ta.SetHeight(inputHeight)
+	return &chatModel{
+		viewport:           viewport.New(),
+		textarea:           ta,
+		backend:            newFakeBackend(),
+		agentName:          "test",
+		width:              80,
+		height:             30,
+		baseViewportHeight: 20,
 	}
 }
 
@@ -685,5 +706,148 @@ func TestCompleteSlashCommand_IncludesSkills(t *testing.T) {
 	}
 	if got := m.completeSlashCommand("/sum"); got != "/summarise" {
 		t.Errorf("completeSlashCommand(%q) = %q, want %q", "/sum", got, "/summarise")
+	}
+}
+
+func tabKey() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: tea.KeyTab}
+}
+
+func shiftTabKey() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+}
+
+func TestTabCompletion_LCPExtendsMultiCandidate(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.skills = []agentSkill{{Name: "example"}, {Name: "exams"}}
+	m.textarea.SetValue("/exa")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/exam" {
+		t.Errorf("after Tab: got %q, want %q", got, "/exam")
+	}
+	if updated.completion.cycling {
+		t.Error("expected cycling=false after LCP extension")
+	}
+	if !updated.completion.visible {
+		t.Error("expected menu visible after LCP extension")
+	}
+}
+
+func TestTabCompletion_FullOnSingleCandidate(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.textarea.SetValue("/qu")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/quit" {
+		t.Errorf("after Tab: got %q, want %q", got, "/quit")
+	}
+	if updated.completion.cycling {
+		t.Error("expected cycling=false on single-candidate completion")
+	}
+}
+
+func TestTabCompletion_CycleAtLCP(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.skills = []agentSkill{{Name: "example"}, {Name: "exams"}}
+	m.textarea.SetValue("/exa")
+	m.textarea.CursorEnd()
+
+	// First Tab: LCP extension to /exam.
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/exam" {
+		t.Fatalf("Tab #1: got %q, want %q", got, "/exam")
+	}
+
+	// Second Tab: at LCP, start cycling, pick first candidate.
+	updated, _ = updated.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/example" {
+		t.Fatalf("Tab #2: got %q, want %q", got, "/example")
+	}
+	if !updated.completion.cycling || updated.completion.cycleIndex != 0 {
+		t.Errorf("Tab #2: expected cycling=true index=0, got cycling=%v index=%d", updated.completion.cycling, updated.completion.cycleIndex)
+	}
+
+	// Third Tab: advance cycle.
+	updated, _ = updated.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/exams" {
+		t.Fatalf("Tab #3: got %q, want %q", got, "/exams")
+	}
+
+	// Fourth Tab: wrap around.
+	updated, _ = updated.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/example" {
+		t.Fatalf("Tab #4 (wrap): got %q, want %q", got, "/example")
+	}
+}
+
+func TestTabCompletion_ShiftTabCyclesBack(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.skills = []agentSkill{{Name: "example"}, {Name: "exams"}}
+	m.textarea.SetValue("/exam")
+	m.textarea.CursorEnd()
+
+	// Tab from LCP enters cycle and selects /example.
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/example" {
+		t.Fatalf("Tab: got %q, want %q", got, "/example")
+	}
+
+	// Shift+Tab from index 0 wraps to last (/exams).
+	updated, _ = updated.Update(shiftTabKey())
+	if got := updated.textarea.Value(); got != "/exams" {
+		t.Errorf("Shift+Tab: got %q, want %q", got, "/exams")
+	}
+}
+
+func TestTabCompletion_NonTabResetsCycle(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.skills = []agentSkill{{Name: "example"}, {Name: "exams"}}
+	m.textarea.SetValue("/exam")
+	m.textarea.CursorEnd()
+
+	// Enter cycle.
+	updated, _ := m.Update(tabKey())
+	if !updated.completion.cycling {
+		t.Fatal("expected to be cycling after Tab at LCP")
+	}
+
+	// Any printable keypress should reset cycle state via refreshCompletionMenu.
+	updated, _ = updated.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if updated.completion.cycling {
+		t.Error("expected cycling=false after non-Tab keypress")
+	}
+}
+
+func TestCompletionMenu_HidesWhenTokenBroken(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.textarea.SetValue("/h")
+	m.textarea.CursorEnd()
+
+	// Trigger a refresh by typing 'e' — textarea becomes "/he" with cursor
+	// at end, and "/he" is still a prefix of /help so the menu opens.
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	if !updated.completion.visible {
+		t.Fatalf("expected menu visible at /he, got value=%q visible=%v", updated.textarea.Value(), updated.completion.visible)
+	}
+
+	// Typing a space breaks the slash-token boundary — cursor sits after
+	// whitespace, so findSlashTokenAt returns ok=false.
+	updated, _ = updated.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	if updated.completion.visible {
+		t.Errorf("expected menu hidden after space breaks the token, value=%q", updated.textarea.Value())
+	}
+}
+
+func TestTabCompletion_NoCandidatesIsNoOp(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.textarea.SetValue("/zzz")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/zzz" {
+		t.Errorf("expected textarea unchanged, got %q", got)
 	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -851,3 +851,121 @@ func TestTabCompletion_NoCandidatesIsNoOp(t *testing.T) {
 		t.Errorf("expected textarea unchanged, got %q", got)
 	}
 }
+
+func TestAgentTabCompletion_LCPExtendsMultiCandidate(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"main", "mail"}
+	m.textarea.SetValue("/agent ma")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent mai" {
+		t.Errorf("after Tab: got %q, want %q", got, "/agent mai")
+	}
+	if updated.completion.cycling {
+		t.Error("expected cycling=false after LCP extension")
+	}
+}
+
+func TestAgentTabCompletion_FullOnSingleCandidate(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"alpha", "beta"}
+	m.textarea.SetValue("/agent al")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent alpha" {
+		t.Errorf("after Tab: got %q, want %q", got, "/agent alpha")
+	}
+}
+
+func TestAgentTabCompletion_CycleAtLCP(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"main", "mail"}
+	m.textarea.SetValue("/agent mai")
+	m.textarea.CursorEnd()
+
+	// First Tab from LCP enters cycle, picks first.
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent main" {
+		t.Fatalf("Tab #1: got %q, want %q", got, "/agent main")
+	}
+	// Second Tab advances cycle.
+	updated, _ = updated.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent mail" {
+		t.Fatalf("Tab #2: got %q, want %q", got, "/agent mail")
+	}
+	// Third Tab wraps.
+	updated, _ = updated.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent main" {
+		t.Fatalf("Tab #3 (wrap): got %q, want %q", got, "/agent main")
+	}
+}
+
+func TestAgentTabCompletion_ShiftTabCyclesBack(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"main", "mail"}
+	m.textarea.SetValue("/agent mai")
+	m.textarea.CursorEnd()
+
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent main" {
+		t.Fatalf("Tab: got %q, want %q", got, "/agent main")
+	}
+	updated, _ = updated.Update(shiftTabKey())
+	if got := updated.textarea.Value(); got != "/agent mail" {
+		t.Errorf("Shift+Tab from index 0 should wrap, got %q", got)
+	}
+}
+
+func TestAgentTabCompletion_PreservesOriginalCasing(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"Alpha", "Beta", "Gamma Two"}
+	m.textarea.SetValue("/agent be")
+	m.textarea.CursorEnd()
+
+	// Single match — full completion preserves original casing.
+	updated, _ := m.Update(tabKey())
+	if got := updated.textarea.Value(); got != "/agent Beta" {
+		t.Errorf("expected original casing preserved, got %q", got)
+	}
+}
+
+func TestAgentTabCompletion_MenuVisibleWhileTyping(t *testing.T) {
+	m := newSlashTabTestModel()
+	m.agentNames = []string{"main", "mail"}
+	m.textarea.SetValue("/agent ma")
+	m.textarea.CursorEnd()
+
+	// A keypress that leaves the textarea in the agent-arg context
+	// should populate the menu via refreshCompletionMenu.
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	if !updated.completion.visible {
+		t.Fatalf("expected menu visible at /agent mai, got value=%q visible=%v", updated.textarea.Value(), updated.completion.visible)
+	}
+	if len(updated.completion.candidates) != 2 {
+		t.Errorf("expected 2 candidates, got %d: %v", len(updated.completion.candidates), updated.completion.candidates)
+	}
+}
+
+func TestLongestCommonPrefixFold(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single preserves casing", []string{"Beta"}, "Beta"},
+		{"mixed case converges", []string{"Beta", "Beach"}, "Be"},
+		{"diverging case", []string{"main", "Mail"}, "mai"},
+		{"first casing wins", []string{"BEta", "beach"}, "BE"},
+		{"no common prefix", []string{"alpha", "Beta"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := longestCommonPrefixFold(tt.in); got != tt.want {
+				t.Errorf("longestCommonPrefixFold(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -58,6 +58,47 @@ func longestCommonPrefix(strs []string) string {
 	return prefix
 }
 
+// longestCommonPrefixFold returns the longest case-insensitive (ASCII fold)
+// prefix shared by every string in strs, taken from the first candidate's
+// casing — so the inserted text reads naturally next to the user's cursor.
+// Used for sources whose candidates carry mixed casing (e.g. agent names);
+// for already-lowercase data it produces the same result as
+// longestCommonPrefix.
+func longestCommonPrefixFold(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	first := strs[0]
+	if first == "" {
+		return ""
+	}
+	n := len(first)
+	for _, s := range strs[1:] {
+		if len(s) < n {
+			n = len(s)
+		}
+		i := 0
+		for i < n {
+			a, b := first[i], s[i]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				break
+			}
+			i++
+		}
+		n = i
+		if n == 0 {
+			return ""
+		}
+	}
+	return first[:n]
+}
+
 // matchingSlashCommands returns every slash command whose lowercased form
 // has prefix as a prefix. Built-ins come first in their curated order
 // (preserving the /agents-before-/agent etc. tiebreaks used by the legacy
@@ -89,24 +130,86 @@ func (m *chatModel) matchingSlashCommands(prefix string) []string {
 	return out
 }
 
-// handleSlashTab implements the Tab semantics for slash-command
-// completion: extend to longest common prefix on the first useful press,
-// then cycle candidates on subsequent presses while still at the LCP.
-//
-// value/start/cursorByte and prefix are the textarea snapshot already
-// resolved by the caller via findSlashTokenAt.
-func (m *chatModel) handleSlashTab(value string, start, cursorByte int, prefix string) {
+// matchingAgentNames returns every agent name whose lowercased form has
+// prefix as a prefix, preserving each agent's original casing in the
+// returned slice. Empty prefix matches every loaded agent. Returns nil
+// when m.agentNames hasn't been populated yet — Tab silently no-ops in
+// that case, matching the legacy completeAgentName behaviour.
+func (m *chatModel) matchingAgentNames(prefix string) []string {
+	if len(m.agentNames) == 0 {
+		return nil
+	}
+	if prefix == "" {
+		out := make([]string, len(m.agentNames))
+		copy(out, m.agentNames)
+		return out
+	}
+	lower := strings.ToLower(prefix)
+	var out []string
+	for _, n := range m.agentNames {
+		if strings.HasPrefix(strings.ToLower(n), lower) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// completionContext describes the completable token at the cursor: where
+// it begins, where the cursor sits, what the user has typed, and the
+// candidate list for that prefix. Sources differ (slash commands +
+// skills vs. agent names) but the menu/Tab/cycle machinery is uniform.
+type completionContext struct {
+	start      int
+	cursorByte int
+	prefix     string
+	candidates []string
+}
+
+// completionAtCursor returns the active completion context at the
+// textarea cursor. Slash commands take priority over agent-name
+// completion — the latter only applies inside the special "/agent "
+// argument context. Returns ok=false when no source applies.
+func (m *chatModel) completionAtCursor() (completionContext, bool) {
+	value := m.textarea.Value()
+	cursorByte := textareaCursorByteOffset(&m.textarea)
+	if start, prefix, ok := findSlashTokenAt(value, cursorByte); ok {
+		return completionContext{
+			start:      start,
+			cursorByte: cursorByte,
+			prefix:     prefix,
+			candidates: m.matchingSlashCommands(prefix),
+		}, true
+	}
+	if start, prefix, ok := findAgentArgAt(value, cursorByte); ok {
+		return completionContext{
+			start:      start,
+			cursorByte: cursorByte,
+			prefix:     prefix,
+			candidates: m.matchingAgentNames(prefix),
+		}, true
+	}
+	return completionContext{}, false
+}
+
+// handleCompletionTab implements the Tab semantics for the active
+// completion source: extend to longest common prefix on the first useful
+// press, then cycle candidates on subsequent presses while still at the
+// LCP. The candidate list is sourced from ctx — slash commands, skills,
+// or agent names — so a single state machine drives both menus.
+func (m *chatModel) handleCompletionTab(ctx completionContext) {
+	value := m.textarea.Value()
+
 	// If we're already cycling and the user hasn't typed since, advance
 	// the index. Detected by checking that the current token is one of
 	// the snapshotted cycleCandidates — refreshCompletionMenu would have
 	// flipped cycling=false on any non-Tab keystroke.
 	if m.completion.cycling && len(m.completion.cycleCandidates) > 0 {
 		for _, c := range m.completion.cycleCandidates {
-			if strings.EqualFold(c, prefix) {
+			if strings.EqualFold(c, ctx.prefix) {
 				m.completion.cycleIndex = (m.completion.cycleIndex + 1) % len(m.completion.cycleCandidates)
 				pick := m.completion.cycleCandidates[m.completion.cycleIndex]
-				newValue := value[:start] + pick + value[cursorByte:]
-				setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
+				newValue := value[:ctx.start] + pick + value[ctx.cursorByte:]
+				setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(pick))
 				return
 			}
 		}
@@ -116,38 +219,34 @@ func (m *chatModel) handleSlashTab(value string, start, cursorByte int, prefix s
 		m.completion.cycleCandidates = nil
 	}
 
-	cands := m.matchingSlashCommands(prefix)
 	switch {
-	case len(cands) == 0:
-		// No candidates — leave the textarea untouched.
+	case len(ctx.candidates) == 0:
 		return
-	case len(cands) == 1:
-		// Single match — full completion.
-		newValue := value[:start] + cands[0] + value[cursorByte:]
-		setTextareaToValueWithCursor(&m.textarea, newValue, start+len(cands[0]))
+	case len(ctx.candidates) == 1:
+		pick := ctx.candidates[0]
+		newValue := value[:ctx.start] + pick + value[ctx.cursorByte:]
+		setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(pick))
 		m.refreshCompletionMenu()
 		return
 	}
 
-	lcp := longestCommonPrefix(cands)
-	lowerPrefix := strings.ToLower(prefix)
-	if len(lcp) > len(lowerPrefix) {
-		// Extend up to the shared prefix.
-		newValue := value[:start] + lcp + value[cursorByte:]
-		setTextareaToValueWithCursor(&m.textarea, newValue, start+len(lcp))
+	lcp := longestCommonPrefixFold(ctx.candidates)
+	if len(lcp) > len(ctx.prefix) {
+		newValue := value[:ctx.start] + lcp + value[ctx.cursorByte:]
+		setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(lcp))
 		m.refreshCompletionMenu()
 		return
 	}
 
 	// At LCP with multiple matches — start cycling.
 	m.completion.cycling = true
-	m.completion.cycleCandidates = cands
+	m.completion.cycleCandidates = ctx.candidates
 	m.completion.cycleIndex = 0
-	pick := cands[0]
-	newValue := value[:start] + pick + value[cursorByte:]
-	setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
+	pick := ctx.candidates[0]
+	newValue := value[:ctx.start] + pick + value[ctx.cursorByte:]
+	setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(pick))
 	m.completion.visible = true
-	m.completion.candidates = cands
+	m.completion.candidates = ctx.candidates
 	m.applyLayout()
 }
 
@@ -244,9 +343,7 @@ func (m *chatModel) applyLayout() {
 // Any visit here resets cycling=false because, by definition, the
 // user has typed something other than Tab.
 func (m *chatModel) refreshCompletionMenu() {
-	value := m.textarea.Value()
-	cursorByte := textareaCursorByteOffset(&m.textarea)
-	_, prefix, ok := findSlashTokenAt(value, cursorByte)
+	ctx, ok := m.completionAtCursor()
 
 	m.completion.cycling = false
 	m.completion.cycleCandidates = nil
@@ -254,17 +351,7 @@ func (m *chatModel) refreshCompletionMenu() {
 
 	wasVisible := m.completion.visible
 
-	if !ok {
-		if wasVisible {
-			m.completion.visible = false
-			m.completion.candidates = nil
-			m.applyLayout()
-		}
-		return
-	}
-
-	cands := m.matchingSlashCommands(prefix)
-	if len(cands) == 0 {
+	if !ok || len(ctx.candidates) == 0 {
 		if wasVisible {
 			m.completion.visible = false
 			m.completion.candidates = nil
@@ -275,9 +362,9 @@ func (m *chatModel) refreshCompletionMenu() {
 
 	prevLen := len(m.completion.candidates)
 	m.completion.visible = true
-	m.completion.candidates = cands
+	m.completion.candidates = ctx.candidates
 
-	if !wasVisible || prevLen != len(cands) {
+	if !wasVisible || prevLen != len(ctx.candidates) {
 		m.applyLayout()
 		if !wasVisible {
 			m.viewport.GotoBottom()

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -1,0 +1,286 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// completionMenuState backs the slash-command completion popup.
+//
+// When the cursor sits at the end of a "/foo" token, the menu displays
+// every matching candidate (built-ins + skills). Tab extends the input
+// to the longest common prefix; once at the LCP and multiple matches
+// remain, repeated Tab cycles cycleCandidates and replaces the input
+// each press (Shift+Tab cycles backward). Any non-Tab keystroke drops
+// out of cycle mode — refreshCompletionMenu is the single place that
+// flips cycling back to false.
+type completionMenuState struct {
+	visible         bool
+	candidates      []string
+	cycling         bool
+	cycleCandidates []string
+	cycleIndex      int
+}
+
+// completionMenuMaxRows caps the number of candidate rows rendered in
+// the completion menu before collapsing the tail into a "+N more" line.
+const completionMenuMaxRows = 10
+
+// completionMenuViewportFloor is the minimum number of viewport rows
+// the completion menu will leave visible. On terminals too short to
+// honour this floor, the menu suppresses itself — Tab still does LCP
+// extension on the underlying state.
+const completionMenuViewportFloor = 5
+
+// longestCommonPrefix returns the longest byte-prefix shared by every string
+// in strs. Empty slice and any zero-length string short-circuit to "".
+// Callers are expected to pass already-lowercased inputs (slash commands and
+// skill names are stored lowercased), so the comparison is byte-level.
+func longestCommonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	prefix := strs[0]
+	for _, s := range strs[1:] {
+		n := len(prefix)
+		if len(s) < n {
+			n = len(s)
+		}
+		i := 0
+		for i < n && prefix[i] == s[i] {
+			i++
+		}
+		prefix = prefix[:i]
+		if prefix == "" {
+			return ""
+		}
+	}
+	return prefix
+}
+
+// matchingSlashCommands returns every slash command whose lowercased form
+// has prefix as a prefix. Built-ins come first in their curated order
+// (preserving the /agents-before-/agent etc. tiebreaks used by the legacy
+// inline ghost-hint), followed by skill names. Duplicates between built-ins
+// and skills are dropped. Returns nil for non-slash inputs.
+func (m *chatModel) matchingSlashCommands(prefix string) []string {
+	lower := strings.ToLower(prefix)
+	if !strings.HasPrefix(lower, "/") {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, cmd := range slashCommands {
+		if strings.HasPrefix(cmd, lower) {
+			seen[cmd] = struct{}{}
+			out = append(out, cmd)
+		}
+	}
+	for _, s := range m.skills {
+		cmd := "/" + strings.ToLower(s.Name)
+		if _, dup := seen[cmd]; dup {
+			continue
+		}
+		if strings.HasPrefix(cmd, lower) {
+			seen[cmd] = struct{}{}
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+// handleSlashTab implements the Tab semantics for slash-command
+// completion: extend to longest common prefix on the first useful press,
+// then cycle candidates on subsequent presses while still at the LCP.
+//
+// value/start/cursorByte and prefix are the textarea snapshot already
+// resolved by the caller via findSlashTokenAt.
+func (m *chatModel) handleSlashTab(value string, start, cursorByte int, prefix string) {
+	// If we're already cycling and the user hasn't typed since, advance
+	// the index. Detected by checking that the current token is one of
+	// the snapshotted cycleCandidates — refreshCompletionMenu would have
+	// flipped cycling=false on any non-Tab keystroke.
+	if m.completion.cycling && len(m.completion.cycleCandidates) > 0 {
+		for _, c := range m.completion.cycleCandidates {
+			if strings.EqualFold(c, prefix) {
+				m.completion.cycleIndex = (m.completion.cycleIndex + 1) % len(m.completion.cycleCandidates)
+				pick := m.completion.cycleCandidates[m.completion.cycleIndex]
+				newValue := value[:start] + pick + value[cursorByte:]
+				setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
+				return
+			}
+		}
+		// Token no longer matches the cycle snapshot — drop out and
+		// re-evaluate from scratch.
+		m.completion.cycling = false
+		m.completion.cycleCandidates = nil
+	}
+
+	cands := m.matchingSlashCommands(prefix)
+	switch {
+	case len(cands) == 0:
+		// No candidates — leave the textarea untouched.
+		return
+	case len(cands) == 1:
+		// Single match — full completion.
+		newValue := value[:start] + cands[0] + value[cursorByte:]
+		setTextareaToValueWithCursor(&m.textarea, newValue, start+len(cands[0]))
+		m.refreshCompletionMenu()
+		return
+	}
+
+	lcp := longestCommonPrefix(cands)
+	lowerPrefix := strings.ToLower(prefix)
+	if len(lcp) > len(lowerPrefix) {
+		// Extend up to the shared prefix.
+		newValue := value[:start] + lcp + value[cursorByte:]
+		setTextareaToValueWithCursor(&m.textarea, newValue, start+len(lcp))
+		m.refreshCompletionMenu()
+		return
+	}
+
+	// At LCP with multiple matches — start cycling.
+	m.completion.cycling = true
+	m.completion.cycleCandidates = cands
+	m.completion.cycleIndex = 0
+	pick := cands[0]
+	newValue := value[:start] + pick + value[cursorByte:]
+	setTextareaToValueWithCursor(&m.textarea, newValue, start+len(pick))
+	m.completion.visible = true
+	m.completion.candidates = cands
+	m.applyLayout()
+}
+
+// menuRowsToRender returns the number of vertical rows the completion
+// menu wants to occupy on screen, including the optional "+N more"
+// overflow line. Returns 0 when the menu is hidden or the baseline
+// viewport is too short to host it without crushing the conversation
+// pane below completionMenuViewportFloor rows.
+func (m *chatModel) menuRowsToRender() int {
+	if !m.completion.visible {
+		return 0
+	}
+	src := m.completion.candidates
+	if m.completion.cycling {
+		src = m.completion.cycleCandidates
+	}
+	if len(src) == 0 {
+		return 0
+	}
+	rows := len(src)
+	if rows > completionMenuMaxRows {
+		rows = completionMenuMaxRows + 1 // +N more line
+	}
+	maxAllowed := m.baseViewportHeight - completionMenuViewportFloor
+	if maxAllowed < 2 {
+		return 0
+	}
+	if rows > maxAllowed {
+		rows = maxAllowed
+	}
+	return rows
+}
+
+// renderCompletionMenu builds the menu's vertical block. Returns an
+// empty string and 0 height when the menu is hidden or the viewport is
+// too short to host it. The highlight glyph marks the current cycle
+// index when cycling; otherwise candidates are rendered uniformly in
+// helpStyle.
+func (m chatModel) renderCompletionMenu() (string, int) {
+	budget := m.menuRowsToRender()
+	if budget == 0 {
+		return "", 0
+	}
+	src := m.completion.candidates
+	if m.completion.cycling {
+		src = m.completion.cycleCandidates
+	}
+	if len(src) == 0 {
+		return "", 0
+	}
+
+	// Reserve a row for "+N more" when we can't fit every candidate.
+	showCount := len(src)
+	overflow := 0
+	if showCount > budget {
+		showCount = budget - 1
+		if showCount < 1 {
+			showCount = budget
+		} else {
+			overflow = len(src) - showCount
+		}
+	}
+
+	var lines []string
+	for i := 0; i < showCount; i++ {
+		cmd := src[i]
+		if m.completion.cycling && i == m.completion.cycleIndex {
+			lines = append(lines, completionMenuHighlightStyle.Render("▸ "+cmd))
+			continue
+		}
+		lines = append(lines, helpStyle.Render("  "+cmd))
+	}
+	if overflow > 0 {
+		lines = append(lines, helpStyle.Render(fmt.Sprintf("  +%d more", overflow)))
+	}
+	return strings.Join(lines, "\n"), len(lines)
+}
+
+// applyLayout sizes the viewport so the completion menu fits between
+// the conversation pane and the input. setSize is the canonical owner
+// of the "menu hidden" baseline; this method reapplies the menu's
+// footprint on top of that baseline whenever menu state changes.
+func (m *chatModel) applyLayout() {
+	h := m.baseViewportHeight - m.menuRowsToRender()
+	if h < 1 {
+		h = 1
+	}
+	m.viewport.SetHeight(h)
+}
+
+// refreshCompletionMenu recomputes the menu state from the current
+// textarea contents. Called after every non-Tab keypress: the Tab
+// handler manages cycling state explicitly and never invokes this.
+// Any visit here resets cycling=false because, by definition, the
+// user has typed something other than Tab.
+func (m *chatModel) refreshCompletionMenu() {
+	value := m.textarea.Value()
+	cursorByte := textareaCursorByteOffset(&m.textarea)
+	_, prefix, ok := findSlashTokenAt(value, cursorByte)
+
+	m.completion.cycling = false
+	m.completion.cycleCandidates = nil
+	m.completion.cycleIndex = 0
+
+	wasVisible := m.completion.visible
+
+	if !ok {
+		if wasVisible {
+			m.completion.visible = false
+			m.completion.candidates = nil
+			m.applyLayout()
+		}
+		return
+	}
+
+	cands := m.matchingSlashCommands(prefix)
+	if len(cands) == 0 {
+		if wasVisible {
+			m.completion.visible = false
+			m.completion.candidates = nil
+			m.applyLayout()
+		}
+		return
+	}
+
+	prevLen := len(m.completion.candidates)
+	m.completion.visible = true
+	m.completion.candidates = cands
+
+	if !wasVisible || prevLen != len(cands) {
+		m.applyLayout()
+		if !wasVisible {
+			m.viewport.GotoBottom()
+		}
+	}
+}

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -24,7 +24,9 @@ type completionMenuState struct {
 
 // completionMenuMaxRows caps the number of candidate rows rendered in
 // the completion menu before collapsing the tail into a "+N more" line.
-const completionMenuMaxRows = 10
+// Tuned low to keep the chat viewport breathable; users narrow the list
+// by typing rather than scrolling the menu.
+const completionMenuMaxRows = 4
 
 // completionMenuViewportFloor is the minimum number of viewport rows
 // the completion menu will leave visible. On terminals too short to

--- a/internal/tui/completion_test.go
+++ b/internal/tui/completion_test.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLongestCommonPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"/help"}, "/help"},
+		{"all same", []string{"/help", "/help"}, "/help"},
+		{"two diverge late", []string{"/example", "/exams"}, "/exam"},
+		{"three converge at slash", []string{"/agents", "/agent", "/clear"}, "/"},
+		{"first is prefix of second", []string{"/agent", "/agents"}, "/agent"},
+		{"empty string in slice", []string{"/help", ""}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := longestCommonPrefix(tt.in)
+			if got != tt.want {
+				t.Errorf("longestCommonPrefix(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchingSlashCommands_BuiltinsAndSkills(t *testing.T) {
+	m := newSlashTestModel()
+	m.skills = []agentSkill{
+		{Name: "example", Description: "x"},
+		{Name: "exams", Description: "y"},
+	}
+
+	// Slash-only prefix returns the full built-in list (in curated order)
+	// followed by skills.
+	got := m.matchingSlashCommands("/")
+	if len(got) != len(slashCommands)+2 {
+		t.Fatalf("expected %d candidates, got %d: %v", len(slashCommands)+2, len(got), got)
+	}
+	for i, cmd := range slashCommands {
+		if got[i] != cmd {
+			t.Errorf("position %d: got %q, want %q (curated order broken)", i, got[i], cmd)
+		}
+	}
+	if got[len(slashCommands)] != "/example" || got[len(slashCommands)+1] != "/exams" {
+		t.Errorf("expected skills appended in skill order, got tail: %v", got[len(slashCommands):])
+	}
+
+	// Prefix that matches only skills.
+	if g := m.matchingSlashCommands("/exa"); !reflect.DeepEqual(g, []string{"/example", "/exams"}) {
+		t.Errorf("/exa: got %v, want [/example /exams]", g)
+	}
+
+	// Prefix that matches both a built-in and ordering tiebreak.
+	if g := m.matchingSlashCommands("/age"); !reflect.DeepEqual(g, []string{"/agents", "/agent"}) {
+		t.Errorf("/age: got %v, want [/agents /agent]", g)
+	}
+
+	// Case-insensitive match on the typed prefix.
+	if g := m.matchingSlashCommands("/Q"); !reflect.DeepEqual(g, []string{"/quit"}) {
+		t.Errorf("/Q: got %v, want [/quit]", g)
+	}
+
+	// Non-slash → nil.
+	if g := m.matchingSlashCommands("hello"); g != nil {
+		t.Errorf("hello: got %v, want nil", g)
+	}
+}
+
+func TestMatchingSlashCommands_SkillNameClashIsDeduped(t *testing.T) {
+	m := newSlashTestModel()
+	// A skill with the same name as a built-in must not duplicate the entry.
+	m.skills = []agentSkill{{Name: "help", Description: "duplicate"}}
+	got := m.matchingSlashCommands("/h")
+	count := 0
+	for _, c := range got {
+		if c == "/help" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected /help once, got %d in %v", count, got)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -107,6 +107,12 @@ var (
 	helpStyle = lipgloss.NewStyle().
 			Foreground(subtle)
 
+	// Completion-menu highlight — applied to the row at the current
+	// cycle index when Tab is cycling through candidates.
+	completionMenuHighlightStyle = lipgloss.NewStyle().
+					Foreground(accent).
+					Bold(true)
+
 	// Connection status bar — a thin dim row above non-chat views
 	// telling the user which connection is in scope. The chat view
 	// folds the same info into its own header bar.


### PR DESCRIPTION
Adds a live completion menu for slash commands and skills, and changes Tab to extend up to the longest common prefix instead of greedily picking the first match.

## Summary
- Open a popup listing every matching slash command and skill as soon as the cursor sits at the end of a slash token; the list filters live as the user keeps typing
- Tab now extends the input to the longest common prefix of the candidates (e.g. `/exa` with `/example` and `/exams` available extends to `/exam`); a single match still completes fully
- Once at the LCP with multiple matches, repeated Tab cycles through candidates and replaces the input each press; Shift+Tab cycles backward
- Menu hides automatically when the slash token is broken (whitespace, cleared input, sent message), and suppresses itself on terminals too short to host it without crushing the conversation pane below five rows
- Help line below the input switches to "Tab: extend · Shift+Tab: back · N matches" while the menu is visible

## Implementation details
- `refreshCompletionMenu` is hooked after the textarea consumes a non-Tab keypress; the Tab and Shift+Tab handlers manage cycle state explicitly so cycling persists across presses but resets on any other key
- `setSize` records a "menu hidden" viewport baseline (`baseViewportHeight`); `applyLayout` shrinks the viewport by the menu's footprint whenever menu state changes, so the conversation pane reflows cleanly
- The legacy single-line ghost-hint and `completeSlashCommand` are unchanged, since they still drive `/agent <name>` arg completion (a single-candidate-by-design path that doesn't open the menu); the curated `slashCommands` order now only breaks ties for that hint, not for Tab