### PR TITLE
ci: clear deprecation warnings in release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
       - name: GoReleaser (dry run)
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --snapshot --skip=publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         id: tap-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: lucinate-ai
           repositories: homebrew-tap
@@ -41,7 +41,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
         if: ${{ !contains(github.ref_name, '-') }}
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.WEBSITE_DISPATCH_APP_ID }}
+          client-id: ${{ vars.WEBSITE_DISPATCH_APP_CLIENT_ID }}
           private-key: ${{ secrets.WEBSITE_DISPATCH_APP_PRIVATE_KEY }}
           owner: lucinate-ai
           repositories: website


### PR DESCRIPTION
Silence the deprecation annotations surfaced by the most recent release CI run.

## Summary
- Switch `actions/create-github-app-token@v3` calls from the deprecated `app-id` input to `client-id`, backed by new `HOMEBREW_TAP_APP_CLIENT_ID` and `WEBSITE_DISPATCH_APP_CLIENT_ID` repository variables.
- Pin `goreleaser/goreleaser-action@v7` to `~> v2` in both the release and CI dry-run workflows, replacing the implicit `latest` that the action warned about.