### PR TITLE
feat: add multi-step routines

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Shell commands** — run locally with `!` or remotely on the gateway with `!!`
 - **Message queueing** so you can keep typing while the agent is responding
 - **Local agent skills** loaded from `~/.agents/skills/` — invoke as a slash command (`/review`) or drop one mid-message (`use /review on the diff`)
+- **Routines** — author multi-step prompt sequences once, replay them with `/routine <name>`. Auto-advance after each reply, or step through manually. Manage them in-TUI with `/routines`.
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
 - **Cron browser** — list, edit, run, create, and duplicate scheduled jobs without leaving the terminal (OpenClaw)
@@ -159,6 +160,8 @@ Type these in the chat input. As soon as you type `/`, a menu shows every matchi
 | `/models` | Open the model picker (filter as you type) |
 | `/model <name>` | Switch model (fuzzy match) |
 | `/reset` | Delete session and start fresh (with confirmation) |
+| `/routine <name>` | Activate a stored multi-step routine in the current session |
+| `/routines` | List, view, edit, or delete routines |
 | `/sessions` | Browse and restore previous sessions |
 | `/skills` | List available agent skills |
 | `/stats` | Show token usage and cost breakdown — OpenClaw only |
@@ -190,6 +193,60 @@ Prefix input with `!!` to run a command on the gateway host. The input border tu
 ```
 
 The gateway's exec security policy controls which remote commands are allowed. If a command is denied, you'll see an error message. Configure exec permissions on the gateway host using `openclaw config`.
+
+## Routines
+
+Recurring prompt workflow you find yourself retyping every Tuesday? Save it as a routine. Each routine is an ordered list of steps; each step is a complete user message. Activate one with `/routine <name>` and lucinate fires the steps at the assistant in order, optionally auto-advancing after every reply.
+
+Manage them with `/routines` — list, view, add, edit, delete. The form has one textarea per step plus `Alt+↑` / `Alt+↓` to insert above/below and `Alt+Delete` to remove. `Alt+S` saves.
+
+Routine files live at `~/.lucinate/routines/<name>/STEPS.md`. The format is plain markdown with optional YAML frontmatter and `---` between steps:
+
+```markdown
+---
+name: review-pr
+mode: auto
+log: ./review.log
+---
+
+list the files changed in the current PR
+
+---
+
+flag any obvious bugs or style issues, one per line
+
+---
+
+write a one-paragraph review summary
+```
+
+`mode: auto` advances on every assistant reply; `manual` (the default) waits for `Enter`. `log:` is optional — when set, each turn is appended to that file, prefixed `user: ...` / `assistant: ...` with ISO timestamps.
+
+While a routine is running you'll see a status row above the input:
+
+```
+routine: review-pr — AUTO — sent: 2/3 — next: write a one-paragraph review summary
+```
+
+Useful keys mid-routine:
+
+| Key | Action |
+|-----|--------|
+| `Alt+M` | Cycle the mode (auto ↔ manual) |
+| `Enter` (empty input) | Send the next step (manual / paused mode) |
+| `Esc` | Cancel the routine and any in-flight reply |
+
+The assistant can steer the routine in its own reply by emitting one of these on its own line:
+
+| Directive | Effect |
+|-----------|--------|
+| `/routine:stop` | End the routine immediately |
+| `/routine:pause` | Pause until you press `Enter` |
+| `/routine:continue` | Explicit no-op (also resumes a paused auto-mode routine) |
+| `/routine:mode auto` | Switch to auto mode |
+| `/routine:mode manual` | Switch to manual mode |
+
+Routines live entirely client-side and work with every backend.
 
 ## One-shot mode
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [agents.md](agents.md) | Agent picker, auto-selection, agent creation |
 | [sessions.md](sessions.md) | Session lifecycle, session browser, compact/reset, message queueing |
 | [crons.md](crons.md) | Gateway cron browser: list/detail/form substates, capability gating, raw-patch edit semantics |
+| [routines.md](routines.md) | Local prompt routines: STEPS.md format, controller lifecycle, auto-advance hook, directives, manager view |
 | [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
 | [one-shot.md](one-shot.md) | One-shot CLI mode: `lucinate send` lifecycle, default session rule, detach semantics, embedding |
 | [chat-launch.md](chat-launch.md) | Pre-navigated TUI launch: `lucinate chat` override plumbing, consumption points, stale-clearing rules |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -4,14 +4,15 @@
 
 | Key | Action |
 |---|---|
-| Enter | Send message |
+| Enter | Send message — or, on empty input with an active routine, advance the routine ([routines.md](routines.md)) |
 | Alt+Enter | Insert newline |
+| Alt+M | Cycle the active routine's mode (auto ↔ manual) — no-op when no routine is active |
 | Ctrl+W | Delete word backward |
 | Up arrow (empty input) | Recall last sent message for editing |
 | Tab | Open slash menu, extend to longest common prefix, then cycle |
 | Shift+Tab | Cycle backward through slash-menu candidates |
 | Page Up / Page Down | Scroll message history |
-| Esc | Cancel in-progress response |
+| Esc | Cancel in-progress response — or, with an active routine, end the routine and (if streaming) cancel the turn |
 
 Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter is not supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
 
@@ -68,6 +69,26 @@ A matching one-line system message is also added to the chat scrollback on disco
 A second header badge — `↑ vX.Y.Z`, rendered in the same warn style as `⚠ disconnected` — appears when the daily startup update check finds a newer release. The check is owned by `internal/update`: a single `GET https://lucinate.ai/latest.json` with a 5-second timeout, fired once per day from `AppModel.Init()`. Anything goes wrong (offline, captive portal, malformed manifest, non-stable build) and `update.Check` returns `nil, nil` — no badge, no error.
 
 The badge is suppressed once the user has seen it: `prefs.LatestSeenVersion` records the manifest version on every successful check, and the badge only appears when the manifest moves *past* that version. Toggle the whole thing off via the `Check for updates on startup` row in `/config`, or set `LUCINATE_DISABLE_UPDATE_CHECK=1` for an unconditional opt-out (useful in CI). The manifest URL itself can be overridden via `LUCINATE_UPDATE_MANIFEST_URL` for local testing.
+
+## Notifications
+
+Ephemeral state messages — confirmation prompts, cancel acks, routine state changes ([routines.md](routines.md)) — render as one or more rows above the input box, between the conversation viewport (or completion menu) and the routine status row when present. Each row is width-padded and styled with `statusStyle` (or `errorStyle` for is-error rows).
+
+The store is `chatModel.notifications []notification` (`internal/tui/notifications.go`). Notifications live outside `m.messages`, so they survive `historyRefreshMsg` and never reach the gateway. They are cleared at the top of the Enter handler whenever the user submits a non-empty input, and on the empty-Enter routine-advance path — the assumption is that any state worth showing in a notification has been read or no longer applies once the user takes their next action.
+
+`m.notify(text)`, `m.notifyError(text)`, and `m.clearNotifications()` are the only entry points; each calls `applyLayout()` so the conversation viewport reflows when notifications appear or disappear. Empty text is dropped silently so callers can `notify(maybeFmt(...))` without a guard.
+
+This replaced the older pattern of appending `chatMessage{role:"system"}` rows for transient state. Persistent client-side rows (the inline `! cmd` / `!! cmd` shell-execution scrollback, gateway connect/disconnect notes, the `/help` / `/stats` / `/skills` info dumps) still go in `m.messages` because their value is in being scrollable history, not in a one-shot read.
+
+## Routine status row
+
+When `m.activeRoutine != nil`, a single styled row renders immediately above the input box:
+
+```
+routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
+```
+
+`AUTO`/`MANUAL` reflects the controller's mode; `(paused)` is appended when `paused` is set. The row is sourced by `routineStatusLine()` and styled by `routineStatusStyle` in `routines_chat.go`. `applyLayout()` subtracts one from the viewport height when a routine is active, mirroring the notification-row accounting. See [routines.md](routines.md) for the full controller surface.
 
 ## Tool call cards
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,6 +27,8 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
 | `/reset` | Delete the session and start fresh — see [sessions.md](sessions.md#compact-and-reset) |
+| `/routine <name>` | Activate a stored routine in the current session — see [routines.md](routines.md) |
+| `/routines` | Open the routines manager (list/view/edit/delete) — see [routines.md](routines.md) |
 | `/sessions` | Open the session browser — see [sessions.md](sessions.md#session-browser) |
 | `/skills` | List discovered skills — see [skills.md](skills.md) |
 | `/stats` | Show a token usage and cost table for the current session — **OpenClaw only** |
@@ -81,6 +83,10 @@ The chat model fetches the agent list once on init via `loadAgentNames()` and st
 
 ## Confirmation pattern
 
-Destructive commands (`/compact`, `/reset`) use a two-step confirmation. On first invocation a `pendingConfirmation` struct is stored on the model containing the prompt string, an optional `runningStatus` line, and an action closure. The prompt is displayed as a system message. On the next Enter keypress, if the input is `y` or `yes` the closure is executed; anything else cancels. This prevents accidental data loss.
+Destructive commands (`/compact`, `/reset`) use a two-step confirmation. On first invocation a `pendingConfirmation` struct is stored on the model containing the prompt string, an optional `runningStatus` line, and an action closure. The prompt is rendered as an ephemeral notification above the input — see [chat-ux.md → Notifications](chat-ux.md#notifications). On the next Enter keypress, if the input is `y` or `yes` the closure is executed; anything else cancels. This prevents accidental data loss.
 
-When `runningStatus` is set, the confirmation handler also appends a pending system row (`pending: true`) carrying that status text. The renderer animates the same braille spinner used for in-flight assistant turns next to the row, and `hasStreamingMessage` keeps `spinnerTickCmd` firing until the action returns. The result handler (`sessionCompactedMsg`, `sessionClearedMsg`) calls `replacePendingSystem` to swap the placeholder for the outcome line in place — no stale "Compacting session…" stuck above the result.
+When `runningStatus` is set, the confirmation handler also appends a pending system row (`pending: true`) carrying that status text to the chat scrollback. The renderer animates the same braille spinner used for in-flight assistant turns next to the row, and `hasStreamingMessage` keeps `spinnerTickCmd` firing until the action returns. The result handler (`sessionCompactedMsg`, `sessionClearedMsg`) calls `replacePendingSystem` to swap the placeholder for the outcome line in place — no stale "Compacting session…" stuck above the result.
+
+## Routine-active navigation gate
+
+Slash commands that strand or replace the chat model — `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections`, `/routine <name>`, `/routines` — route through `gateNavigation()` (`internal/tui/routines_chat.go`) when a routine is active. A `pendingNavConfirm` is set, the prompt is rendered as a notification, and the Enter handler resolves it: `y` cancels any in-flight turn, ends the routine cleanly (closing the log file), and dispatches the navigation; `n` or Esc dismisses the prompt and the routine continues. The state is independent of the generic `pendingConfirmation` so the two flows don't compete. See [routines.md → Slash commands and gating](routines.md#slash-commands-and-gating) for the full rationale.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -1,0 +1,237 @@
+# Routines
+
+Routines are ordered prompt sequences stored on disk and replayed against the active session via `/routine <name>`. Each step is a complete user message; the controller dispatches them one at a time, optionally auto-advancing after each assistant reply. Routines are a chat-only concept — there is no gateway counterpart, and every backend works with them.
+
+The user-facing surface is `/routine <name>` (activate) and `/routines` (manage). Routine state lives entirely in `chatModel`; on disk, each routine is a directory under `~/.lucinate/routines/` containing a single `STEPS.md` file. The implementation splits across `internal/routines/` (file format + storage) and `internal/tui/` (controller + manager view).
+
+## STEPS.md format
+
+Plain markdown. Optional YAML frontmatter delimited by `---` lines carries routine metadata. The body is split into steps on lines containing exactly `---`.
+
+```markdown
+---
+name: demo
+mode: auto              # auto | manual; default = manual
+log: ./demo.log         # absolute or relative-to-cwd; omit to disable logging
+---
+
+generate two integers between 1 and 10
+
+---
+
+if the sum is greater than 10 say /routine:stop, otherwise /routine:continue
+
+---
+
+say "the sum is less than or equal to 10"
+```
+
+Parser rules (`internal/routines/parse.go`):
+
+- If the first non-blank line is `---`, consume YAML frontmatter until the next `---` line. Anything else is treated as body with no frontmatter.
+- The body is split on lines whose `strings.TrimRight(line, " \t\r")` equals `---`.
+- Each chunk is `strings.TrimSpace`'d. Empty chunks are dropped, so consecutive `---` lines collapse harmlessly.
+- The on-disk directory name is the routine's identity (`Routine.Name`); `frontmatter.name` is informational.
+
+`Format(r Routine)` is the round-trip — frontmatter is emitted only when at least one field is non-empty, and steps are joined with `\n---\n\n`. `TestFormatRoundTrip` pins the parse→format→parse invariant.
+
+## Disk layout
+
+Resolved through `config.DataDir()`:
+
+```
+~/.lucinate/routines/
+  <name>/
+    STEPS.md
+```
+
+`internal/routines/store.go` exposes:
+
+| Function | Behaviour |
+|---|---|
+| `Dir()` | `<data-dir>/routines` (not auto-created) |
+| `List()` | Scan + parse every subdirectory; entries that fail to parse are silently skipped so one bad file doesn't sink the listing |
+| `Load(name)` | Returns `Routine{}` + `ErrNotFound` if the directory is missing |
+| `Save(r)` | `MkdirAll(0o700)` + atomic `WriteFile`/`Rename` of `STEPS.md` |
+| `Delete(name)` | `os.RemoveAll(<dir>/<name>)` |
+
+`validName` rejects empty, `.`, `..`, leading-dot, and any name containing `/`, `\\`, or NUL — the same conservative shape used elsewhere for filesystem-derived identifiers.
+
+## Controller
+
+The active routine lives on `chatModel.activeRoutine` (`internal/tui/routines_chat.go`):
+
+```go
+type activeRoutine struct {
+    routine routines.Routine
+    mode    routines.Mode
+    sent    int                 // count of steps already dispatched
+    paused  bool
+    logger  *routines.Logger    // nil if no `log:` configured
+}
+```
+
+Lifecycle entry points on `*chatModel`:
+
+| Method | Purpose |
+|---|---|
+| `startRoutine(name)` | Load + parse from disk, open the log if configured, append the "Routine started" notification, return the `tea.Cmd` for step 0's send |
+| `sendNextRoutineStep()` | Read `Steps[ar.sent]`, increment `ar.sent`, append the user message + assistant placeholder to `m.messages`, set `m.sending=true`, log the user line, return `sendMessage(...)` |
+| `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Returns `nil` unless the routine is active, mode is auto, not paused, and a step remains. Otherwise returns `sendNextRoutineStep`. When all steps have been sent, calls `endRoutine("completed")` and returns nil. |
+| `applyDirectives(reply)` | Scans the assistant reply for `/routine:` directives and applies them in order |
+| `endRoutine(reason)` | Closes the logger, clears `activeRoutine`, posts a "Routine X <reason>" notification |
+| `cycleRoutineMode()` | Bound to `Alt+M` — flips between auto and manual; entering auto unsets `paused` |
+
+Step indexing is strictly monotonic: only `sendNextRoutineStep` increments `ar.sent`, and it does so once per call. Auto-advance is gated solely on `ar.sent < len(Steps)` and the directive/pause flags — there is no path that decrements or skips.
+
+## Auto-advance hook
+
+Auto-advance lives in the `final` case of `handleEvent` (`internal/tui/events.go`). The order matters:
+
+1. Mark the streaming assistant message as finalised (existing behaviour).
+2. If `m.activeRoutine != nil`: log the assistant content (when a logger is configured) and call `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before any auto-advance fires.
+3. Drain `m.pendingMessages` — user-typed queue jumps ahead of the routine.
+4. If the queue is empty and `m.sending` is now false, call `maybeAdvanceRoutine()`. If it returns a cmd, dispatch it (sending the next step) and return.
+5. Otherwise fall through to the standard `refreshHistory` + `loadStats` batch.
+
+`error` and `aborted` set `paused = true` instead of advancing, so a transient gateway error doesn't loop the next step. The user can press Enter (empty input) to retry the next step or Esc to end the routine.
+
+## Stale-event filtering
+
+The OpenClaw gateway has been observed emitting a duplicate `delta` event with the full content right *after* the matching `final`, on the same `runID`. Without filtering, that delta lands on the next routine step's freshly-appended placeholder, flipping `awaitingDelta` and letting a subsequent empty-content `final` falsely finalise an empty turn — which spuriously auto-advances the routine.
+
+`chatModel.prevFinalisedRunID` tracks the last finalised run; the top of the chat-event branch in `handleEvent` drops any event whose `RunID` matches it:
+
+```go
+if chatEv.RunID != "" && chatEv.RunID == m.prevFinalisedRunID {
+    logEvent("  STALE event for finalised run %s — ignored", chatEv.RunID)
+    return nil
+}
+```
+
+`prevFinalisedRunID` is set inside the `final`, `error`, and `aborted` paths, but only when the corresponding state mutation actually happened (gated on the same `finalised` flag). `TestHandleEvent_StaleDeltaAfterFinalIgnored` covers the bug end-to-end.
+
+## Directives
+
+The assistant can steer the routine by emitting one of these on its own line (leading whitespace allowed):
+
+| Directive | Effect |
+|---|---|
+| `/routine:stop` | End the active routine immediately |
+| `/routine:pause` | Pause without ending — Enter sends the next step, Esc ends |
+| `/routine:continue` | Explicit no-op; also unsets `paused` so it can resume an auto-mode routine |
+| `/routine:mode auto` | Switch to auto mode; unsets `paused` |
+| `/routine:mode manual` | Switch to manual mode |
+
+Matching (`internal/routines/directives.go`):
+
+```go
+^\s*/routine:(stop|pause|continue|mode\s+(auto|manual))\s*$
+```
+
+Anchored with `^...$` and applied per line. Inline mentions (`as in /routine:stop`, backtick-wrapped tokens) deliberately do not match. Directives are kept verbatim in the rendered transcript — `applyDirectives` doesn't rewrite the assistant message.
+
+User-typed `/routine:*` lines in the chat input are not parsed. Only assistant replies are scanned.
+
+## Logging
+
+When the frontmatter sets `log: <path>`, `routines.Logger` opens the file (`O_APPEND | O_CREATE | O_WRONLY`, mode `0o600`) at routine start and closes it on `endRoutine`. Relative paths resolve against the lucinate working directory at start time, captured via `os.Getwd()`.
+
+Format:
+
+```
+--- routine: demo started 2026-05-09T22:30:00Z ---
+[2026-05-09T22:30:00Z] user: <step 1 text>
+[2026-05-09T22:30:05Z] assistant: <reply line 1>
+<reply line 2 — no per-line prefix>
+```
+
+Only the *first* line of a multi-line message gets the `[ts] role:` prefix; subsequent lines are written verbatim so log diffs read like the chat. The logger is best-effort — write errors are silently swallowed so a logging hiccup never breaks the running routine. `Open` returns `nil, nil` for an empty path so callers can invoke it unconditionally.
+
+## Manager view
+
+`/routines` opens `routinesModel` (`internal/tui/routines.go`), modelled on the cron browser. Four substates:
+
+| Substate | Purpose |
+|---|---|
+| `routinesSubList` | List of routines (name + step count + mode chips) |
+| `routinesSubDetail` | Read-only view of a single routine — frontmatter, file path, every step rendered in order |
+| `routinesSubForm` | Create / edit form |
+| `routinesSubConfirmDelete` | y/n prompt before `routines.Delete` fires |
+
+The form has three textinputs (name, mode, log) plus a slice of `textarea.Model` for the steps — one per step. The focus index is a single int: `0..2` are the header fields, `3+i` is step `i`. Key bindings inside the form:
+
+| Key | Action |
+|---|---|
+| Tab / Shift+Tab | Cycle focus |
+| Alt+S (or Ctrl+S) | Save — Alt+S is the primary because Ctrl+S is XOFF on most terminals |
+| Alt+Up | Insert blank step above the focused step |
+| Alt+Down | Insert blank step below the focused step |
+| Alt+Delete (or Alt+Backspace) | Remove the focused step (y/n confirm) |
+| Esc | Cancel without saving |
+| Alt+Enter | Newline within a step textarea |
+
+`insertStep(idx, value)` uses an overlap-safe `copy` (`memmove`) so shift-right insertion never duplicates content. `deleteStep(idx)` re-inserts a blank textarea when the slice would otherwise empty out, so the form always has at least one step to type into.
+
+Submission iterates `form.steps` in order, dropping blank ones, and goes through `routines.Save`. Editing with a renamed `name` writes the new directory and `Delete`s the old one. After save (or delete), the model emits `routinesChangedMsg` so the chat view refreshes its `m.routineNames` cache for `/routine <TAB>` completion.
+
+## Slash commands and gating
+
+Two entries in `slashCommands`:
+
+| Command | Behaviour |
+|---|---|
+| `/routine <name>` | Activate the named routine. Bare `/routine` is an error pointing at `/routines`. Tab completion uses `m.routineNames` populated by `loadRoutineNames()` at chat init and after any manager-view CRUD. |
+| `/routines` | Open the manager via `showRoutinesMsg{}` |
+
+Only one routine can run at a time per session. Both commands route through `gateNavigation()` (`routines_chat.go`) when a routine is already active:
+
+```
+Routine "demo" is active. Starting routine "other" will cancel it. Continue? (y/n)
+```
+
+The same gate covers the navigations that strand or replace the chat model — `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections` — for the same reason: the active routine controller can't survive a chat-view reset, and silently dropping it would leak the open log file. On `y`, the gate cancels any in-flight turn (`cancelTurn`) and ends the routine (`endRoutine`) before dispatching the navigation. On `n` or Esc the prompt clears and the routine continues.
+
+`startRoutine` itself still has a defensive `if m.activeRoutine != nil` guard, but in normal flow the gate runs first.
+
+## Notifications
+
+Routine state changes (started, paused, ended) and routine errors are surfaced as ephemeral notifications, not chat rows — see [chat-ux.md → Notifications](chat-ux.md#notifications). They live outside `m.messages` so a `historyRefreshMsg` doesn't wipe them, and they clear when the user submits any non-empty input. The routine controller calls `m.notify` / `m.notifyError` directly; the legacy `appendSystemError` helper still exists but routes to `notifyError` under the hood for older callers.
+
+## Status row
+
+When `m.activeRoutine != nil`, the chat View renders a single styled row immediately above the input box:
+
+```
+routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
+```
+
+`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set; `next:` previews the next step body, single-lined and ellipsised. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`. `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
+
+## Key bindings
+
+| Key | Behaviour |
+|---|---|
+| Alt+M | Cycle mode (auto ↔ manual). No-op when no routine is active. Alt is used because every Ctrl+letter has a readline binding (Ctrl+R reverse-search, Ctrl+S XOFF, etc.). |
+| Esc | When a routine is active: end the routine and (if streaming) cancel the in-flight turn. Otherwise behaves as before (`/cancel`-equivalent or transcript back). |
+| Enter (empty input) | When a routine is active and idle (manual or paused): send the next step. Otherwise no-op. |
+
+## Verification
+
+Unit tests:
+
+- `internal/routines/parse_test.go` — frontmatter parsing, default mode, blank-line preservation, format round-trip.
+- `internal/routines/directives_test.go` — own-line matching, inline-mention rejection, all five directive kinds.
+- `internal/routines/store_test.go` — disk round-trip, invalid-name rejection.
+- `internal/routines/log_test.go` — header + per-message timestamp shape, multi-line bodies, append across reopens, nil-receiver safety.
+- `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` — pins the duplicate-delta-after-final filter.
+- `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
+
+Manual smoke:
+
+1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — next: …`.
+2. Press Enter on an empty input — step 1 dispatches.
+3. Alt+M flips status to `AUTO`. Subsequent step finals auto-advance.
+4. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
+5. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
+6. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.

--- a/internal/routines/directives.go
+++ b/internal/routines/directives.go
@@ -1,0 +1,36 @@
+package routines
+
+import (
+	"regexp"
+	"strings"
+)
+
+// directivePattern matches a /routine: instruction occupying its own line.
+// Leading whitespace is allowed; trailing whitespace is allowed. The body
+// must be one of the supported keywords.
+var directivePattern = regexp.MustCompile(`^\s*/routine:(stop|pause|mode\s+(auto|manual))\s*$`)
+
+// ScanDirectives returns every /routine: directive found in reply, in order
+// of appearance. Each directive must occupy its own line — inline mentions
+// like "send /routine:stop to halt" are ignored deliberately.
+func ScanDirectives(reply string) []Directive {
+	var out []Directive
+	for _, raw := range strings.Split(reply, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		m := directivePattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(strings.TrimSpace(m[1]), "stop"):
+			out = append(out, Directive{Kind: DirectiveStop})
+		case strings.HasPrefix(strings.TrimSpace(m[1]), "pause"):
+			out = append(out, Directive{Kind: DirectivePause})
+		case m[2] == "auto":
+			out = append(out, Directive{Kind: DirectiveModeAuto})
+		case m[2] == "manual":
+			out = append(out, Directive{Kind: DirectiveModeManual})
+		}
+	}
+	return out
+}

--- a/internal/routines/directives.go
+++ b/internal/routines/directives.go
@@ -8,7 +8,7 @@ import (
 // directivePattern matches a /routine: instruction occupying its own line.
 // Leading whitespace is allowed; trailing whitespace is allowed. The body
 // must be one of the supported keywords.
-var directivePattern = regexp.MustCompile(`^\s*/routine:(stop|pause|mode\s+(auto|manual))\s*$`)
+var directivePattern = regexp.MustCompile(`^\s*/routine:(stop|pause|continue|mode\s+(auto|manual))\s*$`)
 
 // ScanDirectives returns every /routine: directive found in reply, in order
 // of appearance. Each directive must occupy its own line — inline mentions
@@ -26,6 +26,8 @@ func ScanDirectives(reply string) []Directive {
 			out = append(out, Directive{Kind: DirectiveStop})
 		case strings.HasPrefix(strings.TrimSpace(m[1]), "pause"):
 			out = append(out, Directive{Kind: DirectivePause})
+		case strings.HasPrefix(strings.TrimSpace(m[1]), "continue"):
+			out = append(out, Directive{Kind: DirectiveContinue})
 		case m[2] == "auto":
 			out = append(out, Directive{Kind: DirectiveModeAuto})
 		case m[2] == "manual":

--- a/internal/routines/directives_test.go
+++ b/internal/routines/directives_test.go
@@ -1,0 +1,83 @@
+package routines
+
+import "testing"
+
+func TestScanDirectives_OwnLineMatches(t *testing.T) {
+	in := `Sure, I'll handle that.
+
+/routine:stop
+`
+	got := ScanDirectives(in)
+	if len(got) != 1 || got[0].Kind != DirectiveStop {
+		t.Errorf("got %+v, want [stop]", got)
+	}
+}
+
+func TestScanDirectives_LeadingWhitespaceOK(t *testing.T) {
+	in := "  /routine:pause"
+	got := ScanDirectives(in)
+	if len(got) != 1 || got[0].Kind != DirectivePause {
+		t.Errorf("got %+v, want [pause]", got)
+	}
+}
+
+func TestScanDirectives_InlineMentionIgnored(t *testing.T) {
+	cases := []string{
+		"You could send /routine:stop here",
+		"`/routine:stop` is the directive",
+		"Reply with /routine:stop to halt.",
+	}
+	for _, in := range cases {
+		got := ScanDirectives(in)
+		if len(got) != 0 {
+			t.Errorf("inline %q -> %+v, want none", in, got)
+		}
+	}
+}
+
+func TestScanDirectives_ModeSwitch(t *testing.T) {
+	cases := []struct {
+		in   string
+		kind DirectiveKind
+	}{
+		{"/routine:mode auto", DirectiveModeAuto},
+		{"/routine:mode  manual", DirectiveModeManual},
+		{"  /routine:mode auto  ", DirectiveModeAuto},
+	}
+	for _, tc := range cases {
+		got := ScanDirectives(tc.in)
+		if len(got) != 1 || got[0].Kind != tc.kind {
+			t.Errorf("%q -> %+v, want kind=%v", tc.in, got, tc.kind)
+		}
+	}
+}
+
+func TestScanDirectives_MultipleInOrder(t *testing.T) {
+	in := `/routine:mode auto
+/routine:pause
+/routine:stop`
+	got := ScanDirectives(in)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%+v)", len(got), got)
+	}
+	want := []DirectiveKind{DirectiveModeAuto, DirectivePause, DirectiveStop}
+	for i := range want {
+		if got[i].Kind != want[i] {
+			t.Errorf("[%d] = %v, want %v", i, got[i].Kind, want[i])
+		}
+	}
+}
+
+func TestScanDirectives_UnknownDirectiveIgnored(t *testing.T) {
+	in := "/routine:explode\n/routine:mode\n/routine:mode neutral"
+	got := ScanDirectives(in)
+	if len(got) != 0 {
+		t.Errorf("got %+v, want none", got)
+	}
+}
+
+func TestScanDirectives_EmptyReply(t *testing.T) {
+	if got := ScanDirectives(""); len(got) != 0 {
+		t.Errorf("got %+v, want none", got)
+	}
+}

--- a/internal/routines/directives_test.go
+++ b/internal/routines/directives_test.go
@@ -35,6 +35,13 @@ func TestScanDirectives_InlineMentionIgnored(t *testing.T) {
 	}
 }
 
+func TestScanDirectives_Continue(t *testing.T) {
+	got := ScanDirectives("/routine:continue")
+	if len(got) != 1 || got[0].Kind != DirectiveContinue {
+		t.Errorf("got %+v, want [continue]", got)
+	}
+}
+
 func TestScanDirectives_ModeSwitch(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/routines/log.go
+++ b/internal/routines/log.go
@@ -1,0 +1,81 @@
+package routines
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Logger appends a routine run to a file. The file is opened on Open and
+// kept open for the duration of the run; Close releases it. All operations
+// are best-effort — a failing write should not break the user's session,
+// so callers ignore returned errors except at Open.
+type Logger struct {
+	f       *os.File
+	now     func() time.Time
+	rootDir string
+}
+
+// Open opens (or creates) the log file at path and writes a run header.
+// Relative paths resolve against rootDir (typically os.Getwd()). Returns
+// nil, nil when path is empty so callers can unconditionally invoke it.
+func Open(path, rootDir, routineName string) (*Logger, error) {
+	if path == "" {
+		return nil, nil
+	}
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(rootDir, abs)
+	}
+	if dir := filepath.Dir(abs); dir != "" {
+		_ = os.MkdirAll(dir, 0o700)
+	}
+	f, err := os.OpenFile(abs, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open routine log: %w", err)
+	}
+	l := &Logger{f: f, now: time.Now, rootDir: rootDir}
+	header := fmt.Sprintf("--- routine: %s started %s ---\n",
+		routineName, l.now().UTC().Format(time.RFC3339))
+	_, _ = f.WriteString(header)
+	return l, nil
+}
+
+// WriteUser appends a user message to the log.
+func (l *Logger) WriteUser(text string) {
+	l.write("user", text)
+}
+
+// WriteAssistant appends an assistant message to the log.
+func (l *Logger) WriteAssistant(text string) {
+	l.write("assistant", text)
+}
+
+// Close flushes and closes the underlying file. Safe on a nil receiver.
+func (l *Logger) Close() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = l.f.Close()
+	l.f = nil
+}
+
+func (l *Logger) write(role, text string) {
+	if l == nil || l.f == nil {
+		return
+	}
+	ts := l.now().UTC().Format(time.RFC3339)
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s: %s\n", ts, role, lines[0])
+	for _, line := range lines[1:] {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	_, _ = l.f.WriteString(b.String())
+}

--- a/internal/routines/log_test.go
+++ b/internal/routines/log_test.go
@@ -1,0 +1,78 @@
+package routines
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLogger_Format(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	l, err := Open(path, dir, "demo")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Pin the clock so the assertion is stable.
+	fixed := time.Date(2026, 5, 9, 14, 30, 5, 0, time.UTC)
+	l.now = func() time.Time { return fixed }
+
+	l.WriteUser("hello")
+	l.WriteAssistant("hi there\nover two lines")
+	l.Close()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(got)
+
+	if !strings.Contains(s, "--- routine: demo started") {
+		t.Errorf("missing run header: %q", s)
+	}
+	if !strings.Contains(s, "[2026-05-09T14:30:05Z] user: hello") {
+		t.Errorf("missing user line: %q", s)
+	}
+	if !strings.Contains(s, "[2026-05-09T14:30:05Z] assistant: hi there\nover two lines") {
+		t.Errorf("missing multi-line assistant message: %q", s)
+	}
+}
+
+func TestLogger_AppendsAcrossRuns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.log")
+
+	for i := 0; i < 2; i++ {
+		l, err := Open(path, dir, "demo")
+		if err != nil {
+			t.Fatalf("Open #%d: %v", i, err)
+		}
+		l.WriteUser("turn")
+		l.Close()
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Count(string(got), "--- routine: demo started") != 2 {
+		t.Errorf("expected 2 run headers, got: %q", string(got))
+	}
+}
+
+func TestLogger_NilSafe(t *testing.T) {
+	l, err := Open("", "/tmp", "x")
+	if err != nil {
+		t.Fatalf("Open(empty path): %v", err)
+	}
+	if l != nil {
+		t.Errorf("Open(empty path) returned non-nil logger")
+	}
+	// Methods on nil receiver must not panic.
+	l.WriteUser("x")
+	l.WriteAssistant("y")
+	l.Close()
+}

--- a/internal/routines/parse.go
+++ b/internal/routines/parse.go
@@ -1,0 +1,132 @@
+package routines
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Parse reads a STEPS.md document and returns the parsed Routine.
+//
+// File grammar (in order):
+//   - Optional YAML frontmatter delimited by lines containing exactly "---".
+//   - One or more step bodies separated by lines containing exactly "---".
+//
+// A frontmatter block is recognised only when the very first non-empty line
+// is "---"; otherwise the whole document is treated as steps. Step bodies
+// preserve internal blank lines, but leading/trailing whitespace around the
+// body is trimmed. Empty bodies (consecutive separators) are dropped.
+//
+// The provided name becomes Routine.Name regardless of any frontmatter.name
+// value — the on-disk directory is the source of truth for identity.
+func Parse(content, name, path string) (Routine, error) {
+	r := Routine{Name: name, Path: path}
+
+	body := content
+	if fm, rest, ok := splitFrontmatter(content); ok {
+		var parsed Frontmatter
+		if err := yaml.Unmarshal([]byte(fm), &parsed); err != nil {
+			return Routine{}, fmt.Errorf("invalid frontmatter YAML: %w", err)
+		}
+		r.Frontmatter = parsed
+		body = rest
+	}
+
+	r.Steps = splitSteps(body)
+	return r, nil
+}
+
+// splitFrontmatter detects a leading YAML frontmatter block and returns
+// the YAML body and the post-frontmatter remainder. The first non-blank
+// line must be "---" and a subsequent "---" line closes the block. Returns
+// ok=false when no frontmatter is present.
+func splitFrontmatter(content string) (yamlBody, rest string, ok bool) {
+	lines := strings.Split(content, "\n")
+
+	// Skip leading blank lines.
+	first := 0
+	for first < len(lines) && strings.TrimSpace(lines[first]) == "" {
+		first++
+	}
+	if first >= len(lines) || strings.TrimRight(lines[first], " \t\r") != "---" {
+		return "", "", false
+	}
+
+	// Find the closing "---".
+	for i := first + 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], " \t\r") != "---" {
+			continue
+		}
+		yamlBody = strings.Join(lines[first+1:i], "\n")
+		rest = strings.Join(lines[i+1:], "\n")
+		return yamlBody, rest, true
+	}
+	return "", "", false
+}
+
+// SplitSteps splits a body (with no frontmatter) on lines containing
+// exactly "---", trims each chunk, and drops empty chunks. Useful when
+// turning editor-form contents into a step list before saving.
+func SplitSteps(body string) []string { return splitSteps(body) }
+
+// splitSteps splits a body on lines containing exactly "---" (ignoring
+// trailing whitespace), trims each chunk, and drops empty chunks.
+func splitSteps(body string) []string {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+	lines := strings.Split(body, "\n")
+	var (
+		steps []string
+		cur   []string
+	)
+	flush := func() {
+		joined := strings.TrimSpace(strings.Join(cur, "\n"))
+		if joined != "" {
+			steps = append(steps, joined)
+		}
+		cur = cur[:0]
+	}
+	for _, line := range lines {
+		if strings.TrimRight(line, " \t\r") == "---" {
+			flush()
+			continue
+		}
+		cur = append(cur, line)
+	}
+	flush()
+	return steps
+}
+
+// Format renders a Routine back to a STEPS.md document. Frontmatter is
+// included only when at least one field is non-empty. Used by the editor
+// UI for round-tripping.
+func Format(r Routine) string {
+	var b strings.Builder
+	if hasFrontmatter(r.Frontmatter) {
+		b.WriteString("---\n")
+		if r.Frontmatter.Name != "" {
+			fmt.Fprintf(&b, "name: %s\n", r.Frontmatter.Name)
+		}
+		if r.Frontmatter.Mode != "" {
+			fmt.Fprintf(&b, "mode: %s\n", r.Frontmatter.Mode)
+		}
+		if r.Frontmatter.Log != "" {
+			fmt.Fprintf(&b, "log: %s\n", r.Frontmatter.Log)
+		}
+		b.WriteString("---\n\n")
+	}
+	for i, step := range r.Steps {
+		if i > 0 {
+			b.WriteString("\n---\n\n")
+		}
+		b.WriteString(strings.TrimSpace(step))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func hasFrontmatter(f Frontmatter) bool {
+	return f.Name != "" || f.Mode != "" || f.Log != ""
+}

--- a/internal/routines/parse_test.go
+++ b/internal/routines/parse_test.go
@@ -1,0 +1,169 @@
+package routines
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_FullFrontmatter(t *testing.T) {
+	in := `---
+name: demo
+mode: auto
+log: ./demo.log
+---
+
+first step
+
+It can have multiple lines
+
+---
+second step
+
+---
+
+third step
+`
+	r, err := Parse(in, "demo", "/x/STEPS.md")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if r.Name != "demo" {
+		t.Errorf("Name = %q, want demo", r.Name)
+	}
+	if r.Frontmatter.Mode != "auto" {
+		t.Errorf("Mode = %q, want auto", r.Frontmatter.Mode)
+	}
+	if r.Frontmatter.Log != "./demo.log" {
+		t.Errorf("Log = %q, want ./demo.log", r.Frontmatter.Log)
+	}
+	if len(r.Steps) != 3 {
+		t.Fatalf("len(Steps) = %d, want 3", len(r.Steps))
+	}
+	if !strings.HasPrefix(r.Steps[0], "first step") {
+		t.Errorf("Step[0] = %q, want prefix 'first step'", r.Steps[0])
+	}
+	if !strings.Contains(r.Steps[0], "It can have multiple lines") {
+		t.Errorf("Step[0] missing second line: %q", r.Steps[0])
+	}
+}
+
+func TestParse_NoFrontmatter(t *testing.T) {
+	in := `first step
+
+---
+
+second step
+`
+	r, err := Parse(in, "x", "")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if r.ResolvedMode() != ModeManual {
+		t.Errorf("ResolvedMode = %q, want manual", r.ResolvedMode())
+	}
+	if len(r.Steps) != 2 {
+		t.Fatalf("len(Steps) = %d, want 2", len(r.Steps))
+	}
+	if r.Steps[0] != "first step" {
+		t.Errorf("Step[0] = %q, want 'first step'", r.Steps[0])
+	}
+}
+
+func TestParse_PreservesInternalBlankLines(t *testing.T) {
+	in := `---
+name: x
+---
+para one
+
+para two
+
+para three
+`
+	r, err := Parse(in, "x", "")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(r.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want 1", len(r.Steps))
+	}
+	got := r.Steps[0]
+	want := "para one\n\npara two\n\npara three"
+	if got != want {
+		t.Errorf("Step[0] = %q, want %q", got, want)
+	}
+}
+
+func TestParse_EmptySeparatorsDropped(t *testing.T) {
+	in := `step one
+---
+---
+step two
+`
+	r, err := Parse(in, "x", "")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(r.Steps) != 2 {
+		t.Fatalf("len(Steps) = %d, want 2 (got %v)", len(r.Steps), r.Steps)
+	}
+}
+
+func TestParse_ResolvedModeDefaults(t *testing.T) {
+	cases := []struct {
+		mode string
+		want Mode
+	}{
+		{"", ModeManual},
+		{"manual", ModeManual},
+		{"auto", ModeAuto},
+		{"bogus", ModeManual},
+	}
+	for _, tc := range cases {
+		r := Routine{Frontmatter: Frontmatter{Mode: tc.mode}}
+		if got := r.ResolvedMode(); got != tc.want {
+			t.Errorf("Mode=%q ResolvedMode=%q want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestFormatRoundTrip(t *testing.T) {
+	r1 := Routine{
+		Name: "demo",
+		Frontmatter: Frontmatter{
+			Name: "demo",
+			Mode: "auto",
+			Log:  "./out.log",
+		},
+		Steps: []string{
+			"first step\n\nwith two paragraphs",
+			"second step",
+		},
+	}
+	s := Format(r1)
+	r2, err := Parse(s, "demo", "")
+	if err != nil {
+		t.Fatalf("Parse(Format()): %v", err)
+	}
+	if r2.Frontmatter != r1.Frontmatter {
+		t.Errorf("frontmatter mismatch: got %+v want %+v", r2.Frontmatter, r1.Frontmatter)
+	}
+	if len(r2.Steps) != len(r1.Steps) {
+		t.Fatalf("len(Steps) = %d, want %d", len(r2.Steps), len(r1.Steps))
+	}
+	for i := range r1.Steps {
+		if r2.Steps[i] != r1.Steps[i] {
+			t.Errorf("Steps[%d]: got %q want %q", i, r2.Steps[i], r1.Steps[i])
+		}
+	}
+}
+
+func TestFormat_NoFrontmatterWhenEmpty(t *testing.T) {
+	r := Routine{Steps: []string{"a", "b"}}
+	s := Format(r)
+	if strings.HasPrefix(s, "---") {
+		t.Errorf("Format emitted frontmatter block for empty Frontmatter: %q", s)
+	}
+	if !strings.Contains(s, "\n---\n") {
+		t.Errorf("Format missing step separator: %q", s)
+	}
+}

--- a/internal/routines/store.go
+++ b/internal/routines/store.go
@@ -1,0 +1,131 @@
+package routines
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// ErrNotFound is returned by Load when no routine directory exists for the
+// requested name.
+var ErrNotFound = errors.New("routine not found")
+
+// Dir returns the routines root directory (<data-dir>/routines). It is not
+// created here — callers that mutate the tree must MkdirAll themselves.
+func Dir() (string, error) {
+	root, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "routines"), nil
+}
+
+// List returns every routine present on disk, sorted by name. Routines whose
+// STEPS.md is missing or unparseable are skipped silently — listing should
+// surface what works rather than refuse on one bad entry.
+func List() ([]Routine, error) {
+	dir, err := Dir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Routine
+	for _, entry := range entries {
+		info, err := os.Stat(filepath.Join(dir, entry.Name()))
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		r, err := Load(entry.Name())
+		if err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Load reads and parses a single routine by name. Returns ErrNotFound if the
+// directory doesn't exist or contains no STEPS.md.
+func Load(name string) (Routine, error) {
+	if !validName(name) {
+		return Routine{}, fmt.Errorf("invalid routine name %q", name)
+	}
+	dir, err := Dir()
+	if err != nil {
+		return Routine{}, err
+	}
+	path := filepath.Join(dir, name, "STEPS.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Routine{}, ErrNotFound
+		}
+		return Routine{}, err
+	}
+	return Parse(string(data), name, path)
+}
+
+// Save writes the routine to disk. The directory <routines>/<name>/ is
+// created when missing. Existing STEPS.md is overwritten atomically.
+func Save(r Routine) error {
+	if !validName(r.Name) {
+		return fmt.Errorf("invalid routine name %q", r.Name)
+	}
+	root, err := Dir()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(root, r.Name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	target := filepath.Join(dir, "STEPS.md")
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, []byte(Format(r)), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, target)
+}
+
+// Delete removes the routine directory and everything beneath it.
+func Delete(name string) error {
+	if !validName(name) {
+		return fmt.Errorf("invalid routine name %q", name)
+	}
+	root, err := Dir()
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(filepath.Join(root, name))
+}
+
+// validName accepts directory-safe routine names: non-empty, no path
+// separators, no leading dot. Mirrors the conservative shape we already
+// enforce on agent identifiers.
+func validName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if name[0] == '.' {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c == '/' || c == '\\' || c == 0:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/routines/store_test.go
+++ b/internal/routines/store_test.go
@@ -1,0 +1,74 @@
+package routines
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+func TestStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	config.SetDataDir(dir)
+	t.Cleanup(func() { config.SetDataDir("") })
+
+	in := Routine{
+		Name: "demo",
+		Frontmatter: Frontmatter{
+			Name: "demo",
+			Mode: string(ModeAuto),
+			Log:  "./demo.log",
+		},
+		Steps: []string{
+			"first step\n\nwith two paragraphs",
+			"second step",
+		},
+	}
+	if err := Save(in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	out, err := Load("demo")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out.Name != "demo" {
+		t.Errorf("Name = %q", out.Name)
+	}
+	if out.ResolvedMode() != ModeAuto {
+		t.Errorf("ResolvedMode = %q", out.ResolvedMode())
+	}
+	if len(out.Steps) != 2 {
+		t.Fatalf("len(Steps) = %d, want 2", len(out.Steps))
+	}
+	if out.Steps[0] != in.Steps[0] {
+		t.Errorf("Steps[0] = %q, want %q", out.Steps[0], in.Steps[0])
+	}
+	if out.Path != filepath.Join(dir, "routines", "demo", "STEPS.md") {
+		t.Errorf("Path = %q", out.Path)
+	}
+
+	listed, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "demo" {
+		t.Errorf("List = %+v, want [demo]", listed)
+	}
+
+	if err := Delete("demo"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := Load("demo"); err != ErrNotFound {
+		t.Errorf("Load after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_RejectsInvalidName(t *testing.T) {
+	cases := []string{"", ".", "..", ".hidden", "with/slash", "with\\back"}
+	for _, name := range cases {
+		if err := Save(Routine{Name: name, Steps: []string{"x"}}); err == nil {
+			t.Errorf("Save(%q) = nil, want error", name)
+		}
+	}
+}

--- a/internal/routines/types.go
+++ b/internal/routines/types.go
@@ -1,0 +1,64 @@
+// Package routines implements multi-step prompt routines: ordered lists of
+// user-facing prompts read from disk, applied via /routine <name> in the chat
+// view, and optionally auto-advanced after each assistant reply.
+package routines
+
+// Mode is the activation mode for an active routine.
+type Mode string
+
+const (
+	ModeManual Mode = "manual"
+	ModeAuto   Mode = "auto"
+)
+
+// Frontmatter is the optional YAML header at the top of a STEPS.md file.
+// Every field is optional; absent fields fall back to documented defaults.
+type Frontmatter struct {
+	Name string `yaml:"name"`
+	Mode string `yaml:"mode"`
+	Log  string `yaml:"log"`
+}
+
+// Routine is a parsed STEPS.md file ready for activation.
+type Routine struct {
+	// Name is the routine's directory name (the on-disk identity).
+	// Frontmatter Name is informational and does not override this.
+	Name string
+
+	// Frontmatter holds the verbatim metadata block from the file.
+	Frontmatter Frontmatter
+
+	// Steps are the ordered step bodies. Each is the user-message text
+	// to send when that step fires, with surrounding whitespace trimmed.
+	Steps []string
+
+	// Path is the absolute path to the routine's STEPS.md file.
+	Path string
+}
+
+// ResolvedMode returns the routine's mode with the documented default
+// (manual) applied when frontmatter omits the field.
+func (r Routine) ResolvedMode() Mode {
+	switch Mode(r.Frontmatter.Mode) {
+	case ModeAuto:
+		return ModeAuto
+	default:
+		return ModeManual
+	}
+}
+
+// DirectiveKind classifies a /routine: directive parsed from an
+// assistant reply.
+type DirectiveKind int
+
+const (
+	DirectiveStop DirectiveKind = iota
+	DirectivePause
+	DirectiveModeAuto
+	DirectiveModeManual
+)
+
+// Directive is a single parsed /routine: instruction.
+type Directive struct {
+	Kind DirectiveKind
+}

--- a/internal/routines/types.go
+++ b/internal/routines/types.go
@@ -56,6 +56,11 @@ const (
 	DirectivePause
 	DirectiveModeAuto
 	DirectiveModeManual
+	// DirectiveContinue is a no-op the assistant can emit to make its
+	// intent explicit ("keep going") in conditional steps. The routine
+	// controller treats it as a recognised pass-through so unknown
+	// /routine: tokens don't silently advance under it.
+	DirectiveContinue
 )
 
 // Directive is a single parsed /routine: instruction.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -23,6 +23,7 @@ const (
 	viewConfig
 	viewCrons
 	viewModelPicker
+	viewRoutines
 )
 
 // BackendFactory builds an unconnected backend.Backend for a stored
@@ -114,6 +115,7 @@ type AppModel struct {
 	configModel      configModel
 	cronsModel       cronsModel
 	modelPicker      modelPickerModel
+	routinesModel    routinesModel
 	backend          backend.Backend
 	activeConn       *config.Connection // the connection backend belongs to; rendered in status bars
 	store            *config.Connections
@@ -268,6 +270,8 @@ func (m AppModel) Actions() []Action {
 		return m.cronsModel.Actions()
 	case viewModelPicker:
 		return m.modelPicker.Actions()
+	case viewRoutines:
+		return m.routinesModel.Actions()
 	}
 	return nil
 }
@@ -305,6 +309,10 @@ func (m AppModel) TriggerAction(id string) (AppModel, tea.Cmd) {
 	case viewModelPicker:
 		var cmd tea.Cmd
 		m.modelPicker, cmd = m.modelPicker.TriggerAction(id)
+		return m, cmd
+	case viewRoutines:
+		var cmd tea.Cmd
+		m.routinesModel, cmd = m.routinesModel.TriggerAction(id)
 		return m, cmd
 	}
 	return m, nil
@@ -456,6 +464,8 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.cronsModel.setSize(msg.Width, msg.Height)
 		case viewModelPicker:
 			m.modelPicker.setSize(msg.Width, msg.Height)
+		case viewRoutines:
+			m.routinesModel.setSize(msg.Width, msg.Height)
 		}
 		return m, nil
 
@@ -580,6 +590,30 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			return m, notify
 		}
 		return m, nil
+
+	case showRoutinesMsg:
+		m.routinesModel = newRoutinesModel(m.hideActionHints, m.disableExitKeys)
+		m.routinesModel.setSize(m.width, m.height)
+		m.state = viewRoutines
+		return m, m.routinesModel.Init()
+
+	case goBackFromRoutinesMsg:
+		m.state = viewChat
+		return m, nil
+
+	case routinesChangedMsg:
+		// Re-scan routine names so the chat's /routine <TAB> completion
+		// reflects edits made in the manager.
+		return m, loadRoutineNames()
+
+	case chatRoutineNamesLoadedMsg:
+		// Forward to the chat model regardless of which view is active —
+		// loadRoutineNames is dispatched from the routines manager too,
+		// and the chatModel needs to see the result so its autocompletion
+		// is current when the user navigates back.
+		var cmd tea.Cmd
+		m.chatModel, cmd = m.chatModel.Update(msg)
+		return m, cmd
 
 	case showCronsMsg:
 		cron, ok := m.backend.(backend.CronBackend)
@@ -799,6 +833,11 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		var cmd tea.Cmd
 		m.modelPicker, cmd = m.modelPicker.Update(msg)
 		return m, cmd
+
+	case viewRoutines:
+		var cmd tea.Cmd
+		m.routinesModel, cmd = m.routinesModel.Update(msg)
+		return m, cmd
 	}
 
 	return m, nil
@@ -995,6 +1034,8 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView(m.cronsModel.View())
 	case viewModelPicker:
 		v = tea.NewView(m.modelPicker.View())
+	case viewRoutines:
+		v = tea.NewView(m.routinesModel.View())
 	default:
 		v = tea.NewView("")
 	}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -177,6 +177,7 @@ type chatModel struct {
 	prefs              config.Preferences
 	pendingConfirm     *pendingConfirmation
 	pendingNavConfirm  *pendingNavConfirm
+	notifications      []notification // ephemeral status rows rendered above the input; cleared when the user submits an input
 	historyLimit       int
 	historyLoading     bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
 	thinkingLevel      string // current thinking level; "" means not set / using gateway default
@@ -619,7 +620,8 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		case "esc":
 			if m.pendingNavConfirm != nil {
 				m.pendingNavConfirm = nil
-				m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled — routine continues."})
+				m.clearNotifications()
+				m.notify("Cancelled — routine continues.")
 				m.updateViewport()
 				return m, nil
 			}
@@ -686,11 +688,19 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				// branch only when there is content.
 				if ar := m.activeRoutine; ar != nil && !m.sending {
 					if (ar.mode == routines.ModeManual || ar.paused) && ar.sent < len(ar.routine.Steps) {
+						m.clearNotifications()
 						return m, m.sendNextRoutineStep()
 					}
 				}
 				return m, nil
 			}
+
+			// Any non-empty submission (typed text, y/n on a confirm,
+			// slash command, queued message) clears the ephemeral
+			// notification rows above the input — the user has just
+			// taken a meaningful action and any pending notifications
+			// have either been read or no longer apply.
+			m.clearNotifications()
 
 			// Resolve a pending routine-cancel-on-navigation prompt. Done
 			// before the generic pendingConfirm path because the nav
@@ -719,7 +729,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 					m.updateViewport()
 					return m, tea.Batch(cmds...)
 				}
-				m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled — routine continues."})
+				m.notify("Cancelled — routine continues.")
 				m.updateViewport()
 				return m, nil
 			}
@@ -732,7 +742,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.pendingConfirm = nil
 				lower := strings.ToLower(text)
 				if lower == "y" || lower == "yes" {
-					m.messages = append(m.messages, chatMessage{role: "system", content: "Confirmed."})
+					m.notify("Confirmed.")
 					var spinnerCmd tea.Cmd
 					if confirm.runningStatus != "" {
 						m.messages = append(m.messages, chatMessage{
@@ -745,7 +755,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 					m.updateViewport()
 					return m, tea.Batch(confirm.action(), spinnerCmd)
 				}
-				m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled."})
+				m.notify("Cancelled.")
 				m.updateViewport()
 				return m, nil
 			}
@@ -945,7 +955,7 @@ func (m *chatModel) sendMessage(text string) tea.Cmd {
 // cancelTurn aborts the active turn and clears pending messages.
 func (m *chatModel) cancelTurn() tea.Cmd {
 	if !m.sending || m.runID == "" {
-		m.messages = append(m.messages, chatMessage{role: "system", content: "Nothing to cancel."})
+		m.notify("Nothing to cancel.")
 		m.updateViewport()
 		return nil
 	}
@@ -963,7 +973,7 @@ func (m *chatModel) cancelTurn() tea.Cmd {
 			last.content += "\n[aborted]"
 		}
 	}
-	m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled."})
+	m.notify("Cancelled.")
 	m.updateViewport()
 	return func() tea.Msg {
 		err := b.ChatAbort(context.Background(), sessionKey, runID)
@@ -1200,9 +1210,13 @@ func (m chatModel) View() string {
 	if line := m.routineStatusLine(); line != "" {
 		routineStatus = routineStatusStyle.Width(m.width).Render(line)
 	}
+	notifications := m.renderNotifications()
 
 	if m.hideInput {
 		parts := []string{header, m.viewport.View()}
+		if notifications != "" {
+			parts = append(parts, notifications)
+		}
 		if routineStatus != "" {
 			parts = append(parts, routineStatus)
 		}
@@ -1217,6 +1231,9 @@ func (m chatModel) View() string {
 	parts := []string{header, m.viewport.View()}
 	if menu != "" {
 		parts = append(parts, menu)
+	}
+	if notifications != "" {
+		parts = append(parts, notifications)
 	}
 	if routineStatus != "" {
 		parts = append(parts, routineStatus)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/client"
 	"github.com/lucinate-ai/lucinate/internal/config"
+	"github.com/lucinate-ai/lucinate/internal/routines"
 )
 
 // textareaCursorByteOffset converts the textarea's (Line, Column) cursor
@@ -167,12 +168,14 @@ type chatModel struct {
 	contextWindow      int // model context capacity for the active session; 0 when unknown
 	skills             []agentSkill
 	agentNames         []string // populated asynchronously by loadAgentNames; powers /agent <TAB> completion
+	routineNames       []string // populated by loadRoutineNames; powers /routine <TAB> completion
 	completion         completionMenuState
 	baseViewportHeight int // viewport height with the completion menu hidden; setSize updates it, applyLayout subtracts the menu's footprint when visible
 	spinnerFrame       int
 	spinnerTicking     bool
 	prefs              config.Preferences
 	pendingConfirm     *pendingConfirmation
+	pendingNavConfirm  *pendingNavConfirm
 	historyLimit       int
 	historyLoading     bool   // true while the initial history fetch is in flight; gates the placeholder in updateViewport
 	thinkingLevel      string // current thinking level; "" means not set / using gateway default
@@ -181,6 +184,7 @@ type chatModel struct {
 	transcript         bool   // true when the model is rendering a cron run-log transcript: read-only, esc returns to the cron detail view that opened it
 	terminalFocused    bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
 	updateLatest       string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
+	activeRoutine      *activeRoutine
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -325,6 +329,7 @@ func (m chatModel) Init() tea.Cmd {
 		m.loadContextUsage(),
 		func() tea.Msg { return skillsDiscoveredMsg{skills: discoverSkills()} },
 		m.loadAgentNames(),
+		loadRoutineNames(),
 	)
 }
 
@@ -577,6 +582,15 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.agentNames = msg.names
 		return m, nil
 
+	case chatRoutineNamesLoadedMsg:
+		m.routineNames = msg.names
+		return m, nil
+
+	case startRoutineMsg:
+		cmd := m.startRoutine(msg.name)
+		m.updateViewport()
+		return m, cmd
+
 	case skillsDiscoveredMsg:
 		m.skills = msg.skills
 		if len(m.skills) > 0 {
@@ -602,11 +616,32 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		logEvent("KEY code=%d mod=%v string=%q", msg.Code, msg.Mod, msg.String())
 		switch msg.String() {
 		case "esc":
+			if m.pendingNavConfirm != nil {
+				m.pendingNavConfirm = nil
+				m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled — routine continues."})
+				m.updateViewport()
+				return m, nil
+			}
+			if m.activeRoutine != nil {
+				var cmd tea.Cmd
+				if m.sending {
+					cmd = m.cancelTurn()
+				}
+				m.endRoutine("cancelled")
+				m.updateViewport()
+				return m, cmd
+			}
 			if m.sending {
 				return m, m.cancelTurn()
 			}
 			if m.transcript {
 				return m, func() tea.Msg { return goBackFromCronTranscriptMsg{} }
+			}
+			return m, nil
+		case "alt+m":
+			if m.activeRoutine != nil {
+				m.cycleRoutineMode()
+				m.updateViewport()
 			}
 			return m, nil
 		case "tab":
@@ -644,6 +679,47 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		case "enter":
 			text := strings.TrimSpace(m.textarea.Value())
 			if text == "" {
+				// Empty Enter advances the active routine when manual or paused
+				// and idle. Keeps the gesture out of the way of the textarea's
+				// regular newline handling (alt+enter), which fires before this
+				// branch only when there is content.
+				if ar := m.activeRoutine; ar != nil && !m.sending {
+					if (ar.mode == routines.ModeManual || ar.paused) && ar.sent < len(ar.routine.Steps) {
+						return m, m.sendNextRoutineStep()
+					}
+				}
+				return m, nil
+			}
+
+			// Resolve a pending routine-cancel-on-navigation prompt. Done
+			// before the generic pendingConfirm path because the nav
+			// gate must end the routine synchronously so the log file
+			// is closed before the chatModel is potentially replaced.
+			if m.pendingNavConfirm != nil {
+				m.textarea.Reset()
+				m.refreshCompletionMenu()
+				confirm := m.pendingNavConfirm
+				m.pendingNavConfirm = nil
+				lower := strings.ToLower(text)
+				if lower == "y" || lower == "yes" {
+					var cmds []tea.Cmd
+					// Abort any in-flight turn the routine kicked off so a
+					// follow-up startRoutineMsg (the /routine <name> path)
+					// finds a clean controller and m.sending == false.
+					if m.sending {
+						if cmd := m.cancelTurn(); cmd != nil {
+							cmds = append(cmds, cmd)
+						}
+					}
+					m.endRoutine("cancelled")
+					if confirm.nav != nil {
+						cmds = append(cmds, confirm.nav)
+					}
+					m.updateViewport()
+					return m, tea.Batch(cmds...)
+				}
+				m.messages = append(m.messages, chatMessage{role: "system", content: "Cancelled — routine continues."})
+				m.updateViewport()
 				return m, nil
 			}
 
@@ -727,6 +803,9 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			m.messages = append(m.messages, chatMessage{role: "user", content: text})
 			m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 			m.sending = true
+			if ar := m.activeRoutine; ar != nil && ar.logger != nil {
+				ar.logger.WriteUser(text)
+			}
 			m.updateViewport()
 			cmds = append(cmds, m.sendMessage(sent), m.ensureSpinnerTicking())
 			return m, tea.Batch(cmds...)
@@ -965,6 +1044,9 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 	}
 	m.messages = append(m.messages, chatMessage{role: "user", content: text})
 	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	if ar := m.activeRoutine; ar != nil && ar.logger != nil {
+		ar.logger.WriteUser(text)
+	}
 	m.updateViewport()
 	return tea.Batch(m.sendMessage(sent), m.ensureSpinnerTicking())
 }
@@ -1097,6 +1179,9 @@ func (m chatModel) View() string {
 		if suffix == "" {
 			token, suffix = m.agentNameHint(value, cursorByte)
 		}
+		if suffix == "" {
+			token, suffix = m.routineNameHint(value, cursorByte)
+		}
 		if suffix != "" {
 			help = helpStyle.Render(fmt.Sprintf(" %s%s — tab to complete", token, suffix))
 		} else if m.hideInput {
@@ -1110,13 +1195,18 @@ func (m chatModel) View() string {
 		}
 	}
 
+	routineStatus := ""
+	if line := m.routineStatusLine(); line != "" {
+		routineStatus = routineStatusStyle.Width(m.width).Render(line)
+	}
+
 	if m.hideInput {
-		return lipgloss.JoinVertical(
-			lipgloss.Left,
-			header,
-			m.viewport.View(),
-			help,
-		)
+		parts := []string{header, m.viewport.View()}
+		if routineStatus != "" {
+			parts = append(parts, routineStatus)
+		}
+		parts = append(parts, help)
+		return lipgloss.JoinVertical(lipgloss.Left, parts...)
 	}
 
 	input := borderStyle.
@@ -1126,6 +1216,9 @@ func (m chatModel) View() string {
 	parts := []string{header, m.viewport.View()}
 	if menu != "" {
 		parts = append(parts, menu)
+	}
+	if routineStatus != "" {
+		parts = append(parts, routineStatus)
 	}
 	parts = append(parts, input, help)
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -158,6 +158,7 @@ type chatModel struct {
 	agentName          string
 	sending            bool
 	runID              string // active run ID for cancellation
+	prevFinalisedRunID string // the chat run we most recently finalised; chat events still bearing this runID are stale duplicates emitted by the gateway after final and must not corrupt the next run's placeholder
 	pendingMessages    []string
 	width              int
 	height             int

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/routines"
 )
 
 // pendingConfirmation holds a deferred action awaiting user confirmation.
@@ -29,13 +30,25 @@ type pendingConfirmation struct {
 	action        func() tea.Cmd
 }
 
+// pendingNavConfirm queues a y/n prompt that gates a navigation command.
+// Used when the user runs /agents, /agent <name>, /sessions, /crons, or
+// /connections while a routine is active — those navigations replace
+// (or strand) the chat model that owns the routine controller, so the
+// user is asked to confirm the cancel first. On y, endRoutine runs
+// synchronously (closing the log) and `nav` fires; on anything else, the
+// prompt is dismissed and the routine continues.
+type pendingNavConfirm struct {
+	prompt string
+	nav    tea.Cmd
+}
+
 // slashCommands is the list of available slash commands for autocomplete.
 // Ordering breaks ties only for the inline ghost-hint and the legacy
 // completeSlashCommand callers — "/agents" appears before "/agent" so the
 // hint surfaces the picker first, "/model" before "/models" likewise.
 // Tab now extends to the longest common prefix and the completion menu
 // shows every candidate, so the curated order no longer rules Tab.
-var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/models", "/quit", "/reset", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/models", "/quit", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -171,7 +184,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	case "/quit", "/exit":
 		return true, tea.Quit
 	case "/agents":
-		return true, func() tea.Msg { return goBackMsg{} }
+		return true, m.gateNavigation("Switching agents", func() tea.Msg { return goBackMsg{} })
 	case "/models":
 		sessionKey := m.sessionKey
 		currentModelID := m.modelID
@@ -244,7 +257,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	case "/config":
 		return true, func() tea.Msg { return showConfigMsg{} }
 	case "/connections":
-		return true, func() tea.Msg { return showConnectionsMsg{} }
+		return true, m.gateNavigation("Switching connections", func() tea.Msg { return showConnectionsMsg{} })
 	case "/crons", "/crons all":
 		if _, ok := m.backend.(backend.CronBackend); !ok {
 			m.messages = append(m.messages, chatMessage{
@@ -260,22 +273,22 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			filterAgentID = ""
 			filterLabel = "all agents"
 		}
-		return true, func() tea.Msg {
+		return true, m.gateNavigation("Opening crons", func() tea.Msg {
 			return showCronsMsg{filterAgentID: filterAgentID, filterLabel: filterLabel}
-		}
+		})
 	case "/sessions":
 		agentID := m.agentID
 		agentName := m.agentName
 		modelID := m.modelID
 		sessionKey := m.sessionKey
-		return true, func() tea.Msg {
+		return true, m.gateNavigation("Opening sessions", func() tea.Msg {
 			return showSessionsMsg{
 				agentID:   agentID,
 				agentName: agentName,
 				modelID:   modelID,
 				mainKey:   sessionKey,
 			}
-		}
+		})
 	case "/help", "/commands":
 		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
@@ -334,6 +347,19 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return m.handleAgentCommand(text)
 	}
 
+	// /routine <name> activates a routine; bare /routine is an error.
+	if command == "/routine" || strings.HasPrefix(command, "/routine ") {
+		return m.handleRoutineCommand(text)
+	}
+
+	// /routines opens the routines management view. While an active
+	// routine is running, opening the manager would strand the in-flight
+	// gateway events (routinesModel.Update doesn't consume them) so the
+	// nav is gated.
+	if command == "/routines" {
+		return true, m.gateNavigation("Opening the routines manager", func() tea.Msg { return showRoutinesMsg{} })
+	}
+
 	// /model with optional argument.
 	if command == "/model" || strings.HasPrefix(command, "/model ") {
 		return m.handleModelCommand(text)
@@ -377,12 +403,12 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
 	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
-		return true, func() tea.Msg { return goBackMsg{} }
+		return true, m.gateNavigation("Switching agents", func() tea.Msg { return goBackMsg{} })
 	}
 
 	query := strings.ToLower(strings.TrimSpace(parts[1]))
 	b := m.backend
-	return true, func() tea.Msg {
+	switchCmd := func() tea.Msg {
 		ctx := context.Background()
 		result, err := b.ListAgents(ctx)
 		if err != nil {
@@ -420,6 +446,7 @@ func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 			err:        err,
 		}
 	}
+	return true, m.gateNavigation("Switching agents", switchCmd)
 }
 
 // handleModelCommand handles `/model <name>`. Bare `/model` is an error —
@@ -614,6 +641,99 @@ func formatDuration(ms int64) string {
 	h := int(d.Hours())
 	m := int(d.Minutes()) % 60
 	return fmt.Sprintf("%dh%dm", h, m)
+}
+
+// handleRoutineCommand handles `/routine` and `/routine <name>`. Bare
+// `/routine` renders an error pointing at /routines. When a routine is
+// already active the call is gated so the user has to confirm cancelling
+// the current routine before the new one starts — only one routine
+// runs per session.
+func (m *chatModel) handleRoutineCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
+		m.messages = append(m.messages, chatMessage{
+			role:   "system",
+			errMsg: "/routine requires a name — use /routines to manage them",
+		})
+		m.updateViewport()
+		return true, nil
+	}
+	name := strings.TrimSpace(parts[1])
+	if m.activeRoutine != nil {
+		label := fmt.Sprintf("Starting routine %q", name)
+		return true, m.gateNavigation(label, func() tea.Msg {
+			return startRoutineMsg{name: name}
+		})
+	}
+	cmd := m.startRoutine(name)
+	m.updateViewport()
+	return true, cmd
+}
+
+// findRoutineArgAt detects whether the cursor sits at the end of the
+// argument of `/routine <name>` on the current line. Mirrors
+// findAgentArgAt: routine names may contain non-space chars only, but we
+// allow any tail of the line so completion can refine.
+func findRoutineArgAt(value string, byteOffset int) (start int, prefix string, ok bool) {
+	if byteOffset < 0 || byteOffset > len(value) {
+		return 0, "", false
+	}
+	if byteOffset < len(value) && value[byteOffset] != '\n' {
+		return 0, "", false
+	}
+	lineStart := byteOffset
+	for lineStart > 0 && value[lineStart-1] != '\n' {
+		lineStart--
+	}
+	const cmd = "/routine "
+	if byteOffset-lineStart < len(cmd) {
+		return 0, "", false
+	}
+	if !strings.EqualFold(value[lineStart:lineStart+len(cmd)], cmd) {
+		return 0, "", false
+	}
+	argStart := lineStart + len(cmd)
+	return argStart, value[argStart:byteOffset], true
+}
+
+// completeRoutineName returns the first routine name matching the prefix.
+func (m *chatModel) completeRoutineName(prefix string) string {
+	lower := strings.ToLower(prefix)
+	for _, n := range m.routineNames {
+		if strings.HasPrefix(strings.ToLower(n), lower) {
+			return n
+		}
+	}
+	return ""
+}
+
+// routineNameHint returns the completion hint for `/routine <name>`.
+func (m *chatModel) routineNameHint(value string, cursorByte int) (token, suffix string) {
+	_, prefix, ok := findRoutineArgAt(value, cursorByte)
+	if !ok {
+		return "", ""
+	}
+	match := m.completeRoutineName(prefix)
+	if match == "" || strings.EqualFold(match, prefix) {
+		return "", ""
+	}
+	return prefix, match[len(prefix):]
+}
+
+// loadRoutineNames returns a tea.Cmd that scans the routines directory and
+// dispatches a chatRoutineNamesLoadedMsg with the discovered names.
+func loadRoutineNames() tea.Cmd {
+	return func() tea.Msg {
+		list, err := routines.List()
+		if err != nil {
+			return chatRoutineNamesLoadedMsg{}
+		}
+		names := make([]string, 0, len(list))
+		for _, r := range list {
+			names = append(names, r.Name)
+		}
+		return chatRoutineNamesLoadedMsg{names: names}
+	}
 }
 
 // handleThinkCommand handles `/think` and `/think <level>`.

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -622,12 +622,11 @@ func TestSlashCommand_Cancel_WhileIdle(t *testing.T) {
 	if cmd != nil {
 		t.Error("expected nil cmd from /cancel when not sending")
 	}
-	if len(m.messages) != initialCount+1 {
-		t.Fatalf("expected %d messages, got %d", initialCount+1, len(m.messages))
+	if len(m.messages) != initialCount {
+		t.Fatalf("expected message count unchanged (%d), got %d", initialCount, len(m.messages))
 	}
-	last := m.messages[len(m.messages)-1]
-	if last.role != "system" || last.content != "Nothing to cancel." {
-		t.Errorf("unexpected message: role=%q content=%q", last.role, last.content)
+	if len(m.notifications) != 1 || m.notifications[0].text != "Nothing to cancel." {
+		t.Errorf("expected single 'Nothing to cancel.' notification, got %+v", m.notifications)
 	}
 }
 
@@ -643,9 +642,8 @@ func TestSlashCommand_Cancel_NoRunID(t *testing.T) {
 	if cmd != nil {
 		t.Error("expected nil cmd when sending but no runID")
 	}
-	last := m.messages[len(m.messages)-1]
-	if last.content != "Nothing to cancel." {
-		t.Errorf("expected 'Nothing to cancel.', got %q", last.content)
+	if len(m.notifications) != 1 || m.notifications[0].text != "Nothing to cancel." {
+		t.Errorf("expected 'Nothing to cancel.' notification, got %+v", m.notifications)
 	}
 }
 

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -365,6 +365,7 @@ func (m *chatModel) applyLayout() {
 	if m.activeRoutine != nil {
 		h--
 	}
+	h -= len(m.notifications)
 	if h < 1 {
 		h = 1
 	}

--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -190,7 +190,36 @@ func (m *chatModel) completionAtCursor() (completionContext, bool) {
 			candidates: m.matchingAgentNames(prefix),
 		}, true
 	}
+	if start, prefix, ok := findRoutineArgAt(value, cursorByte); ok {
+		return completionContext{
+			start:      start,
+			cursorByte: cursorByte,
+			prefix:     prefix,
+			candidates: m.matchingRoutineNames(prefix),
+		}, true
+	}
 	return completionContext{}, false
+}
+
+// matchingRoutineNames returns every routine name whose lowercased form
+// has prefix as a prefix. Empty prefix matches every loaded routine.
+func (m *chatModel) matchingRoutineNames(prefix string) []string {
+	if len(m.routineNames) == 0 {
+		return nil
+	}
+	if prefix == "" {
+		out := make([]string, len(m.routineNames))
+		copy(out, m.routineNames)
+		return out
+	}
+	lower := strings.ToLower(prefix)
+	var out []string
+	for _, n := range m.routineNames {
+		if strings.HasPrefix(strings.ToLower(n), lower) {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // handleCompletionTab implements the Tab semantics for the active
@@ -333,6 +362,9 @@ func (m chatModel) renderCompletionMenu() (string, int) {
 // footprint on top of that baseline whenever menu state changes.
 func (m *chatModel) applyLayout() {
 	h := m.baseViewportHeight - m.menuRowsToRender()
+	if m.activeRoutine != nil {
+		h--
+	}
 	if h < 1 {
 		h = 1
 	}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -200,12 +200,14 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		logEvent("  FINAL msgContent=%s", string(chatEv.Message))
 		m.runID = ""
 		finalised := false
+		assistantContent := ""
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
 			if last.role == "assistant" && last.streaming && !last.awaitingDelta {
 				last.streaming = false
 				last.thinking = extractThinkingFromMessage(chatEv.Message)
 				finalised = true
+				assistantContent = last.content
 				logEvent("  FINALISED — refreshing history thinking_len=%d", len(last.thinking))
 			}
 		}
@@ -214,6 +216,15 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			// Empty ack from gateway — the real response hasn't arrived yet.
 			logEvent("  FINAL ignored (no streaming assistant message)")
 			return nil
+		}
+		// Routine bookkeeping: log assistant content, parse /routine: directives.
+		// Done before drainQueue so a directive (stop/pause/mode) is honoured
+		// before the next routine step would otherwise auto-fire.
+		if m.activeRoutine != nil {
+			if m.activeRoutine.logger != nil && assistantContent != "" {
+				m.activeRoutine.logger.WriteAssistant(assistantContent)
+			}
+			m.applyDirectives(assistantContent)
 		}
 		var cmds []tea.Cmd
 		if m.shouldRingBell() {
@@ -224,6 +235,12 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			// Still draining the queue — defer history refresh until the queue is empty
 			// to avoid replacing m.messages while queued user messages are visible.
 			cmds = append(cmds, drainCmd)
+			return tea.Batch(cmds...)
+		}
+		// User queue empty — try advancing the active routine. The advance itself
+		// sets m.sending and dispatches the next step.
+		if cmd := m.maybeAdvanceRoutine(); cmd != nil {
+			cmds = append(cmds, cmd)
 			return tea.Batch(cmds...)
 		}
 		cmds = append(cmds, m.refreshHistory(), m.loadStats())
@@ -245,6 +262,11 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		if !finalised {
 			return nil
 		}
+		// Pause the routine so a transient error doesn't auto-loop the next
+		// step. The user can press Enter to retry / continue, or Esc to end.
+		if m.activeRoutine != nil {
+			m.activeRoutine.paused = true
+		}
 		return m.drainQueue()
 
 	case "aborted":
@@ -262,6 +284,9 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		m.updateViewport()
 		if !finalised {
 			return nil
+		}
+		if m.activeRoutine != nil {
+			m.activeRoutine.paused = true
 		}
 		return m.drainQueue()
 	}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -166,6 +166,18 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 
 	logEvent("EVENT state=%s runID=%s seq=%d msgLen=%d sessionKey=%s", chatEv.State, chatEv.RunID, chatEv.Seq, len(chatEv.Message), chatEv.SessionKey)
 
+	// Drop stale events from a run we've already finalised. The gateway
+	// occasionally emits a duplicate `delta` (carrying the full content)
+	// after `final` with the same runID; if we let it through, the
+	// stale delta lands on the next routine step's placeholder, flips
+	// awaitingDelta, and lets a subsequent empty final spuriously
+	// finalise the next step — causing back-to-back routine steps to
+	// be advanced without a real response in between.
+	if chatEv.RunID != "" && chatEv.RunID == m.prevFinalisedRunID {
+		logEvent("  STALE event for finalised run %s — ignored", chatEv.RunID)
+		return nil
+	}
+
 	switch chatEv.State {
 	case "delta":
 		deltaText := extractTextFromMessage(chatEv.Message)
@@ -208,6 +220,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.thinking = extractThinkingFromMessage(chatEv.Message)
 				finalised = true
 				assistantContent = last.content
+				m.prevFinalisedRunID = chatEv.RunID
 				logEvent("  FINALISED — refreshing history thinking_len=%d", len(last.thinking))
 			}
 		}
@@ -256,6 +269,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.streaming = false
 				last.errMsg = chatEv.ErrorMessage
 				finalised = true
+				m.prevFinalisedRunID = chatEv.RunID
 			}
 		}
 		m.updateViewport()
@@ -279,6 +293,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.streaming = false
 				last.content += "\n[aborted]"
 				finalised = true
+				m.prevFinalisedRunID = chatEv.RunID
 			}
 		}
 		m.updateViewport()

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -173,6 +173,57 @@ func TestHandleEvent_DeltaIgnoredAfterFinalised(t *testing.T) {
 	}
 }
 
+// TestHandleEvent_StaleDeltaAfterFinalIgnored guards against the
+// duplicate-delta-after-final the openclaw gateway has been observed
+// emitting: a `final` event finalises the assistant turn, then a
+// duplicate `delta` event with the full content arrives carrying the
+// same runID. Without filtering, that stale delta would land on the
+// next routine step's placeholder and corrupt its content + flip
+// awaitingDelta=false, opening a path for the next empty `final` to
+// spuriously finalise an empty assistant turn.
+func TestHandleEvent_StaleDeltaAfterFinalIgnored(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.messages = []chatMessage{
+		{role: "user", content: "step 1"},
+		{role: "assistant", content: "3, 9", streaming: true},
+	}
+
+	// Final for run1 finalises the assistant turn.
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"3, 9"}]}`)
+	m.handleEvent(makeChatEvent("final", "run1", 5, finalMsg))
+
+	if m.prevFinalisedRunID != "run1" {
+		t.Fatalf("prevFinalisedRunID = %q, want run1", m.prevFinalisedRunID)
+	}
+
+	// Simulate routine auto-advance: append a fresh placeholder for the
+	// next step. The stale duplicate delta would normally land here.
+	m.messages = append(m.messages,
+		chatMessage{role: "user", content: "step 2"},
+		chatMessage{role: "assistant", streaming: true, awaitingDelta: true},
+	)
+
+	// Stale duplicate delta arrives bearing run1's id.
+	m.handleEvent(makeChatEvent("delta", "run1", 5, json.RawMessage(`"3, 9"`)))
+
+	last := m.messages[len(m.messages)-1]
+	if last.content != "" {
+		t.Errorf("step 2 placeholder content = %q, want empty (stale delta should have been ignored)", last.content)
+	}
+	if !last.awaitingDelta {
+		t.Error("expected awaitingDelta to remain true; stale delta flipped it")
+	}
+
+	// Empty final for run2 must not finalise: awaitingDelta is still true.
+	emptyFinal := json.RawMessage(``)
+	m.handleEvent(makeChatEvent("final", "run2", 1, emptyFinal))
+
+	if !m.messages[len(m.messages)-1].streaming {
+		t.Error("step 2 should still be streaming; empty final must not finalise when no deltas have arrived")
+	}
+}
+
 func TestHandleEvent_FinalMarksStreamingDone(t *testing.T) {
 	m := newTestChatModel()
 	m.sending = true

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -154,6 +154,32 @@ type chatAgentNamesLoadedMsg struct {
 	names []string
 }
 
+// chatRoutineNamesLoadedMsg delivers routine names to the chat model for
+// `/routine <TAB>` completion.
+type chatRoutineNamesLoadedMsg struct {
+	names []string
+}
+
+// startRoutineMsg requests the chat model to begin a routine. Issued
+// from the routine-cancel-and-replace path: when the user confirms a
+// `/routine X` while another routine is running, the gate first
+// cancels the active routine and then dispatches this msg, which
+// invokes startRoutine on a now-idle controller.
+type startRoutineMsg struct {
+	name string
+}
+
+// showRoutinesMsg signals the AppModel to switch to the routines manager.
+type showRoutinesMsg struct{}
+
+// goBackFromRoutinesMsg signals the AppModel to return to the chat view
+// from the routines manager.
+type goBackFromRoutinesMsg struct{}
+
+// routinesChangedMsg is dispatched after CRUD inside the routines manager
+// so the chat model can re-scan routine names for autocompletion.
+type routinesChangedMsg struct{}
+
 // skillsDiscoveredMsg is returned when skill discovery completes.
 type skillsDiscoveredMsg struct {
 	skills []agentSkill

--- a/internal/tui/notifications.go
+++ b/internal/tui/notifications.go
@@ -1,0 +1,63 @@
+package tui
+
+import "charm.land/lipgloss/v2"
+
+// notification is a single ephemeral row rendered above the input box.
+// The text is shown verbatim with statusStyle (or errorStyle when isError
+// is true). Notifications survive history refreshes (because they live
+// outside m.messages) and are cleared when the user submits an input —
+// the working assumption is that any state worth showing in a
+// notification has been read or no longer applies once the user types
+// their next message.
+type notification struct {
+	text    string
+	isError bool
+}
+
+// notify queues an informational notification.
+func (m *chatModel) notify(text string) {
+	if text == "" {
+		return
+	}
+	m.notifications = append(m.notifications, notification{text: text})
+	m.applyLayout()
+}
+
+// notifyError queues an error-styled notification.
+func (m *chatModel) notifyError(text string) {
+	if text == "" {
+		return
+	}
+	m.notifications = append(m.notifications, notification{text: text, isError: true})
+	m.applyLayout()
+}
+
+// clearNotifications drops every pending notification. Called when the
+// user submits an input.
+func (m *chatModel) clearNotifications() {
+	if len(m.notifications) == 0 {
+		return
+	}
+	m.notifications = nil
+	m.applyLayout()
+}
+
+// renderNotifications returns the styled, multi-line block of pending
+// notifications, sized to width, or "" when there are none. Each row
+// uses statusStyle (or errorStyle for is-error rows) and is padded to
+// the chat width so the styling reads as a coherent band above the
+// input.
+func (m *chatModel) renderNotifications() string {
+	if len(m.notifications) == 0 {
+		return ""
+	}
+	rows := make([]string, 0, len(m.notifications))
+	for _, n := range m.notifications {
+		style := statusStyle
+		if n.isError {
+			style = errorStyle
+		}
+		rows = append(rows, style.Width(m.width).Render(" "+n.text))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, rows...)
+}

--- a/internal/tui/notifications_test.go
+++ b/internal/tui/notifications_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestNotifications_NotifyAndClear(t *testing.T) {
+	m := newTestChatModel()
+
+	m.notify("first")
+	m.notify("second")
+	m.notifyError("uh oh")
+
+	if len(m.notifications) != 3 {
+		t.Fatalf("len = %d, want 3", len(m.notifications))
+	}
+	if m.notifications[0].text != "first" || m.notifications[0].isError {
+		t.Errorf("[0] = %+v", m.notifications[0])
+	}
+	if !m.notifications[2].isError {
+		t.Errorf("[2] should be isError, got %+v", m.notifications[2])
+	}
+
+	m.clearNotifications()
+	if len(m.notifications) != 0 {
+		t.Errorf("after clear: len = %d, want 0", len(m.notifications))
+	}
+}
+
+func TestNotifications_EmptyTextIsDropped(t *testing.T) {
+	m := newTestChatModel()
+	m.notify("")
+	m.notifyError("")
+	if len(m.notifications) != 0 {
+		t.Errorf("empty text appended: %+v", m.notifications)
+	}
+}
+
+func TestNotifications_SurviveHistoryRefresh(t *testing.T) {
+	m := newTestChatModel()
+	m.messages = []chatMessage{{role: "user", content: "old"}}
+	m.notify("Routine \"demo\" stopped by assistant.")
+
+	// Simulate a history refresh replacing m.messages.
+	m.handleHistoryRefresh([]chatMessage{
+		{role: "user", content: "step 1"},
+		{role: "assistant", content: "reply"},
+	})
+
+	if len(m.notifications) != 1 {
+		t.Errorf("notification dropped by history refresh: %+v", m.notifications)
+	}
+}
+
+// handleHistoryRefresh mimics the Update handler's body for
+// historyRefreshMsg, in a way callable from tests without going
+// through the full bubbletea machinery.
+func (m *chatModel) handleHistoryRefresh(replacement []chatMessage) {
+	m.messages = replacement
+}

--- a/internal/tui/routines.go
+++ b/internal/tui/routines.go
@@ -1,0 +1,830 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/routines"
+)
+
+// routinesSubState selects which sub-view of the routines manager renders.
+type routinesSubState int
+
+const (
+	routinesSubList routinesSubState = iota
+	routinesSubDetail
+	routinesSubForm
+	routinesSubConfirmDelete
+)
+
+// Form field indices. Header fields occupy 0..fieldStepStart-1; each
+// element of form.steps occupies fieldStepStart + i.
+const (
+	fieldName = iota
+	fieldMode
+	fieldLog
+	fieldStepStart
+)
+
+// routineItem wraps a Routine for the bubbles list.
+type routineItem struct {
+	routine routines.Routine
+}
+
+func (i routineItem) FilterValue() string { return i.routine.Name }
+
+// routineDelegate renders each list row as two lines: the name and a
+// secondary chip line with mode + step count.
+type routineDelegate struct{}
+
+func (d routineDelegate) Height() int                             { return 2 }
+func (d routineDelegate) Spacing() int                            { return 1 }
+func (d routineDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d routineDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	r, ok := item.(routineItem)
+	if !ok {
+		return
+	}
+	name := r.routine.Name
+	var titleLine string
+	if index == m.Index() {
+		titleLine = lipgloss.NewStyle().Foreground(accent).Bold(true).
+			Render("> " + name)
+	} else {
+		titleLine = "  " + name
+	}
+	mode := strings.ToUpper(string(r.routine.ResolvedMode()))
+	steps := fmt.Sprintf("%d step", len(r.routine.Steps))
+	if len(r.routine.Steps) != 1 {
+		steps += "s"
+	}
+	chips := []string{
+		chipStyle.Render(steps),
+		chipStyle.Render(mode),
+	}
+	if r.routine.Frontmatter.Log != "" {
+		chips = append(chips, chipStyle.Render("logs"))
+	}
+	subtitle := "  " + strings.Join(chips, " ")
+	fmt.Fprint(w, titleLine+"\n"+subtitle)
+}
+
+// routinesModel is the /routines manager view.
+type routinesModel struct {
+	list   list.Model
+	subset routinesSubState
+
+	loading bool
+	err     error
+
+	routines []routines.Routine
+
+	// Detail substate.
+	selectedName string
+
+	// Form substate.
+	form routineForm
+
+	// Confirm-delete substate.
+	pendingDeleteName string
+
+	hideHints       bool
+	disableExitKeys bool
+	width           int
+	height          int
+}
+
+// routineForm holds in-progress form state for create + edit.
+type routineForm struct {
+	mode      string // "create" or "edit"
+	editingID string // existing routine name when editing; "" when creating
+
+	name  textinput.Model
+	mFm   textinput.Model // mode field ("auto" / "manual")
+	log   textinput.Model
+	steps []textarea.Model
+
+	focused int // 0=name, 1=mode, 2=log, 3+i=step i
+	saving  bool
+	err     error
+
+	// pendingStepDelete is set when alt+delete is pressed on a step;
+	// the form view replaces help with a y/n prompt until resolved.
+	pendingStepDelete bool
+	pendingDeleteIdx  int
+}
+
+// fieldCount returns the total focusable field count, including all
+// steps. Used to wrap tab/shift+tab cycling.
+func (f *routineForm) fieldCount() int { return fieldStepStart + len(f.steps) }
+
+// stepIndex returns the index into form.steps for the focused field, or
+// -1 when the focus is on a header field.
+func (f *routineForm) stepIndex() int {
+	if f.focused < fieldStepStart {
+		return -1
+	}
+	return f.focused - fieldStepStart
+}
+
+func newRoutinesModel(hideHints bool, disableExitKeys bool) routinesModel {
+	l := list.New(nil, routineDelegate{}, 0, 0)
+	l.Title = "Routines"
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(!hideHints)
+	l.Styles.Title = headerStyle
+	l.SetFilteringEnabled(false)
+	if disableExitKeys {
+		l.KeyMap.Quit.Unbind()
+		l.KeyMap.ForceQuit.Unbind()
+	}
+	return routinesModel{
+		list:            l,
+		subset:          routinesSubList,
+		loading:         true,
+		hideHints:       hideHints,
+		disableExitKeys: disableExitKeys,
+	}
+}
+
+func (m routinesModel) Init() tea.Cmd { return loadRoutinesList() }
+
+func (m *routinesModel) setSize(w, h int) {
+	m.width = w
+	m.height = h
+	m.list.SetSize(w, h-2)
+	if m.subset == routinesSubForm {
+		m.sizeFormBody()
+	}
+}
+
+// sizeFormBody adjusts the visible height of every step textarea to fit
+// the available terminal vertical space. Header textinputs are always
+// single-line; the remaining height is divided across the step
+// textareas with a per-step floor of 3 lines so each step stays usable
+// even when the form is long.
+func (m *routinesModel) sizeFormBody() {
+	if len(m.form.steps) == 0 {
+		return
+	}
+	const perStepFloor = 3
+	const reservedChrome = 14 // header + name/mode/log labels+inputs + help
+	available := m.height - reservedChrome
+	if available < perStepFloor*len(m.form.steps) {
+		available = perStepFloor * len(m.form.steps)
+	}
+	per := available / len(m.form.steps)
+	if per < perStepFloor {
+		per = perStepFloor
+	}
+	if per > 8 {
+		per = 8 // cap so a single tall textarea doesn't eat the form
+	}
+	width := m.width - 4
+	if width < 20 {
+		width = 20
+	}
+	for i := range m.form.steps {
+		m.form.steps[i].SetHeight(per)
+		m.form.steps[i].SetWidth(width)
+	}
+}
+
+// routinesListLoadedMsg delivers the routines slice from disk.
+type routinesListLoadedMsg struct {
+	routines []routines.Routine
+	err      error
+}
+
+// routineSavedMsg is dispatched after a save attempt.
+type routineSavedMsg struct {
+	name string
+	err  error
+}
+
+// routineDeletedMsg is dispatched after a delete attempt.
+type routineDeletedMsg struct {
+	name string
+	err  error
+}
+
+func loadRoutinesList() tea.Cmd {
+	return func() tea.Msg {
+		list, err := routines.List()
+		return routinesListLoadedMsg{routines: list, err: err}
+	}
+}
+
+func (m routinesModel) Update(msg tea.Msg) (routinesModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case routinesListLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.err = nil
+		m.routines = msg.routines
+		items := make([]list.Item, len(msg.routines))
+		for i, r := range msg.routines {
+			items[i] = routineItem{routine: r}
+		}
+		m.list.SetItems(items)
+		return m, nil
+
+	case routineSavedMsg:
+		if msg.err != nil {
+			m.form.err = msg.err
+			m.form.saving = false
+			return m, nil
+		}
+		m.subset = routinesSubList
+		m.form = routineForm{}
+		m.loading = true
+		return m, tea.Batch(loadRoutinesList(), func() tea.Msg { return routinesChangedMsg{} })
+
+	case routineDeletedMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.subset = routinesSubList
+		m.selectedName = ""
+		m.loading = true
+		return m, tea.Batch(loadRoutinesList(), func() tea.Msg { return routinesChangedMsg{} })
+
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	}
+
+	if m.subset == routinesSubList {
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m routinesModel) handleKey(msg tea.KeyPressMsg) (routinesModel, tea.Cmd) {
+	switch m.subset {
+	case routinesSubList:
+		return m.handleListKey(msg)
+	case routinesSubDetail:
+		return m.handleDetailKey(msg)
+	case routinesSubForm:
+		return m.handleFormKey(msg)
+	case routinesSubConfirmDelete:
+		return m.handleConfirmKey(msg)
+	}
+	return m, nil
+}
+
+func (m routinesModel) handleListKey(msg tea.KeyPressMsg) (routinesModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return m, func() tea.Msg { return goBackFromRoutinesMsg{} }
+	case "n":
+		m.form = newRoutineForm("", routines.Routine{})
+		m.subset = routinesSubForm
+		m.sizeFormBody()
+		return m, nil
+	case "enter":
+		item, ok := m.list.SelectedItem().(routineItem)
+		if !ok {
+			return m, nil
+		}
+		m.selectedName = item.routine.Name
+		m.subset = routinesSubDetail
+		return m, nil
+	case "up", "k", "down", "j":
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m routinesModel) handleDetailKey(msg tea.KeyPressMsg) (routinesModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "left", "h":
+		m.subset = routinesSubList
+		m.selectedName = ""
+		return m, nil
+	case "e":
+		r, ok := m.findRoutine(m.selectedName)
+		if !ok {
+			return m, nil
+		}
+		m.form = newRoutineForm(r.Name, r)
+		m.subset = routinesSubForm
+		m.sizeFormBody()
+		return m, nil
+	case "d":
+		m.pendingDeleteName = m.selectedName
+		m.subset = routinesSubConfirmDelete
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m routinesModel) handleConfirmKey(msg tea.KeyPressMsg) (routinesModel, tea.Cmd) {
+	switch strings.ToLower(msg.String()) {
+	case "y":
+		name := m.pendingDeleteName
+		m.pendingDeleteName = ""
+		return m, func() tea.Msg {
+			err := routines.Delete(name)
+			return routineDeletedMsg{name: name, err: err}
+		}
+	case "n", "esc":
+		m.pendingDeleteName = ""
+		m.subset = routinesSubDetail
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m routinesModel) handleFormKey(msg tea.KeyPressMsg) (routinesModel, tea.Cmd) {
+	// Resolve a pending step-delete confirmation first — every other key
+	// is interpreted relative to the prompt while it's open.
+	if m.form.pendingStepDelete {
+		switch strings.ToLower(msg.String()) {
+		case "y":
+			m.deleteStep(m.form.pendingDeleteIdx)
+			m.form.pendingStepDelete = false
+			return m, nil
+		case "n", "esc":
+			m.form.pendingStepDelete = false
+			return m, nil
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "esc":
+		m.form = routineForm{}
+		m.subset = routinesSubList
+		return m, nil
+	case "tab":
+		n := m.form.fieldCount()
+		if n > 0 {
+			m.form.focused = (m.form.focused + 1) % n
+			m.refocus()
+		}
+		return m, nil
+	case "shift+tab":
+		n := m.form.fieldCount()
+		if n > 0 {
+			m.form.focused = (m.form.focused - 1 + n) % n
+			m.refocus()
+		}
+		return m, nil
+	// alt+s is the primary save key; ctrl+s is kept as an alias defensively
+	// because some terminals interpret ctrl+s as XOFF and never deliver it.
+	case "alt+s", "ctrl+s":
+		return m.submitForm()
+	case "alt+up":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.insertStep(idx, "")
+			m.form.focused = fieldStepStart + idx // focus the new (above) step
+			m.refocus()
+			m.sizeFormBody()
+		}
+		return m, nil
+	case "alt+down":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.insertStep(idx+1, "")
+			m.form.focused = fieldStepStart + idx + 1 // focus the new (below) step
+			m.refocus()
+			m.sizeFormBody()
+		}
+		return m, nil
+	case "alt+delete", "alt+backspace":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.form.pendingStepDelete = true
+			m.form.pendingDeleteIdx = idx
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	switch m.form.focused {
+	case fieldName:
+		m.form.name, cmd = m.form.name.Update(msg)
+	case fieldMode:
+		m.form.mFm, cmd = m.form.mFm.Update(msg)
+	case fieldLog:
+		m.form.log, cmd = m.form.log.Update(msg)
+	default:
+		idx := m.form.stepIndex()
+		if idx >= 0 && idx < len(m.form.steps) {
+			m.form.steps[idx], cmd = m.form.steps[idx].Update(msg)
+		}
+	}
+	return m, cmd
+}
+
+// insertStep splices a fresh textarea at idx, shifting subsequent steps
+// down. Caller is responsible for setting form.focused afterward.
+func (m *routinesModel) insertStep(idx int, value string) {
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(m.form.steps) {
+		idx = len(m.form.steps)
+	}
+	ta := newStepTextarea(value)
+	m.form.steps = append(m.form.steps, textarea.Model{})
+	copy(m.form.steps[idx+1:], m.form.steps[idx:])
+	m.form.steps[idx] = ta
+}
+
+// deleteStep removes the step at idx. If the result would be empty, a
+// fresh blank step is inserted so the form always has at least one
+// step to type into.
+func (m *routinesModel) deleteStep(idx int) {
+	if idx < 0 || idx >= len(m.form.steps) {
+		return
+	}
+	m.form.steps = append(m.form.steps[:idx], m.form.steps[idx+1:]...)
+	if len(m.form.steps) == 0 {
+		m.form.steps = []textarea.Model{newStepTextarea("")}
+	}
+	// Keep focus near the deleted spot. Cap to last step.
+	maxFocus := m.form.fieldCount() - 1
+	if m.form.focused > maxFocus {
+		m.form.focused = maxFocus
+	}
+	m.refocus()
+	m.sizeFormBody()
+}
+
+func (m *routinesModel) refocus() {
+	m.form.name.Blur()
+	m.form.mFm.Blur()
+	m.form.log.Blur()
+	for i := range m.form.steps {
+		m.form.steps[i].Blur()
+	}
+	switch m.form.focused {
+	case fieldName:
+		m.form.name.Focus()
+	case fieldMode:
+		m.form.mFm.Focus()
+	case fieldLog:
+		m.form.log.Focus()
+	default:
+		idx := m.form.stepIndex()
+		if idx >= 0 && idx < len(m.form.steps) {
+			m.form.steps[idx].Focus()
+		}
+	}
+}
+
+func (m routinesModel) submitForm() (routinesModel, tea.Cmd) {
+	name := strings.TrimSpace(m.form.name.Value())
+	if name == "" {
+		m.form.err = fmt.Errorf("name is required")
+		return m, nil
+	}
+	mode := strings.ToLower(strings.TrimSpace(m.form.mFm.Value()))
+	if mode != "" && mode != string(routines.ModeAuto) && mode != string(routines.ModeManual) {
+		m.form.err = fmt.Errorf("mode must be 'auto' or 'manual'")
+		return m, nil
+	}
+	steps := make([]string, 0, len(m.form.steps))
+	for _, ta := range m.form.steps {
+		if v := strings.TrimSpace(ta.Value()); v != "" {
+			steps = append(steps, v)
+		}
+	}
+	r := routines.Routine{
+		Name: name,
+		Frontmatter: routines.Frontmatter{
+			Name: name,
+			Mode: mode,
+			Log:  strings.TrimSpace(m.form.log.Value()),
+		},
+		Steps: steps,
+	}
+	if len(r.Steps) == 0 {
+		m.form.err = fmt.Errorf("at least one non-empty step is required")
+		return m, nil
+	}
+	if m.form.mode == "edit" && m.form.editingID != "" && m.form.editingID != name {
+		// Rename: delete old then save new. Save first to ensure no data loss
+		// on partial failure.
+		oldName := m.form.editingID
+		m.form.saving = true
+		return m, func() tea.Msg {
+			if err := routines.Save(r); err != nil {
+				return routineSavedMsg{name: name, err: err}
+			}
+			_ = routines.Delete(oldName)
+			return routineSavedMsg{name: name}
+		}
+	}
+	m.form.saving = true
+	return m, func() tea.Msg {
+		err := routines.Save(r)
+		return routineSavedMsg{name: name, err: err}
+	}
+}
+
+func newRoutineForm(editingID string, existing routines.Routine) routineForm {
+	name := textinput.New()
+	name.Placeholder = "routine-name"
+	name.SetValue(existing.Name)
+	name.Focus()
+
+	mFm := textinput.New()
+	mFm.Placeholder = "manual"
+	mFm.SetValue(existing.Frontmatter.Mode)
+
+	log := textinput.New()
+	log.Placeholder = "./routine.log (optional)"
+	log.SetValue(existing.Frontmatter.Log)
+
+	steps := make([]textarea.Model, 0, len(existing.Steps))
+	for _, s := range existing.Steps {
+		steps = append(steps, newStepTextarea(s))
+	}
+	if len(steps) == 0 {
+		// Always show at least one step textarea so the user has an
+		// obvious place to start typing on a fresh routine.
+		steps = append(steps, newStepTextarea(""))
+	}
+
+	mode := "create"
+	if editingID != "" {
+		mode = "edit"
+	}
+	return routineForm{
+		mode:      mode,
+		editingID: editingID,
+		name:      name,
+		mFm:       mFm,
+		log:       log,
+		steps:     steps,
+		focused:   fieldName,
+	}
+}
+
+// newStepTextarea constructs a textarea pre-configured for routine
+// steps: no line numbers, alt+enter for newline (the chat textarea
+// uses the same convention), and the seed value applied.
+func newStepTextarea(value string) textarea.Model {
+	ta := textarea.New()
+	ta.Placeholder = "step content (alt+enter for newline)"
+	ta.SetValue(value)
+	ta.ShowLineNumbers = false
+	ta.Prompt = ""
+	ta.KeyMap.InsertNewline.SetKeys("alt+enter")
+	return ta
+}
+
+func (m routinesModel) findRoutine(name string) (routines.Routine, bool) {
+	for _, r := range m.routines {
+		if r.Name == name {
+			return r, true
+		}
+	}
+	return routines.Routine{}, false
+}
+
+// Actions returns the top-level discoverable actions for the active subset.
+func (m routinesModel) Actions() []Action {
+	switch m.subset {
+	case routinesSubList:
+		var actions []Action
+		actions = append(actions, Action{ID: "new", Label: "New routine", Key: "n"})
+		actions = append(actions, Action{ID: "back", Label: "Back to chat", Key: "esc"})
+		return actions
+	case routinesSubDetail:
+		return []Action{
+			{ID: "edit", Label: "Edit", Key: "e"},
+			{ID: "delete", Label: "Delete", Key: "d"},
+			{ID: "back", Label: "Back", Key: "esc"},
+		}
+	case routinesSubForm:
+		return []Action{
+			{ID: "save", Label: "Save", Key: "alt+s"},
+			{ID: "insert-above", Label: "Insert step above", Key: "alt+up"},
+			{ID: "insert-below", Label: "Insert step below", Key: "alt+down"},
+			{ID: "delete-step", Label: "Delete step", Key: "alt+delete"},
+			{ID: "cancel", Label: "Cancel", Key: "esc"},
+		}
+	case routinesSubConfirmDelete:
+		return []Action{
+			{ID: "confirm-delete", Label: "Delete", Key: "y"},
+			{ID: "cancel-delete", Label: "Cancel", Key: "n"},
+		}
+	}
+	return nil
+}
+
+// TriggerAction routes view-level commands. Mirrors the ID space declared
+// by Actions().
+func (m routinesModel) TriggerAction(id string) (routinesModel, tea.Cmd) {
+	switch id {
+	case "new":
+		m.form = newRoutineForm("", routines.Routine{})
+		m.subset = routinesSubForm
+		m.sizeFormBody()
+		return m, nil
+	case "edit":
+		r, ok := m.findRoutine(m.selectedName)
+		if !ok {
+			return m, nil
+		}
+		m.form = newRoutineForm(r.Name, r)
+		m.subset = routinesSubForm
+		m.sizeFormBody()
+		return m, nil
+	case "delete":
+		m.pendingDeleteName = m.selectedName
+		m.subset = routinesSubConfirmDelete
+		return m, nil
+	case "confirm-delete":
+		name := m.pendingDeleteName
+		m.pendingDeleteName = ""
+		return m, func() tea.Msg {
+			err := routines.Delete(name)
+			return routineDeletedMsg{name: name, err: err}
+		}
+	case "cancel-delete":
+		m.pendingDeleteName = ""
+		m.subset = routinesSubDetail
+		return m, nil
+	case "save":
+		return m.submitForm()
+	case "insert-above":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.insertStep(idx, "")
+			m.form.focused = fieldStepStart + idx
+			m.refocus()
+			m.sizeFormBody()
+		}
+		return m, nil
+	case "insert-below":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.insertStep(idx+1, "")
+			m.form.focused = fieldStepStart + idx + 1
+			m.refocus()
+			m.sizeFormBody()
+		}
+		return m, nil
+	case "delete-step":
+		if idx := m.form.stepIndex(); idx >= 0 {
+			m.form.pendingStepDelete = true
+			m.form.pendingDeleteIdx = idx
+		}
+		return m, nil
+	case "cancel":
+		m.form = routineForm{}
+		m.subset = routinesSubList
+		return m, nil
+	case "back":
+		switch m.subset {
+		case routinesSubDetail:
+			m.subset = routinesSubList
+			return m, nil
+		default:
+			return m, func() tea.Msg { return goBackFromRoutinesMsg{} }
+		}
+	}
+	return m, nil
+}
+
+func (m routinesModel) View() string {
+	switch m.subset {
+	case routinesSubList:
+		return m.viewList()
+	case routinesSubDetail:
+		return m.viewDetail()
+	case routinesSubForm:
+		return m.viewForm()
+	case routinesSubConfirmDelete:
+		return m.viewConfirmDelete()
+	}
+	return ""
+}
+
+func (m routinesModel) viewList() string {
+	if m.loading {
+		return statusStyle.Render("Loading routines...")
+	}
+	if m.err != nil {
+		return errorStyle.Render(fmt.Sprintf("error: %v", m.err))
+	}
+	if len(m.routines) == 0 {
+		body := emptyHistoryStyle.Render("No routines yet — press n to create one.")
+		hint := helpStyle.Render(renderActionHints(m.Actions()))
+		return lipgloss.JoinVertical(lipgloss.Left,
+			headerStyle.Width(m.width).Render(" Routines"),
+			body,
+			hint)
+	}
+	hint := ""
+	if !m.hideHints {
+		hint = helpStyle.Render(renderActionHints(m.Actions()))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, m.list.View(), hint)
+}
+
+func (m routinesModel) viewDetail() string {
+	r, ok := m.findRoutine(m.selectedName)
+	if !ok {
+		return errorStyle.Render("routine not found")
+	}
+	var b strings.Builder
+	b.WriteString(headerStyle.Width(m.width).Render(" Routines · " + r.Name))
+	b.WriteString("\n\n")
+	mode := strings.ToUpper(string(r.ResolvedMode()))
+	b.WriteString(statusStyle.Render(fmt.Sprintf("mode: %s    steps: %d", mode, len(r.Steps))))
+	b.WriteString("\n")
+	if r.Frontmatter.Log != "" {
+		b.WriteString(statusStyle.Render("log: " + r.Frontmatter.Log))
+		b.WriteString("\n")
+	}
+	b.WriteString(statusStyle.Render("path: " + r.Path))
+	b.WriteString("\n\n")
+	for i, step := range r.Steps {
+		b.WriteString(lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("Step %d", i+1)))
+		b.WriteString("\n")
+		b.WriteString(step)
+		b.WriteString("\n\n")
+	}
+	if !m.hideHints {
+		b.WriteString(helpStyle.Render(renderActionHints(m.Actions())))
+	}
+	return b.String()
+}
+
+func (m routinesModel) viewForm() string {
+	var b strings.Builder
+	title := " Routines · New"
+	if m.form.mode == "edit" {
+		title = " Routines · Edit " + m.form.editingID
+	}
+	b.WriteString(headerStyle.Width(m.width).Render(title))
+	b.WriteString("\n\n")
+
+	row := func(label string, field string) {
+		b.WriteString(lipgloss.NewStyle().Bold(true).Render(label))
+		b.WriteString("\n")
+		b.WriteString(field)
+		b.WriteString("\n\n")
+	}
+	row("Name", m.form.name.View())
+	row("Mode (auto|manual)", m.form.mFm.View())
+	row("Log path (optional)", m.form.log.View())
+
+	for i, ta := range m.form.steps {
+		marker := "  "
+		if m.form.stepIndex() == i {
+			marker = "▶ "
+		}
+		label := lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%sStep %d", marker, i+1))
+		b.WriteString(label)
+		b.WriteString("\n")
+		b.WriteString(ta.View())
+		b.WriteString("\n\n")
+	}
+
+	if m.form.err != nil {
+		b.WriteString(errorStyle.Render(m.form.err.Error()))
+		b.WriteString("\n\n")
+	}
+	if m.form.pendingStepDelete {
+		prompt := fmt.Sprintf("Delete step %d? (y/n)", m.form.pendingDeleteIdx+1)
+		b.WriteString(errorStyle.Render(prompt))
+		return b.String()
+	}
+	if !m.hideHints {
+		b.WriteString(helpStyle.Render(" alt+s: save · alt+↑/↓: insert step · alt+delete: remove step · tab: next field · esc: cancel"))
+	}
+	return b.String()
+}
+
+func (m routinesModel) viewConfirmDelete() string {
+	prompt := fmt.Sprintf("Delete routine %q? This removes the directory and all steps.", m.pendingDeleteName)
+	hints := helpStyle.Render(" y: confirm · n: cancel")
+	return lipgloss.JoinVertical(lipgloss.Left,
+		headerStyle.Width(m.width).Render(" Routines · Delete"),
+		"",
+		prompt,
+		"",
+		hints,
+	)
+}

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -65,10 +65,7 @@ func (m *chatModel) startRoutine(name string) tea.Cmd {
 	}
 	m.activeRoutine = ar
 	m.applyLayout()
-	m.messages = append(m.messages, chatMessage{
-		role:    "system",
-		content: fmt.Sprintf("Routine %q started — %d step(s), %s mode.", r.Name, len(r.Steps), ar.mode),
-	})
+	m.notify(fmt.Sprintf("Routine %q started — %d step(s), %s mode.", r.Name, len(r.Steps), ar.mode))
 	return m.sendNextRoutineStep()
 }
 
@@ -130,10 +127,12 @@ func (m *chatModel) applyDirectives(reply string) {
 			m.endRoutine("stopped by assistant")
 		case routines.DirectivePause:
 			m.activeRoutine.paused = true
-			m.messages = append(m.messages, chatMessage{
-				role:    "system",
-				content: "Routine paused — press Enter to send the next step, Esc to end.",
-			})
+			m.notify("Routine paused — press Enter to send the next step, Esc to end.")
+		case routines.DirectiveContinue:
+			// Explicit no-op: the assistant declared its intent to keep
+			// going. Unsetting paused lets a /routine:continue resume a
+			// previously-paused routine in auto mode.
+			m.activeRoutine.paused = false
 		case routines.DirectiveModeAuto:
 			m.activeRoutine.mode = routines.ModeAuto
 			m.activeRoutine.paused = false
@@ -155,10 +154,7 @@ func (m *chatModel) endRoutine(reason string) {
 	}
 	m.activeRoutine = nil
 	m.applyLayout()
-	m.messages = append(m.messages, chatMessage{
-		role:    "system",
-		content: fmt.Sprintf("Routine %q %s.", ar.routine.Name, reason),
-	})
+	m.notify(fmt.Sprintf("Routine %q %s.", ar.routine.Name, reason))
 }
 
 // cycleRoutineMode flips the active routine between auto and manual.
@@ -195,15 +191,15 @@ func (m *chatModel) gateNavigation(label string, navCmd tea.Cmd) tea.Cmd {
 		prompt: prompt,
 		nav:    navCmd,
 	}
-	m.messages = append(m.messages, chatMessage{role: "system", content: prompt})
-	m.updateViewport()
+	m.notify(prompt)
 	return nil
 }
 
-// appendSystemError is a small helper for routine-initiated error rows.
+// appendSystemError publishes a routine-initiated error as an
+// error-styled notification. The name is kept for callers that pre-date
+// the notification system.
 func (m *chatModel) appendSystemError(msg string) {
-	m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg})
-	m.updateViewport()
+	m.notifyError(msg)
 }
 
 // routineStatusLine renders the in-chat status row for the active routine.

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -1,0 +1,246 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/routines"
+)
+
+// activeRoutine holds the in-flight state for a routine the user has
+// activated via /routine <name>. While set, the chatModel auto-advances in
+// auto mode after each assistant final, repurposes Enter on empty input to
+// send the next step, and binds Alt+M to mode cycling.
+type activeRoutine struct {
+	routine routines.Routine
+	mode    routines.Mode
+	sent    int  // count of steps already dispatched (== index of next step)
+	paused  bool // true when the routine should not auto-advance even in auto mode
+	logger  *routines.Logger
+}
+
+// startRoutine loads a routine by name, prepares the controller, and sends
+// the first step. Returns a tea.Cmd that submits the step to the gateway.
+// On any failure (load, parse, log open) renders a system error message
+// inline and returns nil.
+func (m *chatModel) startRoutine(name string) tea.Cmd {
+	if m.activeRoutine != nil {
+		m.appendSystemError(fmt.Sprintf("a routine is already active: %s", m.activeRoutine.routine.Name))
+		return nil
+	}
+	if m.sending {
+		m.appendSystemError("a turn is in flight — wait for it to finish before starting a routine")
+		return nil
+	}
+	r, err := routines.Load(name)
+	if err != nil {
+		if err == routines.ErrNotFound {
+			m.appendSystemError(fmt.Sprintf("routine %q not found", name))
+		} else {
+			m.appendSystemError(fmt.Sprintf("could not load routine %q: %v", name, err))
+		}
+		return nil
+	}
+	if len(r.Steps) == 0 {
+		m.appendSystemError(fmt.Sprintf("routine %q has no steps", name))
+		return nil
+	}
+
+	ar := &activeRoutine{
+		routine: r,
+		mode:    r.ResolvedMode(),
+	}
+	if logPath := strings.TrimSpace(r.Frontmatter.Log); logPath != "" {
+		cwd, _ := os.Getwd()
+		logger, err := routines.Open(logPath, cwd, r.Name)
+		if err != nil {
+			m.appendSystemError(fmt.Sprintf("routine log unavailable: %v (continuing without log)", err))
+		} else {
+			ar.logger = logger
+		}
+	}
+	m.activeRoutine = ar
+	m.applyLayout()
+	m.messages = append(m.messages, chatMessage{
+		role:    "system",
+		content: fmt.Sprintf("Routine %q started — %d step(s), %s mode.", r.Name, len(r.Steps), ar.mode),
+	})
+	return m.sendNextRoutineStep()
+}
+
+// sendNextRoutineStep dispatches the next pending step as a user message.
+// Caller must verify activeRoutine is non-nil and a step remains. After
+// returning, sending is true and the assistant placeholder is in place.
+func (m *chatModel) sendNextRoutineStep() tea.Cmd {
+	ar := m.activeRoutine
+	text := ar.routine.Steps[ar.sent]
+	ar.sent++
+	ar.paused = false
+
+	sent := text
+	if len(m.skills) > 0 {
+		if expanded, ok := expandSkillReferences(text, m.skills); ok {
+			sent = expanded
+		}
+	}
+	m.messages = append(m.messages, chatMessage{role: "user", content: text})
+	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.sending = true
+	if ar.logger != nil {
+		ar.logger.WriteUser(text)
+	}
+	m.updateViewport()
+	return tea.Batch(m.sendMessage(sent), m.ensureSpinnerTicking())
+}
+
+// maybeAdvanceRoutine returns a tea.Cmd that fires the next step when
+// auto-advance conditions are met. Callers invoke it after the user-message
+// queue has drained on a chat-final event so user-typed messages take
+// precedence over routine steps.
+func (m *chatModel) maybeAdvanceRoutine() tea.Cmd {
+	ar := m.activeRoutine
+	if ar == nil || ar.paused || ar.mode != routines.ModeAuto {
+		return nil
+	}
+	if ar.sent >= len(ar.routine.Steps) {
+		m.endRoutine("completed")
+		return nil
+	}
+	return m.sendNextRoutineStep()
+}
+
+// applyDirectives scans an assistant reply for /routine: control directives
+// and applies them in order. End-of-routine directives win over later mode
+// changes — once stop is seen the controller is cleared and subsequent
+// directives are no-ops.
+func (m *chatModel) applyDirectives(reply string) {
+	if m.activeRoutine == nil || reply == "" {
+		return
+	}
+	for _, d := range routines.ScanDirectives(reply) {
+		if m.activeRoutine == nil {
+			return
+		}
+		switch d.Kind {
+		case routines.DirectiveStop:
+			m.endRoutine("stopped by assistant")
+		case routines.DirectivePause:
+			m.activeRoutine.paused = true
+			m.messages = append(m.messages, chatMessage{
+				role:    "system",
+				content: "Routine paused — press Enter to send the next step, Esc to end.",
+			})
+		case routines.DirectiveModeAuto:
+			m.activeRoutine.mode = routines.ModeAuto
+			m.activeRoutine.paused = false
+		case routines.DirectiveModeManual:
+			m.activeRoutine.mode = routines.ModeManual
+		}
+	}
+}
+
+// endRoutine releases the active routine. The reason is recorded in the log
+// (if any) and surfaced as a brief system message in the transcript.
+func (m *chatModel) endRoutine(reason string) {
+	ar := m.activeRoutine
+	if ar == nil {
+		return
+	}
+	if ar.logger != nil {
+		ar.logger.Close()
+	}
+	m.activeRoutine = nil
+	m.applyLayout()
+	m.messages = append(m.messages, chatMessage{
+		role:    "system",
+		content: fmt.Sprintf("Routine %q %s.", ar.routine.Name, reason),
+	})
+}
+
+// cycleRoutineMode flips the active routine between auto and manual.
+// Cycling out of paused-auto into auto unsets paused so the next final
+// auto-advances; cycling into manual leaves paused alone.
+func (m *chatModel) cycleRoutineMode() {
+	ar := m.activeRoutine
+	if ar == nil {
+		return
+	}
+	switch ar.mode {
+	case routines.ModeAuto:
+		ar.mode = routines.ModeManual
+	default:
+		ar.mode = routines.ModeAuto
+		ar.paused = false
+	}
+}
+
+// gateNavigation returns navCmd unchanged when no routine is active, or
+// queues a y/n confirmation that — on confirm — ends the active routine
+// (closing its log) and then runs navCmd. Used to wrap slash commands
+// that strand or replace the chat model the routine lives on.
+//
+// label is the short verb phrase that completes "Switching agents",
+// "Opening sessions", etc., and is rendered into the prompt text.
+func (m *chatModel) gateNavigation(label string, navCmd tea.Cmd) tea.Cmd {
+	if m.activeRoutine == nil {
+		return navCmd
+	}
+	prompt := fmt.Sprintf("Routine %q is active. %s will cancel it. Continue? (y/n)",
+		m.activeRoutine.routine.Name, label)
+	m.pendingNavConfirm = &pendingNavConfirm{
+		prompt: prompt,
+		nav:    navCmd,
+	}
+	m.messages = append(m.messages, chatMessage{role: "system", content: prompt})
+	m.updateViewport()
+	return nil
+}
+
+// appendSystemError is a small helper for routine-initiated error rows.
+func (m *chatModel) appendSystemError(msg string) {
+	m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg})
+	m.updateViewport()
+}
+
+// routineStatusLine renders the in-chat status row for the active routine.
+// Returns "" when no routine is active. The output is plain text scoped to
+// at most one display line; the View pads it to the chat width.
+func (m *chatModel) routineStatusLine() string {
+	ar := m.activeRoutine
+	if ar == nil {
+		return ""
+	}
+	mode := strings.ToUpper(string(ar.mode))
+	if ar.paused {
+		mode += " (paused)"
+	}
+	total := len(ar.routine.Steps)
+	next := ""
+	if ar.sent < total {
+		next = " — next: " + previewLine(ar.routine.Steps[ar.sent], 40)
+	}
+	return fmt.Sprintf("routine: %s — %s — sent: %d/%d%s",
+		ar.routine.Name, mode, ar.sent, total, next)
+}
+
+// routineStatusStyle styles the in-chat status row.
+var routineStatusStyle = lipgloss.NewStyle().
+	Foreground(accent).
+	Bold(true).
+	Padding(0, 1)
+
+// previewLine reduces text to a single-line, ellipsised preview.
+func previewLine(text string, max int) string {
+	t := strings.ReplaceAll(text, "\r", " ")
+	t = strings.ReplaceAll(t, "\n", " ")
+	t = strings.Join(strings.Fields(t), " ")
+	runes := []rune(t)
+	if len(runes) <= max {
+		return t
+	}
+	return string(runes[:max-1]) + "…"
+}


### PR DESCRIPTION
Author multi-step prompt sequences once, replay them with `/routine <name>`. Each routine is a markdown file of `---`-separated steps that lucinate dispatches against the active session, optionally auto-advancing after every reply.

fixes #116 

## Summary

- New `internal/routines/` package — `STEPS.md` parser/formatter (YAML frontmatter, `---`-separated steps), filesystem store under `~/.lucinate/routines/<name>/`, `/routine:` directive scanner, and append-only run logger.
- New `/routine <name>` and `/routines` slash commands. The manager view (`internal/tui/routines.go`) provides list / view / form / confirm-delete substates with one textarea per step plus `Alt+↑` / `Alt+↓` / `Alt+Delete` step manipulation and `Alt+S` save.
- Routine controller on `chatModel` with auto-advance hook in the chat `final` event, in-chat status row above the input, `Alt+M` mode cycling, Esc-cancels-routine semantics, and Enter-advances on empty input.
- Five `/routine:` directives the assistant can emit on its own line: `stop`, `pause`, `continue`, `mode auto`, `mode manual`.
- Single-routine-per-session invariant: `/routine`, `/routines`, `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/connections` are gated by a y/n prompt that aborts the in-flight turn and ends the routine cleanly before navigating.
- New ephemeral notification rows above the input — confirmation prompts, cancel acks, routine state changes — that survive `historyRefreshMsg` and clear on the next user submission. Replaces the previous `m.messages`-as-system-row pattern for transient state.
- Stale-event filter: track the most recently finalised `runID` and drop later chat events bearing it. Fixes a duplicate-`delta`-after-`final` quirk where the stale delta would corrupt the next routine step's placeholder and let an empty-content final spuriously advance.
- Documentation: new `docs/routines.md`, plus updates to `docs/README.md`, `docs/commands.md`, `docs/chat-ux.md`, and the root `README.md`.

## Implementation details

The auto-advance hook lives in the existing chat `final` handler, intentionally after `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before the next step would otherwise fire, and after `drainQueue` so user-typed messages jump ahead of routine steps. Step indexing is strictly monotonic — `ar.sent++` runs in exactly one place — so dispatch order matches `Steps[]` order regardless of event interleaving.

The notification system was the second attempt at preserving the "Routine X stopped" message past the post-turn `refreshHistory`. The first attempt skipped the refresh when a routine had been active; that worked but left chat behaviour split between routine and non-routine turns. Notifications live outside `m.messages` instead, so chat refresh now behaves identically in both modes.

`Alt+M` is used for mode cycling rather than any `Ctrl+letter` because every readline-bound `Ctrl+letter` (`Ctrl+R`, `Ctrl+S` — XOFF, `Ctrl+W`, etc.) either has a meaning in the chat textarea or is swallowed by the terminal. `Alt+S` is the form's primary save key for the same XOFF reason; `Ctrl+S` is kept as an alias for terminals that pass it through.