### PR TITLE
fix(tui): always resync after final via a generation merge boundary

### DIFF
--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -102,6 +102,25 @@ When restored history is non-empty, a dimmed separator row is rendered above the
 
 See [sessions.md](sessions.md#lifecycle) for how history loading fits into the session lifecycle.
 
+## Mid-turn history resync
+
+After a turn finalises, the chat view fetches `chat.history` from the gateway and merges it into `m.messages`. The merge is *not* a wholesale replacement — that would wipe live state (the next routine step's placeholder, an in-flight tool card, a system row the user just took an action on).
+
+The mechanism is a generation counter:
+
+- `chatModel.gen` is a monotonically increasing `uint64` (starts at 1).
+- Every `appendMessage(...)` stamps the current `m.gen` onto the row.
+- A successful `final` (or `error`/`aborted`) calls `bumpGen()`, which captures the current value as the "boundary" and then advances the counter. The boundary is what the just-issued `refreshHistoryAt(boundary)` carries.
+- When the resulting `historyRefreshMsg` lands, `mergeHistoryRefresh(server, boundary)` keeps every existing row with `gen > boundary` (the live tail — appended by the post-bump `drainQueue` / `maybeAdvanceRoutine` / recovery path) and prepends the server-fetched canonical state.
+
+Practical consequences:
+
+- Rows imported from `chat.history` carry `gen=0` (the chatMessage zero value), so any subsequent refresh treats them as history-side and replaces them cleanly.
+- Tool cards from the *just-finalised* turn are lost on refresh — the gateway's history view doesn't model them. Tool cards for the *current* (next) turn survive because they're tagged with the new gen at append time.
+- Empty `final` acks (the gateway ping that arrives before any real content) intentionally do NOT bump the gen, because no turn has actually completed.
+
+Tests pin the contract: `TestMergeHistoryRefresh_PreservesLiveTail`, `TestMergeHistoryRefresh_NoLiveTail`, `TestHandleEvent_FinalBumpsGen`, `TestHandleEvent_FinalEmptyAckDoesNotBumpGen`.
+
 ## Connect timeout
 
 Each (re)connect attempt has a per-attempt deadline applied to the WebSocket / HTTP handshake. The default is 15 seconds; the range is 5–300 seconds via `/config` ("Connect timeout"). The configured value is loaded by `app.DefaultBackendFactory` (`app/factory.go`) for every backend dispatch, so the same setting governs the initial connect and the supervisor's reconnect attempts. Bump it when targeting a slow local LLM that cold-starts on first request.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -100,16 +100,18 @@ Auto-advance lives in the `final` case of `handleEvent` (`internal/tui/events.go
 
 The OpenClaw gateway has been observed emitting a duplicate `delta` event with the full content right *after* the matching `final`, on the same `runID`. Without filtering, that delta lands on the next routine step's freshly-appended placeholder, flipping `awaitingDelta` and letting a subsequent empty-content `final` falsely finalise an empty turn — which spuriously auto-advances the routine.
 
-`chatModel.prevFinalisedRunID` tracks the last finalised run; the top of the chat-event branch in `handleEvent` drops any event whose `RunID` matches it:
+`chatModel.finalisedRuns` is a bounded LRU set (cap `finalisedRunsCap = 32`) of run IDs we have already finalised; the top of the chat-event branch in `handleEvent` drops any event whose `RunID` is a member:
 
 ```go
-if chatEv.RunID != "" && chatEv.RunID == m.prevFinalisedRunID {
+if m.finalisedRuns.contains(chatEv.RunID) {
     logEvent("  STALE event for finalised run %s — ignored", chatEv.RunID)
     return nil
 }
 ```
 
-`prevFinalisedRunID` is set inside the `final`, `error`, and `aborted` paths, but only when the corresponding state mutation actually happened (gated on the same `finalised` flag). `TestHandleEvent_StaleDeltaAfterFinalIgnored` covers the bug end-to-end.
+The set is added to inside the `final`, `error`, and `aborted` paths, but only when the corresponding state mutation actually happened (gated on the same `finalised` flag). FIFO eviction keeps a long-lived chat from growing the filter unboundedly.
+
+The set's depth matters: a single-deep filter is enough for the immediate duplicate-after-final case, but back-to-back routine steps open a wider window. A stale event for run N-2 can arrive while run N is streaming; with only the most-recent run remembered, that earlier id slips past and corrupts the live placeholder. `TestHandleEvent_StaleDeltaAfterFinalIgnored` pins the duplicate case; `TestHandleEvent_StaleDeltaFromOlderRunIgnored` pins the back-to-back race; `TestFinalisedRunSet_EvictsOldestPastCap` pins the FIFO bound.
 
 ## Directives
 
@@ -224,7 +226,7 @@ Unit tests:
 - `internal/routines/directives_test.go` — own-line matching, inline-mention rejection, all five directive kinds.
 - `internal/routines/store_test.go` — disk round-trip, invalid-name rejection.
 - `internal/routines/log_test.go` — header + per-message timestamp shape, multi-line bodies, append across reopens, nil-receiver safety.
-- `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` — pins the duplicate-delta-after-final filter.
+- `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` / `TestHandleEvent_StaleDeltaFromOlderRunIgnored` / `TestFinalisedRunSet_*` — pin the bounded stale-run filter.
 - `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
 
 Manual smoke:

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -89,12 +89,15 @@ Step indexing is strictly monotonic: only `sendNextRoutineStep` increments `ar.s
 Auto-advance lives in the `final` case of `handleEvent` (`internal/tui/events.go`). The order matters:
 
 1. Mark the streaming assistant message as finalised (existing behaviour).
-2. If `m.activeRoutine != nil`: log the assistant content (when a logger is configured) and call `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before any auto-advance fires.
-3. Drain `m.pendingMessages` — user-typed queue jumps ahead of the routine.
-4. If the queue is empty and `m.sending` is now false, call `maybeAdvanceRoutine()`. If it returns a cmd, dispatch it (sending the next step) and return.
-5. Otherwise fall through to the standard `refreshHistory` + `loadStats` batch.
+2. Capture the merge boundary via `bumpGen()` — the just-finalised turn is now on the history-side of any refresh issued from here on; subsequent appends get the new gen and survive the merge.
+3. If `m.activeRoutine != nil`: log the assistant content (when a logger is configured) and call `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before any auto-advance fires.
+4. Always queue `refreshHistoryAt(boundary)` and `loadStats()`. The merge in the `historyRefreshMsg` handler is non-destructive — the live tail of the next routine step (placeholder, in-flight tool card, system rows) survives because those rows carry a higher gen than the boundary.
+5. Drain `m.pendingMessages` via `drainQueueSkipRefresh` — user-typed queue jumps ahead of the routine. The `SkipRefresh` variant is used because we already queued the resync above; `drainQueue`'s built-in empty-queue refresh would otherwise duplicate it.
+6. If the queue was empty and `m.sending` is now false, call `maybeAdvanceRoutine()`. If it returns a cmd, append it to the batch (sending the next step).
 
-`error` and `aborted` set `paused = true` instead of advancing, so a transient gateway error doesn't loop the next step. The user can press Enter (empty input) to retry the next step or Esc to end the routine.
+The unconditional refresh is the heart of the resync architecture. Pre-Layer-3, the refresh was deferred to "queue empty AND no routine to advance", which meant a 10-step auto-mode routine accumulated drift across all 10 steps before the first server-canonical reconciliation. With drift large enough, stale-event filtering became the only line of defence against spurious step submission. Now every `final` reconciles, every step.
+
+`error` and `aborted` also `bumpGen()` so the boundary stays monotonic, and set `paused = true` instead of advancing — so a transient gateway error doesn't loop the next step. The user can press Enter (empty input) to retry the next step or Esc to end the routine. They do not currently issue their own refresh; the next successful turn's refresh covers the canonical reconciliation.
 
 ## Stale-event filtering
 
@@ -227,6 +230,9 @@ Unit tests:
 - `internal/routines/store_test.go` — disk round-trip, invalid-name rejection.
 - `internal/routines/log_test.go` — header + per-message timestamp shape, multi-line bodies, append across reopens, nil-receiver safety.
 - `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` / `TestHandleEvent_StaleDeltaFromOlderRunIgnored` / `TestFinalisedRunSet_*` — pin the bounded stale-run filter.
+- `internal/tui/events_test.go::TestHandleEvent_FinalRefreshesEvenWithQueuedMessages` / `TestHandleEvent_FinalRefreshesDuringRoutineAutoAdvance` — pin that the resync fires on every successful `final`, not just at queue/routine end.
+- `internal/tui/events_test.go::TestHandleEvent_FinalBumpsGen` / `TestHandleEvent_FinalEmptyAckDoesNotBumpGen` — pin the gen-bump semantics that anchor the merge boundary.
+- `internal/tui/events_test.go::TestMergeHistoryRefresh_PreservesLiveTail` / `TestMergeHistoryRefresh_NoLiveTail` — pin the merge contract the unconditional refresh depends on.
 - `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
 
 Manual smoke:

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -158,7 +158,7 @@ type chatModel struct {
 	agentName          string
 	sending            bool
 	runID              string // active run ID for cancellation
-	prevFinalisedRunID string // the chat run we most recently finalised; chat events still bearing this runID are stale duplicates emitted by the gateway after final and must not corrupt the next run's placeholder
+	finalisedRuns      finalisedRunSet // bounded LRU of run IDs we have already finalised; chat events still bearing one of these IDs are stale duplicates emitted by the gateway after final and must not corrupt the next run's placeholder
 	pendingMessages    []string
 	width              int
 	height             int

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -114,7 +114,7 @@ func (m *chatModel) applyConnState(next ConnStateMsg) {
 			m.removeThinkingPlaceholder()
 			m.sending = false
 			m.runID = ""
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: "Lost gateway connection — attempting to reconnect…",
 			})
@@ -122,7 +122,7 @@ func (m *chatModel) applyConnState(next ConnStateMsg) {
 		}
 	case client.StatusConnected:
 		if prev.Status == client.StatusDisconnected || prev.Status == client.StatusReconnecting {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: "Reconnected to gateway.",
 			})
@@ -133,7 +133,7 @@ func (m *chatModel) applyConnState(next ConnStateMsg) {
 		if next.Err != nil {
 			errLine = fmt.Sprintf("Reconnect failed (%v). Quit (Ctrl+C) and restart to re-authenticate.", next.Err)
 		}
-		m.messages = append(m.messages, chatMessage{role: "system", errMsg: errLine})
+		m.appendMessage(chatMessage{role: "system", errMsg: errLine})
 		m.updateViewport()
 	}
 }
@@ -159,6 +159,7 @@ type chatModel struct {
 	sending            bool
 	runID              string // active run ID for cancellation
 	finalisedRuns      finalisedRunSet // bounded LRU of run IDs we have already finalised; chat events still bearing one of these IDs are stale duplicates emitted by the gateway after final and must not corrupt the next run's placeholder
+	gen                uint64 // generation counter stamped onto every newly-appended chatMessage; bumped after each turn finalises so the just-finalised turn can be replaced by a server-canonical refresh while the next turn's live state survives the merge
 	pendingMessages    []string
 	width              int
 	height             int
@@ -216,6 +217,68 @@ func (m *chatModel) hasStreamingMessage() bool {
 	return false
 }
 
+// appendMessage stamps the current gen counter onto msg and appends it
+// to m.messages. Returns a pointer into the slice so callers that need
+// to mutate the just-appended row (e.g. delta-streaming) can do so
+// without a second slice walk; callers that don't may safely ignore
+// the return.
+//
+// All "live" appends — user turns, streaming placeholders, tool cards,
+// system rows, error rows — must go through this helper rather than
+// raw append, so the merge in historyRefreshMsg can correctly
+// distinguish "history-side" rows (replaced by server canonical state)
+// from the "live tail" (preserved across the merge).
+func (m *chatModel) appendMessage(msg chatMessage) *chatMessage {
+	msg.gen = m.gen
+	m.messages = append(m.messages, msg)
+	return &m.messages[len(m.messages)-1]
+}
+
+// bumpGen captures the current generation and advances the counter.
+// Called from the chat-event final/error/aborted paths after a turn
+// has been successfully finalised, so the just-finalised turn (and
+// everything before it) is on the "history-side" of the next
+// refresh's boundary, while subsequent appends — drained queue,
+// auto-advanced routine step, recovery system rows — fall on the
+// "live tail" side and survive the merge.
+//
+// Returns the captured (pre-increment) value so callers can pass it
+// straight into refreshHistoryAt.
+func (m *chatModel) bumpGen() uint64 {
+	boundary := m.gen
+	m.gen++
+	return boundary
+}
+
+// mergeHistoryRefresh replaces the history-side of m.messages with
+// server-canonical history while preserving the live tail (rows whose
+// gen exceeds the boundary captured at refresh-issue time). Concretely:
+// fetched server messages come first, every existing row with
+// gen > boundary is appended afterwards in original order.
+//
+// Used by the historyRefreshMsg handler. Pulled into a helper because
+// the merge logic is non-trivial enough to warrant a unit test that
+// doesn't have to thread through the full bubbletea Update path.
+func (m *chatModel) mergeHistoryRefresh(server []chatMessage, boundary uint64) {
+	// Walk once, partitioning. Pre-size the live slice from a count
+	// pass to avoid repeated growth — long live tails (e.g. an active
+	// routine with a tool card mid-execution) would otherwise reallocate.
+	liveCount := 0
+	for i := range m.messages {
+		if m.messages[i].gen > boundary {
+			liveCount++
+		}
+	}
+	merged := make([]chatMessage, 0, len(server)+liveCount)
+	merged = append(merged, server...)
+	for i := range m.messages {
+		if m.messages[i].gen > boundary {
+			merged = append(merged, m.messages[i])
+		}
+	}
+	m.messages = merged
+}
+
 // removeThinkingPlaceholder removes the streaming assistant placeholder added
 // when a message is sent, before any gateway delta has arrived.
 func (m *chatModel) removeThinkingPlaceholder() {
@@ -233,14 +296,19 @@ func (m *chatModel) removeThinkingPlaceholder() {
 // pending row is found (the prompt was cancelled, or some prior
 // handler already cleared it), the replacement is appended instead so
 // the user still sees the result.
+//
+// In-place swaps inherit the existing row's gen so the merge boundary
+// stays consistent; the fall-through append goes through appendMessage
+// for the same reason.
 func (m *chatModel) replacePendingSystem(replacement chatMessage) {
 	for i := len(m.messages) - 1; i >= 0; i-- {
 		if m.messages[i].role == "system" && m.messages[i].pending {
+			replacement.gen = m.messages[i].gen
 			m.messages[i] = replacement
 			return
 		}
 	}
-	m.messages = append(m.messages, replacement)
+	m.appendMessage(replacement)
 }
 
 // ensureSpinnerTicking starts the spinner animation if one is not already scheduled.
@@ -320,6 +388,10 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		hideInput:       hideInput,
 		terminalFocused: true,
 		pendingMessages: pending,
+		// Start at gen=1 so the zero value on chatMessage.gen reads as
+		// "older than any live turn" — server-history imports keep that
+		// default and are always replaceable on subsequent refreshes.
+		gen: 1,
 	}
 }
 
@@ -475,12 +547,15 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.historyLoading = false
 		switch {
 		case msg.err != nil:
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:   "system",
 				errMsg: fmt.Sprintf("Could not load conversation history: %v", msg.err),
 			})
 		case len(msg.messages) > 0:
 			lastTs := lastTimestampMs(msg.messages)
+			// Server-imported rows keep gen=0 (the chatMessage zero
+			// value) so any subsequent refresh treats them as
+			// history-side and replaces them cleanly.
 			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
 			m.messages = append(hist, m.messages...)
 		}
@@ -496,16 +571,16 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		return m, nil
 
 	case agentSwitchFailedMsg:
-		m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+		m.appendMessage(chatMessage{role: "system", errMsg: msg.err.Error()})
 		m.updateViewport()
 		return m, nil
 
 	case modelSwitchedMsg:
 		if msg.err != nil {
-			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+			m.appendMessage(chatMessage{role: "system", errMsg: msg.err.Error()})
 		} else {
 			m.modelID = msg.modelID
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: fmt.Sprintf("Switched to %s", msg.modelID),
 			})
@@ -527,9 +602,9 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 
 	case gatewayStatusMsg:
 		if msg.err != nil {
-			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+			m.appendMessage(chatMessage{role: "system", errMsg: msg.err.Error()})
 		} else {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: formatGatewayStatus(msg.health, msg.uptimeMs),
 			})
@@ -539,14 +614,14 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 
 	case thinkingChangedMsg:
 		if msg.err != nil {
-			m.messages = append(m.messages, chatMessage{role: "system", errMsg: msg.err.Error()})
+			m.appendMessage(chatMessage{role: "system", errMsg: msg.err.Error()})
 		} else {
 			m.thinkingLevel = msg.level
 			display := msg.level
 			if display == "" || display == "off" {
 				display = "off"
 			}
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: fmt.Sprintf("Thinking level set to %s", display),
 			})
@@ -569,7 +644,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		} else {
 			m.sessionKey = msg.newSessionKey
 			m.messages = nil
-			m.messages = append(m.messages, chatMessage{role: "system", content: "Session cleared. Starting fresh."})
+			m.appendMessage(chatMessage{role: "system", content: "Session cleared. Starting fresh."})
 		}
 		m.updateViewport()
 		return m, nil
@@ -596,7 +671,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	case skillsDiscoveredMsg:
 		m.skills = msg.skills
 		if len(m.skills) > 0 {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: fmt.Sprintf("%d agent skill(s) loaded — type /skills to list", len(m.skills)),
 			})
@@ -606,7 +681,13 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 
 	case historyRefreshMsg:
 		if msg.err == nil && len(msg.messages) > 0 {
-			m.messages = msg.messages
+			// Merge: replace history-side rows with server-canonical
+			// state, preserve the live tail (rows whose gen exceeds
+			// the boundary captured at refresh-issue time). This makes
+			// it safe to refresh mid-routine, mid-queue-drain, and
+			// while a tool card is in flight — scenarios where the old
+			// wholesale-replace would have wiped live state.
+			m.mergeHistoryRefresh(msg.messages, msg.boundary)
 			m.updateViewport()
 		}
 		// History refresh fires after each completed turn — pull a
@@ -745,7 +826,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 					m.notify("Confirmed.")
 					var spinnerCmd tea.Cmd
 					if confirm.runningStatus != "" {
-						m.messages = append(m.messages, chatMessage{
+						m.appendMessage(chatMessage{
 							role:    "system",
 							content: confirm.runningStatus,
 							pending: true,
@@ -784,8 +865,8 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				if command == "" {
 					return m, nil
 				}
-				m.messages = append(m.messages, chatMessage{role: "system", content: fmt.Sprintf("!! %s", command)})
-				m.messages = append(m.messages, chatMessage{role: "system", content: "running on gateway..."})
+				m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("!! %s", command)})
+				m.appendMessage(chatMessage{role: "system", content: "running on gateway..."})
 				m.sending = true
 				m.updateViewport()
 				cmds = append(cmds, m.execCommand(command))
@@ -797,8 +878,8 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				if command == "" {
 					return m, nil
 				}
-				m.messages = append(m.messages, chatMessage{role: "system", content: fmt.Sprintf("$ %s", command)})
-				m.messages = append(m.messages, chatMessage{role: "system", content: "running..."})
+				m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("$ %s", command)})
+				m.appendMessage(chatMessage{role: "system", content: "running..."})
 				m.sending = true
 				m.updateViewport()
 				cmds = append(cmds, localExecCommand(command))
@@ -811,8 +892,8 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 					sent = expanded
 				}
 			}
-			m.messages = append(m.messages, chatMessage{role: "user", content: text})
-			m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+			m.appendMessage(chatMessage{role: "user", content: text})
+			m.appendMessage(chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 			m.sending = true
 			if ar := m.activeRoutine; ar != nil && ar.logger != nil {
 				ar.logger.WriteUser(text)
@@ -864,7 +945,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		if msg.err != nil {
 			logEvent("SEND_ERROR: %v", msg.err)
 			m.removeThinkingPlaceholder()
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:   "assistant",
 				errMsg: msg.err.Error(),
 			})
@@ -1014,8 +1095,12 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 	if len(m.pendingMessages) == 0 {
 		m.sending = false
 		if refresh {
-			// Queue fully drained — refresh history now that all messages have been sent.
-			return tea.Batch(m.refreshHistory(), m.loadStats())
+			// Queue fully drained — refresh history with a boundary
+			// of m.gen-1 so the just-finalised turn (and everything
+			// older) is replaced by server canonical state, while any
+			// rows that arrive between issue and result (typically
+			// none on this path, but possible) survive the merge.
+			return tea.Batch(m.refreshHistoryAt(m.gen-1), m.loadStats())
 		}
 		return nil
 	}
@@ -1029,8 +1114,8 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 			m.sending = false
 			return nil
 		}
-		m.messages = append(m.messages, chatMessage{role: "system", content: fmt.Sprintf("!! %s", command)})
-		m.messages = append(m.messages, chatMessage{role: "system", content: "running on gateway..."})
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("!! %s", command)})
+		m.appendMessage(chatMessage{role: "system", content: "running on gateway..."})
 		m.updateViewport()
 		return m.execCommand(command)
 	}
@@ -1041,8 +1126,8 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 			m.sending = false
 			return nil
 		}
-		m.messages = append(m.messages, chatMessage{role: "system", content: fmt.Sprintf("$ %s", command)})
-		m.messages = append(m.messages, chatMessage{role: "system", content: "running..."})
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("$ %s", command)})
+		m.appendMessage(chatMessage{role: "system", content: "running..."})
 		m.updateViewport()
 		return localExecCommand(command)
 	}
@@ -1053,8 +1138,8 @@ func (m *chatModel) drainQueueOpt(refresh bool) tea.Cmd {
 			sent = expanded
 		}
 	}
-	m.messages = append(m.messages, chatMessage{role: "user", content: text})
-	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.appendMessage(chatMessage{role: "user", content: text})
+	m.appendMessage(chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 	if ar := m.activeRoutine; ar != nil && ar.logger != nil {
 		ar.logger.WriteUser(text)
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -203,7 +203,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	case "/compact":
 		compact, ok := m.backend.(backend.CompactBackend)
 		if !ok {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:   "system",
 				errMsg: "/compact is not available on this connection",
 			})
@@ -221,7 +221,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 				}
 			},
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:    "system",
 			content: m.pendingConfirm.prompt,
 		})
@@ -248,7 +248,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 				}
 			},
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:    "system",
 			content: m.pendingConfirm.prompt,
 		})
@@ -260,7 +260,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, m.gateNavigation("Switching connections", func() tea.Msg { return showConnectionsMsg{} })
 	case "/crons", "/crons all":
 		if _, ok := m.backend.(backend.CronBackend); !ok {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:   "system",
 				errMsg: "/crons is not available on this connection",
 			})
@@ -294,7 +294,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:    "system",
 			content: helpText,
 		})
@@ -302,17 +302,17 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 		return true, nil
 	case "/stats":
 		if m.stats == nil {
-			m.messages = append(m.messages, chatMessage{role: "system", content: "Stats not yet loaded..."})
+			m.appendMessage(chatMessage{role: "system", content: "Stats not yet loaded..."})
 			m.updateViewport()
 			return true, m.loadStats()
 		}
-		m.messages = append(m.messages, chatMessage{role: "system", content: m.formatStatsTable()})
+		m.appendMessage(chatMessage{role: "system", content: m.formatStatsTable()})
 		m.updateViewport()
 		return true, nil
 	case "/status":
 		status, ok := m.backend.(backend.StatusBackend)
 		if !ok {
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:   "system",
 				errMsg: "/status is not available on this connection",
 			})
@@ -327,13 +327,13 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 
 	case "/skills":
 		if len(m.skills) == 0 {
-			m.messages = append(m.messages, chatMessage{role: "system", content: "No agent skills found.\nPlace skills in <cwd>/.agents/skills/<name>/SKILL.md or ~/.agents/skills/<name>/SKILL.md"})
+			m.appendMessage(chatMessage{role: "system", content: "No agent skills found.\nPlace skills in <cwd>/.agents/skills/<name>/SKILL.md or ~/.agents/skills/<name>/SKILL.md"})
 		} else {
 			var lines []string
 			for _, s := range m.skills {
 				lines = append(lines, fmt.Sprintf("  /%s — %s", s.Name, s.Description))
 			}
-			m.messages = append(m.messages, chatMessage{
+			m.appendMessage(chatMessage{
 				role:    "system",
 				content: "Available skills:\n" + strings.Join(lines, "\n"),
 			})
@@ -386,7 +386,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		}
 
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:   "system",
 			errMsg: fmt.Sprintf("unknown command: %s (try /help)", firstToken),
 		})
@@ -454,7 +454,7 @@ func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
 	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:   "system",
 			errMsg: "/model requires a name — use /models to open the picker",
 		})
@@ -651,7 +651,7 @@ func formatDuration(ms int64) string {
 func (m *chatModel) handleRoutineCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
 	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:   "system",
 			errMsg: "/routine requires a name — use /routines to manage them",
 		})
@@ -745,7 +745,7 @@ func (m *chatModel) handleThinkCommand(text string) (bool, tea.Cmd) {
 		if level == "" {
 			level = "off (gateway default)"
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:    "system",
 			content: fmt.Sprintf("Thinking level: %s\nAvailable levels: %s", level, strings.Join(thinkingLevels, ", ")),
 		})
@@ -762,7 +762,7 @@ func (m *chatModel) handleThinkCommand(text string) (bool, tea.Cmd) {
 		}
 	}
 	if !valid {
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:   "system",
 			errMsg: fmt.Sprintf("unknown thinking level %q — valid levels: %s", level, strings.Join(thinkingLevels, ", ")),
 		})
@@ -772,7 +772,7 @@ func (m *chatModel) handleThinkCommand(text string) (bool, tea.Cmd) {
 
 	thinking, ok := m.backend.(backend.ThinkingBackend)
 	if !ok {
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:   "system",
 			errMsg: "/think is not available on this connection",
 		})

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -300,7 +300,6 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		// advanced routine step, recovery system rows) get the new gen
 		// and survive the merge.
 		boundary := m.bumpGen()
-		_ = boundary // wired up by Layer 3; Layer 2 keeps the old gating.
 		// Routine bookkeeping: log assistant content, parse /routine: directives.
 		// Done before drainQueue so a directive (stop/pause/mode) is honoured
 		// before the next routine step would otherwise auto-fire.
@@ -314,20 +313,33 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		if m.shouldRingBell() {
 			cmds = append(cmds, bellCmd())
 		}
-		drainCmd := m.drainQueue()
-		if m.sending {
-			// Still draining the queue — defer history refresh until the queue is empty
-			// to avoid replacing m.messages while queued user messages are visible.
-			cmds = append(cmds, drainCmd)
-			return tea.Batch(cmds...)
-		}
-		// User queue empty — try advancing the active routine. The advance itself
-		// sets m.sending and dispatches the next step.
-		if cmd := m.maybeAdvanceRoutine(); cmd != nil {
-			cmds = append(cmds, cmd)
-			return tea.Batch(cmds...)
-		}
+		// Always resync canonical history. Layer 2's merge in the
+		// historyRefreshMsg handler keeps the live tail (anything
+		// appended below at gen > boundary) intact, so this is safe
+		// even when a routine is auto-advancing or a queued message
+		// is about to be dispatched. Without this unconditional
+		// resync, mid-routine drift would accumulate over many steps
+		// and could let a stale chat event slip through the gate that
+		// guards spurious step submission.
 		cmds = append(cmds, m.refreshHistoryAt(boundary), m.loadStats())
+		// drainQueueSkipRefresh because we have already queued the
+		// resync above; the queue-empty branch of the regular
+		// drainQueue would otherwise issue a redundant refresh with
+		// the same boundary.
+		if cmd := m.drainQueueSkipRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		// If the queue was empty, drainQueueSkipRefresh has set
+		// m.sending=false and returned nil. The routine controller
+		// can advance now; it sets m.sending=true and dispatches the
+		// next step. Tagged with the new gen, that step's appended
+		// rows are on the live side of the boundary the refresh is
+		// carrying — the merge will preserve them.
+		if !m.sending {
+			if cmd := m.maybeAdvanceRoutine(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 		return tea.Batch(cmds...)
 
 	case "error":

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -264,7 +264,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				return nil
 			}
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:      "assistant",
 			content:   deltaText,
 			streaming: true,
@@ -294,6 +294,13 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			logEvent("  FINAL ignored (no streaming assistant message)")
 			return nil
 		}
+		// Capture the merge boundary *before* bumping so the just-
+		// finalised turn is on the history-side of any refresh issued
+		// from here on; subsequent appends (drained queue, auto-
+		// advanced routine step, recovery system rows) get the new gen
+		// and survive the merge.
+		boundary := m.bumpGen()
+		_ = boundary // wired up by Layer 3; Layer 2 keeps the old gating.
 		// Routine bookkeeping: log assistant content, parse /routine: directives.
 		// Done before drainQueue so a directive (stop/pause/mode) is honoured
 		// before the next routine step would otherwise auto-fire.
@@ -320,7 +327,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			cmds = append(cmds, cmd)
 			return tea.Batch(cmds...)
 		}
-		cmds = append(cmds, m.refreshHistory(), m.loadStats())
+		cmds = append(cmds, m.refreshHistoryAt(boundary), m.loadStats())
 		return tea.Batch(cmds...)
 
 	case "error":
@@ -340,6 +347,11 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		if !finalised {
 			return nil
 		}
+		// Bump so any subsequent refresh treats the errored turn as
+		// history-side. The error row itself was stamped with the
+		// pre-bump gen (still streaming when we mutated it in place),
+		// so it's on the history-side of the boundary too.
+		m.bumpGen()
 		// Pause the routine so a transient error doesn't auto-loop the next
 		// step. The user can press Enter to retry / continue, or Esc to end.
 		if m.activeRoutine != nil {
@@ -364,6 +376,9 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 		if !finalised {
 			return nil
 		}
+		// Same rationale as the error branch — keep the boundary
+		// monotonic so cancelled turns don't pollute the next merge.
+		m.bumpGen()
 		if m.activeRoutine != nil {
 			m.activeRoutine.paused = true
 		}
@@ -439,7 +454,7 @@ func (m *chatModel) handleAgentEvent(ev protocol.Event) tea.Cmd {
 		if name == "" {
 			name = "tool"
 		}
-		m.messages = append(m.messages, chatMessage{
+		m.appendMessage(chatMessage{
 			role:         "tool",
 			toolName:     name,
 			toolCallID:   td.ToolCallID,

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -57,6 +57,68 @@ func extractTextFromMessage(raw json.RawMessage) string {
 	return backend.ExtractChatText(raw)
 }
 
+// finalisedRunsCap bounds the size of finalisedRunSet. The gateway emits
+// stale duplicates rarely and only within a small window after final, so
+// 32 prior runs is far more than needed in practice — but keeping a hard
+// cap means a long-lived chat with thousands of turns never grows the
+// filter unboundedly.
+const finalisedRunsCap = 32
+
+// finalisedRunSet is a bounded FIFO set of run IDs we have already
+// finalised, used to drop stale chat events the gateway emits after a
+// run has completed. The previous implementation tracked only the most
+// recent finalised run, which was sufficient for the duplicate-after-
+// final case but missed the back-to-back routine race: if a stale event
+// arrives for run N-2 while run N-1 is streaming, it would slip past
+// the single-deep filter (since prevFinalised had moved on to run N-1)
+// and corrupt the placeholder. With a bounded set we cover that window
+// without retaining state across sessions.
+type finalisedRunSet struct {
+	ids   []string        // ordered oldest→newest; len ≤ finalisedRunsCap
+	inSet map[string]bool // O(1) membership for contains()
+}
+
+// add records id as finalised. Empty IDs are ignored (older gateways,
+// non-run-scoped events). Re-adding an existing id is a no-op so the
+// FIFO ordering stays meaningful.
+func (s *finalisedRunSet) add(id string) {
+	if id == "" {
+		return
+	}
+	if s.inSet == nil {
+		s.inSet = make(map[string]bool, finalisedRunsCap)
+	}
+	if s.inSet[id] {
+		return
+	}
+	if len(s.ids) >= finalisedRunsCap {
+		oldest := s.ids[0]
+		s.ids = s.ids[1:]
+		delete(s.inSet, oldest)
+	}
+	s.ids = append(s.ids, id)
+	s.inSet[id] = true
+}
+
+// contains reports whether id has been finalised. Empty IDs are never
+// members so callers can pass chatEv.RunID directly without guarding.
+func (s *finalisedRunSet) contains(id string) bool {
+	if id == "" {
+		return false
+	}
+	return s.inSet[id]
+}
+
+// last returns the most recently added id, or "" when the set is empty.
+// Useful for tests that want to assert "the most recent finalisation
+// was run X" without poking at internals.
+func (s *finalisedRunSet) last() string {
+	if len(s.ids) == 0 {
+		return ""
+	}
+	return s.ids[len(s.ids)-1]
+}
+
 // extractEventSessionKey pulls a top-level "sessionKey" string out of any
 // event payload. Returns "" when the payload has no sessionKey, is empty,
 // or fails to parse — those cases must be allowed through (older gateways,
@@ -166,14 +228,16 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 
 	logEvent("EVENT state=%s runID=%s seq=%d msgLen=%d sessionKey=%s", chatEv.State, chatEv.RunID, chatEv.Seq, len(chatEv.Message), chatEv.SessionKey)
 
-	// Drop stale events from a run we've already finalised. The gateway
-	// occasionally emits a duplicate `delta` (carrying the full content)
-	// after `final` with the same runID; if we let it through, the
-	// stale delta lands on the next routine step's placeholder, flips
-	// awaitingDelta, and lets a subsequent empty final spuriously
-	// finalise the next step — causing back-to-back routine steps to
-	// be advanced without a real response in between.
-	if chatEv.RunID != "" && chatEv.RunID == m.prevFinalisedRunID {
+	// Drop stale events from any run we have already finalised. The
+	// gateway occasionally emits a duplicate `delta` (carrying the full
+	// content) after `final` with the same runID; if we let it through,
+	// the stale delta lands on the next routine step's placeholder,
+	// flips awaitingDelta, and lets a subsequent empty final spuriously
+	// finalise the next step. The set is bounded so the filter covers
+	// back-to-back routine steps where a stale event for run N-k can
+	// arrive while run N is streaming, not just the immediately prior
+	// run.
+	if m.finalisedRuns.contains(chatEv.RunID) {
 		logEvent("  STALE event for finalised run %s — ignored", chatEv.RunID)
 		return nil
 	}
@@ -220,7 +284,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.thinking = extractThinkingFromMessage(chatEv.Message)
 				finalised = true
 				assistantContent = last.content
-				m.prevFinalisedRunID = chatEv.RunID
+				m.finalisedRuns.add(chatEv.RunID)
 				logEvent("  FINALISED — refreshing history thinking_len=%d", len(last.thinking))
 			}
 		}
@@ -269,7 +333,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.streaming = false
 				last.errMsg = chatEv.ErrorMessage
 				finalised = true
-				m.prevFinalisedRunID = chatEv.RunID
+				m.finalisedRuns.add(chatEv.RunID)
 			}
 		}
 		m.updateViewport()
@@ -293,7 +357,7 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 				last.streaming = false
 				last.content += "\n[aborted]"
 				finalised = true
-				m.prevFinalisedRunID = chatEv.RunID
+				m.finalisedRuns.add(chatEv.RunID)
 			}
 		}
 		m.updateViewport()

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/a3tai/openclaw-go/protocol"
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/routines"
 )
 
 // makeChatEvent builds a protocol.Event wrapping a ChatEvent payload.
@@ -399,6 +402,106 @@ func TestHandleEvent_FinalBumpsGen(t *testing.T) {
 	if m.gen != startGen+1 {
 		t.Errorf("successful final must bump gen: got %d, want %d", m.gen, startGen+1)
 	}
+}
+
+// TestHandleEvent_FinalRefreshesEvenWithQueuedMessages pins Layer 3:
+// the resync now fires on every final, even when a queued message is
+// about to be dispatched. Pre-Layer-3, a non-empty queue caused the
+// refresh to be deferred until the queue fully drained — which let
+// drift accumulate across queued turns. The merge in Layer 2 makes
+// this safe: the freshly-appended live tail survives the refresh.
+func TestHandleEvent_FinalRefreshesEvenWithQueuedMessages(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.pendingMessages = []string{"queued"}
+	m.messages = []chatMessage{
+		{role: "user", content: "first", gen: 1},
+		{role: "assistant", content: "answer", streaming: true, gen: 1},
+	}
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"answer"}]}`)
+	cmd := m.handleEvent(makeChatEvent("final", "run1", 1, finalMsg))
+	if cmd == nil {
+		t.Fatal("expected a non-nil batch cmd from final")
+	}
+	if !batchProducesMsg(cmd, func(msg tea.Msg) bool {
+		_, ok := msg.(historyRefreshMsg)
+		return ok
+	}) {
+		t.Error("expected historyRefreshMsg in the batch — Layer 3 must always resync, even with a queued message about to dispatch")
+	}
+	// The queued message must still have been drained: m.messages now
+	// contains the user turn for "queued" and a fresh placeholder.
+	last := m.messages[len(m.messages)-1]
+	if last.role != "assistant" || !last.streaming || !last.awaitingDelta {
+		t.Errorf("queued message should have appended a fresh placeholder, got %+v", last)
+	}
+}
+
+// TestHandleEvent_FinalRefreshesDuringRoutineAutoAdvance pins the
+// routine-specific case: under auto mode, every step's final now
+// resyncs *and* dispatches the next step. Pre-Layer-3, the refresh
+// was deferred to routine end, so a 10-step routine accumulated drift
+// across all 10 steps before the first server-canonical reconciliation.
+func TestHandleEvent_FinalRefreshesDuringRoutineAutoAdvance(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.activeRoutine = &activeRoutine{
+		routine: routines.Routine{
+			Name:  "demo",
+			Steps: []string{"step 1", "step 2", "step 3"},
+		},
+		mode: routines.ModeAuto,
+		sent: 1,
+	}
+	m.messages = []chatMessage{
+		{role: "user", content: "step 1", gen: 1},
+		{role: "assistant", content: "ok", streaming: true, gen: 1},
+	}
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"ok"}]}`)
+	cmd := m.handleEvent(makeChatEvent("final", "run1", 1, finalMsg))
+	if cmd == nil {
+		t.Fatal("expected a non-nil batch cmd")
+	}
+	if !batchProducesMsg(cmd, func(msg tea.Msg) bool {
+		_, ok := msg.(historyRefreshMsg)
+		return ok
+	}) {
+		t.Error("Layer 3: refresh must fire on every routine step's final, not just the last one")
+	}
+	// And the routine has advanced — step 2 was dispatched.
+	if m.activeRoutine == nil {
+		t.Fatal("active routine vanished")
+	}
+	if m.activeRoutine.sent != 2 {
+		t.Errorf("activeRoutine.sent = %d, want 2 (auto-advance must still fire)", m.activeRoutine.sent)
+	}
+}
+
+// batchProducesMsg walks a tea.Cmd (and any nested tea.BatchMsg) and
+// returns true when at least one leaf cmd produces a message
+// satisfying pred. Used to assert "this batch contains a refresh"
+// without caring about ordering or sibling cmds.
+func batchProducesMsg(cmd tea.Cmd, pred func(tea.Msg) bool) bool {
+	if cmd == nil {
+		return false
+	}
+	msg := cmd()
+	if msg == nil {
+		return false
+	}
+	if pred(msg) {
+		return true
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			if batchProducesMsg(sub, pred) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // TestHandleEvent_FinalEmptyAckDoesNotBumpGen is the negative case:

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -193,8 +193,8 @@ func TestHandleEvent_StaleDeltaAfterFinalIgnored(t *testing.T) {
 	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"3, 9"}]}`)
 	m.handleEvent(makeChatEvent("final", "run1", 5, finalMsg))
 
-	if m.prevFinalisedRunID != "run1" {
-		t.Fatalf("prevFinalisedRunID = %q, want run1", m.prevFinalisedRunID)
+	if !m.finalisedRuns.contains("run1") {
+		t.Fatalf("finalisedRuns should contain run1, got last=%q", m.finalisedRuns.last())
 	}
 
 	// Simulate routine auto-advance: append a fresh placeholder for the
@@ -222,6 +222,128 @@ func TestHandleEvent_StaleDeltaAfterFinalIgnored(t *testing.T) {
 	if !m.messages[len(m.messages)-1].streaming {
 		t.Error("step 2 should still be streaming; empty final must not finalise when no deltas have arrived")
 	}
+}
+
+// TestHandleEvent_StaleDeltaFromOlderRunIgnored covers the back-to-back
+// routine race the bounded set fixes: a stale event for run N-2 arrives
+// while run N is streaming. The previous one-deep prevFinalisedRunID
+// filter only caught duplicates of the *most recent* final, so a stale
+// delta or final for any earlier run would slip through and corrupt
+// the live placeholder. With the LRU, every recent finalised run is
+// remembered.
+func TestHandleEvent_StaleDeltaFromOlderRunIgnored(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+
+	// Walk through three back-to-back routine steps. After each final,
+	// the run's id is added to the set; after the third, the set holds
+	// run1, run2, run3.
+	m.messages = []chatMessage{
+		{role: "user", content: "step 1"},
+		{role: "assistant", content: "reply 1", streaming: true},
+	}
+	m.handleEvent(makeChatEvent("final", "run1", 1, json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"reply 1"}]}`)))
+
+	m.messages = append(m.messages,
+		chatMessage{role: "user", content: "step 2"},
+		chatMessage{role: "assistant", content: "reply 2", streaming: true},
+	)
+	m.handleEvent(makeChatEvent("final", "run2", 1, json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"reply 2"}]}`)))
+
+	m.messages = append(m.messages,
+		chatMessage{role: "user", content: "step 3"},
+		chatMessage{role: "assistant", streaming: true, awaitingDelta: true},
+	)
+
+	// Stale delta from run1 arrives — single-deep filter would let this
+	// through because prevFinalisedRunID has moved on to run2.
+	m.handleEvent(makeChatEvent("delta", "run1", 99, json.RawMessage(`"corrupted"`)))
+
+	last := m.messages[len(m.messages)-1]
+	if last.content != "" {
+		t.Errorf("run1 stale delta must not corrupt run3's placeholder: content = %q", last.content)
+	}
+	if !last.awaitingDelta {
+		t.Error("run1 stale delta must not flip awaitingDelta on run3's placeholder")
+	}
+
+	// Stale final from run2 should also be filtered.
+	m.handleEvent(makeChatEvent("final", "run2", 99, json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"x"}]}`)))
+	if !m.messages[len(m.messages)-1].streaming {
+		t.Error("run2 stale final must not finalise run3's placeholder")
+	}
+}
+
+// TestFinalisedRunSet_EvictsOldestPastCap pins the FIFO eviction so a
+// long-running session doesn't grow the set unboundedly. We add cap+1
+// distinct ids and confirm the very first is no longer a member.
+func TestFinalisedRunSet_EvictsOldestPastCap(t *testing.T) {
+	var s finalisedRunSet
+	for i := 0; i <= finalisedRunsCap; i++ {
+		s.add("r" + itoa(i))
+	}
+	if s.contains("r0") {
+		t.Error("r0 should have been evicted after adding cap+1 ids")
+	}
+	if !s.contains("r" + itoa(finalisedRunsCap)) {
+		t.Error("most recent id must still be a member")
+	}
+	if !s.contains("r1") {
+		t.Error("r1 should still be a member (only r0 evicted)")
+	}
+	if got := s.last(); got != "r"+itoa(finalisedRunsCap) {
+		t.Errorf("last() = %q, want r%d", got, finalisedRunsCap)
+	}
+}
+
+// TestFinalisedRunSet_IgnoresEmpty pins that empty ids are not stored
+// and not reported as members — older gateways may emit events without
+// a runID and those must fall through the filter, not be matched.
+func TestFinalisedRunSet_IgnoresEmpty(t *testing.T) {
+	var s finalisedRunSet
+	s.add("")
+	if s.contains("") {
+		t.Error("empty id must never be a member")
+	}
+	if got := s.last(); got != "" {
+		t.Errorf("last() with empty inputs = %q, want \"\"", got)
+	}
+}
+
+// TestFinalisedRunSet_ReAddIsNoOp pins that re-adding an existing id
+// does not consume a slot or shuffle ordering.
+func TestFinalisedRunSet_ReAddIsNoOp(t *testing.T) {
+	var s finalisedRunSet
+	s.add("a")
+	s.add("b")
+	s.add("a")
+	if got := s.last(); got != "b" {
+		t.Errorf("last() = %q, want b — re-adding existing id must not move it to the tail", got)
+	}
+}
+
+// itoa is a tiny std-free helper so the test doesn't import strconv
+// just for run-id formatting.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }
 
 func TestHandleEvent_FinalMarksStreamingDone(t *testing.T) {

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -44,6 +44,9 @@ func makeChatEventWithError(state, runID, errMsg string) protocol.Event {
 }
 
 // newTestChatModel creates a minimal chatModel suitable for unit tests.
+// gen starts at 1 to mirror production (newChatModel) so test rows
+// appended via appendMessage end up on the live side of any boundary
+// computed in tests.
 func newTestChatModel() *chatModel {
 	vp := viewport.New()
 	return &chatModel{
@@ -52,6 +55,7 @@ func newTestChatModel() *chatModel {
 		agentName: "test",
 		width:     80,
 		height:    30,
+		gen:       1,
 	}
 }
 
@@ -307,6 +311,116 @@ func TestFinalisedRunSet_IgnoresEmpty(t *testing.T) {
 	}
 	if got := s.last(); got != "" {
 		t.Errorf("last() with empty inputs = %q, want \"\"", got)
+	}
+}
+
+// TestMergeHistoryRefresh_PreservesLiveTail pins the central merge
+// invariant: rows whose gen exceeds the boundary survive a refresh,
+// rows at or below it are replaced by server canonical state. This is
+// the safety net that lets Layer 3 issue refreshes mid-routine without
+// wiping the next step's placeholder.
+func TestMergeHistoryRefresh_PreservesLiveTail(t *testing.T) {
+	m := newTestChatModel()
+	m.gen = 5
+	// Existing local state spans two turns: gen=4 (just finalised) and
+	// gen=5 (next routine step's placeholder + an in-flight tool card).
+	m.messages = []chatMessage{
+		{role: "user", content: "step 1", gen: 4},
+		{role: "assistant", content: "answer 1", gen: 4},
+		{role: "user", content: "step 2", gen: 5},
+		{role: "tool", toolName: "bash", toolState: "running", gen: 5},
+		{role: "assistant", streaming: true, awaitingDelta: true, gen: 5},
+	}
+	server := []chatMessage{
+		{role: "user", content: "step 1"},          // server-canonical (gen=0)
+		{role: "assistant", content: "answer 1 (canonical)"},
+	}
+	m.mergeHistoryRefresh(server, 4)
+
+	if len(m.messages) != len(server)+3 {
+		t.Fatalf("merged len = %d, want %d", len(m.messages), len(server)+3)
+	}
+	if m.messages[0].content != "step 1" || m.messages[1].content != "answer 1 (canonical)" {
+		t.Errorf("server prefix not placed first: %+v", m.messages[:2])
+	}
+	tail := m.messages[2:]
+	if tail[0].content != "step 2" || tail[0].gen != 5 {
+		t.Errorf("live tail step-2 user lost: %+v", tail[0])
+	}
+	if tail[1].role != "tool" || tail[1].toolState != "running" {
+		t.Errorf("live tail tool card lost: %+v", tail[1])
+	}
+	if tail[2].role != "assistant" || !tail[2].awaitingDelta {
+		t.Errorf("live tail placeholder lost: %+v", tail[2])
+	}
+}
+
+// TestMergeHistoryRefresh_NoLiveTail pins the empty-tail case: if every
+// row sits at or below the boundary (the queue-fully-drained scenario),
+// the merge is equivalent to wholesale replacement.
+func TestMergeHistoryRefresh_NoLiveTail(t *testing.T) {
+	m := newTestChatModel()
+	m.gen = 3
+	m.messages = []chatMessage{
+		{role: "user", content: "old", gen: 1},
+		{role: "assistant", content: "older", gen: 2},
+	}
+	server := []chatMessage{
+		{role: "user", content: "fresh"},
+		{role: "assistant", content: "fresher"},
+	}
+	m.mergeHistoryRefresh(server, 2)
+
+	if len(m.messages) != 2 {
+		t.Fatalf("merged len = %d, want 2 (live tail empty)", len(m.messages))
+	}
+	if m.messages[0].content != "fresh" || m.messages[1].content != "fresher" {
+		t.Errorf("expected wholesale replacement, got %+v", m.messages)
+	}
+}
+
+// TestHandleEvent_FinalBumpsGen pins that a successful final is what
+// advances the generation counter. An "empty ack" final (no streaming
+// placeholder to finalise) must NOT bump — otherwise the boundary
+// would drift forward without a real turn completing, and a later
+// refresh would treat genuine live state as history-side.
+func TestHandleEvent_FinalBumpsGen(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	m.messages = []chatMessage{
+		{role: "user", content: "hi", gen: 1},
+		{role: "assistant", content: "ack", streaming: true, gen: 1},
+	}
+	startGen := m.gen
+
+	finalMsg := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"ack"}]}`)
+	m.handleEvent(makeChatEvent("final", "run1", 1, finalMsg))
+
+	if m.gen != startGen+1 {
+		t.Errorf("successful final must bump gen: got %d, want %d", m.gen, startGen+1)
+	}
+}
+
+// TestHandleEvent_FinalEmptyAckDoesNotBumpGen is the negative case:
+// the gateway sometimes emits an early empty `final` ack before the
+// real response has been finalised. That must not advance the gen,
+// because no turn has actually completed.
+func TestHandleEvent_FinalEmptyAckDoesNotBumpGen(t *testing.T) {
+	m := newTestChatModel()
+	m.sending = true
+	// Placeholder still awaitingDelta — the gateway ack arrives before
+	// any content has streamed.
+	m.messages = []chatMessage{
+		{role: "user", content: "hi", gen: 1},
+		{role: "assistant", streaming: true, awaitingDelta: true, gen: 1},
+	}
+	startGen := m.gen
+
+	emptyFinal := json.RawMessage(`{"role":"assistant","content":[]}`)
+	m.handleEvent(makeChatEvent("final", "run1", 1, emptyFinal))
+
+	if m.gen != startGen {
+		t.Errorf("empty ack must NOT bump gen: got %d, started at %d", m.gen, startGen)
 	}
 }
 

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -34,14 +34,26 @@ func (m chatModel) loadHistory() tea.Cmd {
 	}
 }
 
-func (m chatModel) refreshHistory() tea.Cmd {
+// refreshHistoryAt issues a server-history fetch and tags the result
+// with the boundary captured at issue time. The merge in the
+// historyRefreshMsg handler keeps every existing row whose gen exceeds
+// boundary (the live tail) and replaces the rest with the fetched
+// state — making it safe for callers to refresh while the next turn
+// is already streaming, a tool card is mid-execution, or a pending
+// system row is awaiting outcome.
+//
+// Callers in the chat-event final/error/aborted paths pass the gen
+// they captured *before* bumping (i.e. the just-finalised turn's gen),
+// so that turn and everything older gets replaced by canonical state.
+// Callers on the queue-drained path pass m.gen-1 for the same reason.
+func (m chatModel) refreshHistoryAt(boundary uint64) tea.Cmd {
 	sessionKey := m.sessionKey
 	b := m.backend
 	renderer := m.renderer
 	limit := m.historyLimit
 	return func() tea.Msg {
 		msgs, err := fetchHistory(b, sessionKey, renderer, limit)
-		return historyRefreshMsg{messages: msgs, err: err}
+		return historyRefreshMsg{messages: msgs, boundary: boundary, err: err}
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -21,6 +21,15 @@ type chatMessage struct {
 	rendered      bool  // true if content has been glamour-rendered (contains ANSI codes)
 	timestampMs   int64 // unix millis; only used by "separator" rows to label resume time
 
+	// gen is the chatModel.gen counter at the moment this row was
+	// appended. It partitions the message list into a "history-side"
+	// portion (rows whose gen ≤ the refresh boundary, replaced from
+	// server canonical state) and a "live tail" (rows whose gen >
+	// boundary, preserved across the merge). Rows imported from server
+	// history (via fetchHistory) leave this as the zero value, which
+	// reads as "older than any live turn" — i.e. always replaceable.
+	gen uint64
+
 	// Tool fields populated only when role == "tool".
 	toolName     string
 	toolCallID   string
@@ -51,9 +60,16 @@ type historyLoadedMsg struct {
 	err      error
 }
 
-// historyRefreshMsg replaces all messages with fresh history after a response completes.
+// historyRefreshMsg merges server-canonical history into the message
+// list after a response completes. boundary is the chatModel.gen value
+// captured at the moment the refresh was issued; the merge keeps every
+// existing row with gen > boundary (the live tail — placeholder for the
+// next turn, in-flight tool cards, system rows the user is actively
+// looking at) and replaces everything ≤ boundary with the fetched
+// server history. The two halves are then concatenated, server first.
 type historyRefreshMsg struct {
 	messages []chatMessage
+	boundary uint64
 	err      error
 }
 

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -84,8 +84,8 @@ func (m *chatModel) sendNextRoutineStep() tea.Cmd {
 			sent = expanded
 		}
 	}
-	m.messages = append(m.messages, chatMessage{role: "user", content: text})
-	m.messages = append(m.messages, chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
+	m.appendMessage(chatMessage{role: "user", content: text})
+	m.appendMessage(chatMessage{role: "assistant", streaming: true, awaitingDelta: true})
 	m.sending = true
 	if ar.logger != nil {
 		ar.logger.WriteUser(text)


### PR DESCRIPTION
Closes a class of subtle chat-event drift bugs by making mid-turn server-history resync safe and unconditional, replacing the deferred-until-quiet refresh policy that let drift accumulate across queued turns and routine auto-advances.

## Summary

- **Layer 1 — bounded LRU stale-run filter** (`f02c593`): replaced the single-deep `prevFinalisedRunID` with a 32-entry FIFO set so back-to-back routine steps cannot let stale events from earlier runs (N-2, N-3, ...) slip past the gate that protects the live placeholder.
- **Layer 2 — generation-tagged merge** (`b84c345`): every appended `chatMessage` now carries a `gen` counter; `historyRefreshMsg` carries the boundary captured at issue time; the merge keeps every row with `gen > boundary` (the live tail) and replaces everything else with server-canonical state. Wholesale-replacement is gone.
- **Layer 3 — always resync after `final`** (`a2dbf0d`): the final handler issues `refreshHistoryAt(boundary)` unconditionally and then drains the queue / advances the routine. A 10-step auto-mode routine now reconciles canonical history every step instead of deferring until the routine completes.
- Documentation updated in `docs/routines.md` (auto-advance hook, stale-event filtering) and `docs/chat-ux.md` (new "Mid-turn history resync" section describing the gen + merge mechanism).

## Implementation details

The three layers are deliberately independent and committed separately:

- **Layer 1 alone** stops the spurious step submission symptom — a stale event from any recent finalised run is now dropped, not just from the most recent. Could ship as a stand-alone hotfix.
- **Layer 2 alone** introduces the gen field, the `appendMessage` helper, and the merge — but does not change *when* refreshes fire. A regression in the merge would only surface for the existing refresh sites (queue-empty, routine-end), keeping the blast radius small while the mechanism beds in.
- **Layer 3** flips the policy: refresh fires on every successful `final`. Safe because Layer 2 makes the merge non-destructive for in-flight tool cards and the next-turn placeholder.

The boundary semantics rest on `bumpGen()` only firing when a turn actually finalises — empty `final` acks (the gateway ping that arrives before any real content) intentionally do not bump, so the boundary cannot drift forward without a real turn completing. `TestHandleEvent_FinalEmptyAckDoesNotBumpGen` pins this.

Tool cards from a just-finalised turn are still lost on refresh — server history doesn't model them. Tool cards for the *current* turn survive because they're tagged with the new gen at append time. This matches the existing implicit behaviour at routine-end / queue-end refresh, just applied earlier and more consistently.

This PR targets `feat/routines` so the diff is scoped to the chat-event-merging work; once #128 lands the base will rebase onto main automatically.