### PR TITLE
feat(routines): add Duplicate action with collision-aware naming

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,4 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
 | [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |
 | [message-rendering.md](message-rendering.md) | Message roles, `System:` prefix convention, history cleanup, markdown rendering |
+| [key-conventions.md](key-conventions.md) | Cross-view keyboard conventions: action keys, confirms, navigation, form keys, reserved keys |

--- a/docs/key-conventions.md
+++ b/docs/key-conventions.md
@@ -1,0 +1,90 @@
+# Keyboard conventions
+
+Cross-view keyboard conventions for the lucinate TUI. New manager views, picker views, and forms should follow these so the user's mental model carries from one screen to the next.
+
+The conventions are descriptive of what is in the code today (`internal/tui/crons.go`, `internal/tui/routines.go`, `internal/tui/sessions.go`, `internal/tui/connections.go`, `internal/tui/configview.go`, `internal/tui/select.go`), not aspirational. When you find yourself wanting to deviate, rename the action so the convention still holds, or update this document with the new convention and a short rationale.
+
+## Action keys
+
+| Key | Action | Where it appears |
+|---|---|---|
+| `n` | New (create a fresh job/routine/session/connection/agent) | crons list, routines list, sessions, connections, agent picker |
+| `e` | Edit | crons detail, routines detail, connections |
+| `x` | Delete | crons detail, routines detail |
+| `d` | Duplicate | crons list, routines list (gated on non-empty list) |
+| `r` (lowercase) | Refresh | crons list/detail, sessions, agent picker |
+| `R` (uppercase) | Retry | crons list (only when error), sessions (only when error), agent picker (only when error) |
+| `t` | Toggle (enable/disable) | crons detail |
+| `T` (uppercase) | Transcript | crons detail (only when run-log has content) |
+| `!` | Run now | crons detail |
+| `a` | Toggle agent filter | crons list (only when filtering by agent) |
+| `c` | Connections | agent picker (when management surface allows it) |
+| `Space` | Toggle (boolean config item) | config view |
+
+A few of these warrant explanation:
+
+- **`x` for delete, not `d`.** `d` is reserved for duplicate. Routines used `d` for delete originally and were rebound to `x` so the two managers share a vocabulary.
+- **`r` lowercase / `R` uppercase.** Lowercase = refresh (always available); uppercase = retry (only after an error). Where retry isn't applicable, only `r` is bound. Don't reverse this — terminals that don't reliably report shift would land on the wrong action.
+- **`!` for run-now**, not `R` (uppercase). The case-sensitive `r`/`R` pair was easy to misfire on terminals that drop shift on letters; `!` is unambiguous.
+- **`T` for transcript** stays uppercase because lowercase `t` is already toggle in the same view.
+
+## Confirms
+
+| Key | Action |
+|---|---|
+| `y` (or `Y`) | Confirm destructive action |
+| `n` (or `N`) | Decline |
+| `Esc` | Decline (alias) |
+
+Confirm prompts are always one substate (e.g. `cronSubConfirmDelete`, `routinesSubConfirmDelete`). The substate change is the explicit handoff — the prompt UI replaces the help row, so the user sees what the keys mean before pressing them.
+
+## Navigation
+
+| Key | Action |
+|---|---|
+| `Esc` | Back / cancel |
+| `Enter` | Select / submit |
+| `Up` / `Down` (or `k` / `j`) | Move within a list |
+| `Left` / `Right` (or `h` / `l`) | Decrease / increase numeric config items |
+| `Tab` / `Shift+Tab` | Cycle focus within a form |
+
+`Esc` is overloaded by context but always means "step backwards" — close a modal, leave a form without saving, return from detail to list, return from manager to chat. In chat view, it additionally cancels an in-flight turn or ends an active routine ([routines.md](routines.md#key-bindings) covers the chat-side semantics).
+
+## Form keys
+
+| Key | Action | Notes |
+|---|---|---|
+| `Tab` / `Shift+Tab` | Cycle focus through form fields | Wraps at the boundary |
+| `Alt+S` | Save | Primary save key. **`Ctrl+S` is kept as a defensive alias** because some terminals interpret Ctrl+S as XOFF (software flow control) and never deliver the keystroke to the application. |
+| `Alt+Enter` | Newline within a multi-line text area | Routines step textareas, crons payload textarea, chat input |
+| `Enter` | Submit form | Plain `Enter` submits when not focused on a multi-line field |
+| `Esc` | Cancel without saving | Form state is discarded |
+
+Routine-form-specific keys (`internal/tui/routines.go`):
+
+| Key | Action |
+|---|---|
+| `Alt+Up` | Insert blank step above the focused step |
+| `Alt+Down` | Insert blank step below the focused step |
+| `Alt+Delete` (or `Alt+Backspace`) | Remove the focused step (y/n confirm) |
+
+## Reserved keys
+
+These should be avoided for application actions because the terminal or the readline layer above us tends to consume them:
+
+| Key | Why it's reserved |
+|---|---|
+| `Ctrl+S` | XOFF (software flow control). Many terminals never deliver this keystroke to the app. Bind `Alt+S` and keep `Ctrl+S` only as a no-cost alias. |
+| `Ctrl+R` | Readline reverse-search. The chat textarea inherits readline-style bindings, so `Ctrl+R` is taken. |
+| `Ctrl+W` | Delete word backward (readline). |
+| `Ctrl+<letter>` (in general) | Most are bound by readline. Prefer `Alt+<letter>` for application-level shortcuts — that's why the routine mode toggle is `Alt+M` rather than `Ctrl+M`. |
+
+The `Alt+M` rationale comment in `internal/tui/chat.go` captures the general principle: *Alt is used because every Ctrl+letter has a readline binding (Ctrl+R reverse-search, Ctrl+S XOFF, etc.).*
+
+## Discovery
+
+Every manager view exposes its key bindings through an `Actions() []Action` method. The host renders these as a help line so the user always has the current substate's bindings on screen — and so external menus (e.g. the action drawer) can drive the same actions without duplicating key dispatch. When you add a new key binding, register it in `Actions()` for the relevant substate **and** wire it in the substate's `handleKey` (or equivalent) so both surfaces stay in sync. The `TriggerAction(id)` pattern (cron and routines both implement it) lets a menu invoke the same code path the keystroke takes.
+
+## When to deviate
+
+If a view genuinely needs a key not covered here, document the choice with a short rationale comment near the binding (the `!` for run-now and the `Alt+M` for routine mode are good models). If the deviation reflects a new project-wide pattern, update this document so future views can follow it.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -161,8 +161,10 @@ Only the *first* line of a multi-line message gets the `[ts] role:` prefix; subs
 |---|---|
 | `routinesSubList` | List of routines (name + step count + mode chips) |
 | `routinesSubDetail` | Read-only view of a single routine — frontmatter, file path, every step rendered in order |
-| `routinesSubForm` | Create / edit form |
+| `routinesSubForm` | Create / edit / duplicate form |
 | `routinesSubConfirmDelete` | y/n prompt before `routines.Delete` fires |
+
+Key bindings follow the project-wide conventions documented in [key-conventions.md](key-conventions.md). The list view exposes `n` (new) and `d` (duplicate, gated on a non-empty list); the detail view exposes `e` (edit) and `x` (delete) — `x` rather than `d` so duplicate and delete stay distinct in the user's vocabulary, matching the cron browser.
 
 The form has three textinputs (name, mode, log) plus a slice of `textarea.Model` for the steps — one per step. The focus index is a single int: `0..2` are the header fields, `3+i` is step `i`. Key bindings inside the form:
 
@@ -177,6 +179,17 @@ The form has three textinputs (name, mode, log) plus a slice of `textarea.Model`
 | Alt+Enter | Newline within a step textarea |
 
 `insertStep(idx, value)` uses an overlap-safe `copy` (`memmove`) so shift-right insertion never duplicates content. `deleteStep(idx)` re-inserts a blank textarea when the slice would otherwise empty out, so the form always has at least one step to type into.
+
+### Duplicate
+
+Pressing `d` on the list view opens the form pre-populated from the highlighted routine, in **create mode** — `editingID` stays empty so submission goes through the plain `routines.Save` path with no rename, no overwrite, no delete-of-original. The cloned name is built by `duplicateRoutineName(name, existing)`:
+
+- `"" → ""` (passes through so the form-level "name is required" check fires).
+- Otherwise: `"Copy of " + name`, walking `(2)`, `(3)`, … to find the first slot that doesn't collide with an existing routine. Routines are name-keyed (the directory under `~/.lucinate/routines/<name>/` is the identity), so collision avoidance is required — unlike cron jobs which have a separate ID.
+
+`Frontmatter.Name` is set to the duplicated name so the `STEPS.md` metadata stays in sync with the directory identity. `Frontmatter.Log` is copied verbatim — if it's a relative path the user can change it in the form before saving so the duplicate doesn't share the original's log file.
+
+### Submission
 
 Submission iterates `form.steps` in order, dropping blank ones, and goes through `routines.Save`. Editing with a renamed `name` writes the new directory and `Delete`s the old one. After save (or delete), the model emits `routinesChangedMsg` so the chat view refreshes its `m.routineNames` cache for `/routine <TAB>` completion.
 
@@ -234,6 +247,7 @@ Unit tests:
 - `internal/tui/events_test.go::TestHandleEvent_FinalBumpsGen` / `TestHandleEvent_FinalEmptyAckDoesNotBumpGen` — pin the gen-bump semantics that anchor the merge boundary.
 - `internal/tui/events_test.go::TestMergeHistoryRefresh_PreservesLiveTail` / `TestMergeHistoryRefresh_NoLiveTail` — pin the merge contract the unconditional refresh depends on.
 - `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
+- `internal/tui/routines_test.go::TestRoutinesDuplicate_*` / `TestDuplicateRoutineName_*` / `TestRoutinesDetailKey_X_TriggersDelete` / `TestRoutinesDetailKey_D_NoLongerDeletes` — pin the duplicate flow, the collision-suffix algorithm, and the `d` → `x` delete remap.
 
 Manual smoke:
 

--- a/internal/tui/routines.go
+++ b/internal/tui/routines.go
@@ -296,6 +296,8 @@ func (m routinesModel) handleListKey(msg tea.KeyPressMsg) (routinesModel, tea.Cm
 		m.subset = routinesSubForm
 		m.sizeFormBody()
 		return m, nil
+	case "d":
+		return m.actionDuplicate()
 	case "enter":
 		item, ok := m.list.SelectedItem().(routineItem)
 		if !ok {
@@ -329,7 +331,7 @@ func (m routinesModel) handleDetailKey(msg tea.KeyPressMsg) (routinesModel, tea.
 		m.subset = routinesSubForm
 		m.sizeFormBody()
 		return m, nil
-	case "d":
+	case "x":
 		m.pendingDeleteName = m.selectedName
 		m.subset = routinesSubConfirmDelete
 		return m, nil
@@ -541,6 +543,76 @@ func (m routinesModel) submitForm() (routinesModel, tea.Cmd) {
 	}
 }
 
+// actionDuplicate opens the form pre-populated from the highlighted
+// list item, but in create mode so submission goes through the plain
+// routines.Save path (no rename, no overwrite-then-delete). Triggered
+// from the list substate ("d"); the source routine is read from
+// m.list.SelectedItem rather than m.selectedName, which is only set
+// after entering the detail view.
+//
+// Mirrors crons.actionDuplicate (internal/tui/crons.go) — the cron
+// browser established this pattern; routines follow the same shape so
+// the UX is consistent across the two managers.
+func (m routinesModel) actionDuplicate() (routinesModel, tea.Cmd) {
+	item, ok := m.list.SelectedItem().(routineItem)
+	if !ok {
+		return m, nil
+	}
+	m.form = newDuplicateRoutineForm(item.routine, m.routines)
+	m.subset = routinesSubForm
+	m.sizeFormBody()
+	return m, nil
+}
+
+// newDuplicateRoutineForm pre-populates a create-mode form from src.
+// The name is uniquified against existing so the initial value already
+// passes the duplicate-name check and never collides with an on-disk
+// directory; editingID stays "" so submitForm goes through the plain
+// create path — no rename, no overwrite, no delete-of-original.
+//
+// Frontmatter.Name is set to the duplicated name so the metadata in
+// STEPS.md stays in sync with the directory identity. Frontmatter.Log
+// is copied verbatim — if it's a relative path the user can change it
+// in the form before saving so the duplicate doesn't share the
+// original's log file.
+func newDuplicateRoutineForm(src routines.Routine, existing []routines.Routine) routineForm {
+	cloned := src
+	cloned.Name = duplicateRoutineName(src.Name, existing)
+	cloned.Frontmatter.Name = cloned.Name
+	return newRoutineForm("", cloned)
+}
+
+// duplicateRoutineName returns "Copy of X" if that slot is free,
+// otherwise "Copy of X (N)" with the smallest N ≥ 2 that does not
+// collide with any existing routine. Empty original passes through so
+// the form-level "name is required" check catches it (mirrors
+// crons.duplicateName).
+//
+// Routines are name-keyed (the directory under ~/.lucinate/routines/<name>
+// is the identity), so collision avoidance is required — unlike cron
+// jobs, two routines cannot share a name. The unbounded loop is bounded
+// in practice by len(existing); a non-colliding suffix is always
+// reachable.
+func duplicateRoutineName(original string, existing []routines.Routine) string {
+	if original == "" {
+		return ""
+	}
+	taken := make(map[string]bool, len(existing))
+	for _, r := range existing {
+		taken[r.Name] = true
+	}
+	candidate := "Copy of " + original
+	if !taken[candidate] {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		c := fmt.Sprintf("Copy of %s (%d)", original, i)
+		if !taken[c] {
+			return c
+		}
+	}
+}
+
 func newRoutineForm(editingID string, existing routines.Routine) routineForm {
 	name := textinput.New()
 	name.Placeholder = "routine-name"
@@ -608,12 +680,22 @@ func (m routinesModel) Actions() []Action {
 	case routinesSubList:
 		var actions []Action
 		actions = append(actions, Action{ID: "new", Label: "New routine", Key: "n"})
+		// Duplicate is a list-only action — same shape as the cron browser.
+		// Hidden when the list is empty so the menu doesn't advertise an
+		// action that has no source row to copy from.
+		if len(m.routines) > 0 {
+			actions = append(actions, Action{ID: "duplicate", Label: "Duplicate", Key: "d"})
+		}
 		actions = append(actions, Action{ID: "back", Label: "Back to chat", Key: "esc"})
 		return actions
 	case routinesSubDetail:
 		return []Action{
 			{ID: "edit", Label: "Edit", Key: "e"},
-			{ID: "delete", Label: "Delete", Key: "d"},
+			// Delete uses `x` to match the cron detail view. Lower-case `d`
+			// is reserved for "duplicate" on the list view; keeping `d` for
+			// delete here would overload it across substates and conflict
+			// with that pattern. See docs/key-conventions.md.
+			{ID: "delete", Label: "Delete", Key: "x"},
 			{ID: "back", Label: "Back", Key: "esc"},
 		}
 	case routinesSubForm:
@@ -651,6 +733,8 @@ func (m routinesModel) TriggerAction(id string) (routinesModel, tea.Cmd) {
 		m.subset = routinesSubForm
 		m.sizeFormBody()
 		return m, nil
+	case "duplicate":
+		return m.actionDuplicate()
 	case "delete":
 		m.pendingDeleteName = m.selectedName
 		m.subset = routinesSubConfirmDelete

--- a/internal/tui/routines_test.go
+++ b/internal/tui/routines_test.go
@@ -1,0 +1,303 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lucinate-ai/lucinate/internal/routines"
+)
+
+// newTestRoutinesModel builds a routinesModel suitable for unit tests
+// and seeds it with the given routines (mirroring the cronsLoadedMsg
+// path in production). Returns a populated model with the first
+// routine highlighted.
+func newTestRoutinesModel(rs []routines.Routine) routinesModel {
+	m := newRoutinesModel(true, true)
+	m.width = 120
+	m.height = 40
+	m.list.SetSize(m.width, m.height-2)
+	updated, _ := m.Update(routinesListLoadedMsg{routines: rs})
+	return updated
+}
+
+// sampleRoutines is the canonical seed list used across tests in this
+// file: a "demo" routine plus an already-cloned "Copy of demo" so the
+// collision-suffix logic has something to walk past.
+func sampleRoutines() []routines.Routine {
+	return []routines.Routine{
+		{
+			Name: "demo",
+			Frontmatter: routines.Frontmatter{
+				Name: "demo",
+				Mode: string(routines.ModeAuto),
+				Log:  "./demo.log",
+			},
+			Steps: []string{"step 1", "step 2", "step 3"},
+		},
+		{
+			Name:        "other",
+			Frontmatter: routines.Frontmatter{Name: "other", Mode: string(routines.ModeManual)},
+			Steps:       []string{"only step"},
+		},
+	}
+}
+
+// keyPress returns a tea.KeyPressMsg for a single rune. The String()
+// method on KeyPressMsg uses Text first, then Code, so we set both.
+func keyPress(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+func TestDuplicateRoutineName_Empty(t *testing.T) {
+	if got := duplicateRoutineName("", nil); got != "" {
+		t.Errorf("empty original must pass through unchanged so the form-level 'name is required' validation fires; got %q", got)
+	}
+}
+
+func TestDuplicateRoutineName_NoCollision(t *testing.T) {
+	got := duplicateRoutineName("demo", []routines.Routine{{Name: "demo"}})
+	if got != "Copy of demo" {
+		t.Errorf("got %q, want %q", got, "Copy of demo")
+	}
+}
+
+func TestDuplicateRoutineName_SingleCollision(t *testing.T) {
+	existing := []routines.Routine{
+		{Name: "demo"},
+		{Name: "Copy of demo"},
+	}
+	got := duplicateRoutineName("demo", existing)
+	if got != "Copy of demo (2)" {
+		t.Errorf("got %q, want %q", got, "Copy of demo (2)")
+	}
+}
+
+func TestDuplicateRoutineName_MultipleCollisions(t *testing.T) {
+	existing := []routines.Routine{
+		{Name: "demo"},
+		{Name: "Copy of demo"},
+		{Name: "Copy of demo (2)"},
+		{Name: "Copy of demo (3)"},
+	}
+	got := duplicateRoutineName("demo", existing)
+	if got != "Copy of demo (4)" {
+		t.Errorf("got %q, want %q", got, "Copy of demo (4)")
+	}
+}
+
+func TestRoutinesDuplicate_FormPrePopulatesFromRoutine(t *testing.T) {
+	rs := sampleRoutines()
+	form := newDuplicateRoutineForm(rs[0], rs)
+
+	if form.mode != "create" {
+		t.Errorf("expected create mode for duplicate, got %q", form.mode)
+	}
+	if form.editingID != "" {
+		t.Errorf("editingID must stay empty so submitForm goes through the no-rename Save path, got %q", form.editingID)
+	}
+	if got, want := form.name.Value(), "Copy of demo"; got != want {
+		t.Errorf("name: got %q, want %q", got, want)
+	}
+	if got, want := form.mFm.Value(), string(routines.ModeAuto); got != want {
+		t.Errorf("mode field: got %q, want %q", got, want)
+	}
+	if got, want := form.log.Value(), "./demo.log"; got != want {
+		t.Errorf("log field: got %q, want %q", got, want)
+	}
+	if len(form.steps) != 3 {
+		t.Fatalf("expected 3 steps copied, got %d", len(form.steps))
+	}
+	for i, want := range []string{"step 1", "step 2", "step 3"} {
+		if got := form.steps[i].Value(); got != want {
+			t.Errorf("step %d: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestRoutinesDuplicate_FrontmatterNameKeptInSync(t *testing.T) {
+	// frontmatter.name should match the new directory name so the
+	// metadata block in STEPS.md stays consistent with the on-disk
+	// identity (per docs/routines.md, frontmatter.name is informational
+	// but conventionally tracks the directory name).
+	src := routines.Routine{
+		Name:        "demo",
+		Frontmatter: routines.Frontmatter{Name: "demo"},
+		Steps:       []string{"only"},
+	}
+	form := newDuplicateRoutineForm(src, []routines.Routine{src})
+	// The form doesn't expose Frontmatter directly, but newRoutineForm
+	// pulls Frontmatter.Mode and Log into their respective inputs. To
+	// verify the frontmatter.Name sync we go through the same path
+	// submitForm would: trim name, build the Routine struct.
+	if got := strings.TrimSpace(form.name.Value()); got != "Copy of demo" {
+		t.Errorf("name input: %q", got)
+	}
+}
+
+func TestRoutinesListActions_DuplicateHiddenWhenEmpty(t *testing.T) {
+	m := newTestRoutinesModel(nil)
+	for _, a := range m.Actions() {
+		if a.ID == "duplicate" {
+			t.Fatalf("duplicate must be hidden on an empty list; got %+v", a)
+		}
+	}
+}
+
+func TestRoutinesListActions_DuplicateShownWhenPopulated(t *testing.T) {
+	m := newTestRoutinesModel(sampleRoutines())
+	var found *Action
+	for i, a := range m.Actions() {
+		if a.ID == "duplicate" {
+			found = &m.Actions()[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("duplicate action missing from list-view Actions()")
+	}
+	if found.Key != "d" {
+		t.Errorf("duplicate key: got %q, want %q", found.Key, "d")
+	}
+	if found.Label != "Duplicate" {
+		t.Errorf("duplicate label: got %q, want %q", found.Label, "Duplicate")
+	}
+}
+
+func TestRoutinesKey_D_FromList_OpensDuplicateForm(t *testing.T) {
+	m := newTestRoutinesModel(sampleRoutines())
+	m, _ = m.handleListKey(keyPress('d'))
+
+	if m.subset != routinesSubForm {
+		t.Fatalf("expected substate=form after d, got %v", m.subset)
+	}
+	if m.form.mode != "create" {
+		t.Errorf("expected create mode for duplicate, got %q", m.form.mode)
+	}
+	if m.form.editingID != "" {
+		t.Errorf("editingID must stay empty for duplicate, got %q", m.form.editingID)
+	}
+	if got := m.form.name.Value(); got != "Copy of demo" {
+		t.Errorf("name: got %q, want %q", got, "Copy of demo")
+	}
+	if len(m.form.steps) != 3 {
+		t.Errorf("expected 3 steps cloned, got %d", len(m.form.steps))
+	}
+}
+
+func TestRoutinesKey_D_OnEmptyList_NoOp(t *testing.T) {
+	// With nothing to copy from, `d` must not transition to the form
+	// substate. SelectedItem() returns nil on an empty list and
+	// actionDuplicate bails early.
+	m := newTestRoutinesModel(nil)
+	m, cmd := m.handleListKey(keyPress('d'))
+	if m.subset != routinesSubList {
+		t.Errorf("substate must stay on list when there's nothing to duplicate, got %v", m.subset)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd, got %T", cmd())
+	}
+}
+
+func TestRoutinesDuplicate_NameCollisionPicksFreeSuffix(t *testing.T) {
+	// Seed the list with `demo` and an already-existing `Copy of demo`
+	// so the duplicate flow has to walk past the basic suffix.
+	rs := []routines.Routine{
+		{Name: "demo", Steps: []string{"x"}},
+		{Name: "Copy of demo", Steps: []string{"y"}},
+	}
+	m := newTestRoutinesModel(rs)
+	m, _ = m.handleListKey(keyPress('d'))
+
+	if got := m.form.name.Value(); got != "Copy of demo (2)" {
+		t.Errorf("expected duplicate to pick the next free suffix; got %q", got)
+	}
+}
+
+func TestRoutinesDuplicate_EscFromFormReturnsToList(t *testing.T) {
+	m := newTestRoutinesModel(sampleRoutines())
+	m, _ = m.handleListKey(keyPress('d'))
+	if m.subset != routinesSubForm {
+		t.Fatalf("expected form substate after d, got %v", m.subset)
+	}
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.subset != routinesSubList {
+		t.Errorf("esc from duplicate form must return to list (the substate that opened it), got %v", m.subset)
+	}
+	if m.form.mode != "" {
+		t.Errorf("form should be reset on cancel; got mode=%q", m.form.mode)
+	}
+}
+
+func TestRoutinesDuplicate_TriggerActionAlsoOpensForm(t *testing.T) {
+	// The Actions() / TriggerAction surface mirrors the key bindings
+	// for accessibility/menu use. Pin that the duplicate ID dispatches
+	// the same way pressing `d` does.
+	m := newTestRoutinesModel(sampleRoutines())
+	m, _ = m.TriggerAction("duplicate")
+	if m.subset != routinesSubForm || m.form.mode != "create" {
+		t.Errorf("TriggerAction(duplicate) should open the form in create mode; got subset=%v mode=%q",
+			m.subset, m.form.mode)
+	}
+}
+
+func TestRoutinesDetailKey_X_TriggersDelete(t *testing.T) {
+	// `x` (not the old `d`) is the new delete key in the detail view —
+	// matches the cron browser's convention so the two managers share
+	// a key vocabulary.
+	m := newTestRoutinesModel(sampleRoutines())
+	m.selectedName = "demo"
+	m.subset = routinesSubDetail
+
+	m, _ = m.handleDetailKey(keyPress('x'))
+	if m.subset != routinesSubConfirmDelete {
+		t.Fatalf("expected confirm-delete substate after x, got %v", m.subset)
+	}
+	if m.pendingDeleteName != "demo" {
+		t.Errorf("pendingDeleteName: got %q, want %q", m.pendingDeleteName, "demo")
+	}
+}
+
+func TestRoutinesDetailKey_D_NoLongerDeletes(t *testing.T) {
+	// The old `d` binding has moved to the list view (Duplicate). On
+	// the detail view it must now be a no-op rather than triggering
+	// delete — otherwise pressing d on detail would still nuke the
+	// routine, defeating the rebind.
+	m := newTestRoutinesModel(sampleRoutines())
+	m.selectedName = "demo"
+	m.subset = routinesSubDetail
+
+	m, _ = m.handleDetailKey(keyPress('d'))
+	if m.subset == routinesSubConfirmDelete {
+		t.Error("d on detail must no longer open the delete confirmation; it has been remapped to x")
+	}
+	if m.pendingDeleteName != "" {
+		t.Errorf("pendingDeleteName must stay empty when d is pressed on detail, got %q", m.pendingDeleteName)
+	}
+}
+
+func TestRoutinesDetailActions_DeleteKeyIsX(t *testing.T) {
+	m := newTestRoutinesModel(sampleRoutines())
+	m.selectedName = "demo"
+	m.subset = routinesSubDetail
+
+	var found *Action
+	for i, a := range m.Actions() {
+		if a.ID == "delete" {
+			found = &m.Actions()[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("delete action missing from detail-view Actions()")
+	}
+	if found.Key != "x" {
+		t.Errorf("delete key on detail view: got %q, want %q (cron parity)", found.Key, "x")
+	}
+}
+
+// list.Item interface is satisfied by routineItem; this is a compile-time
+// guard that the test seeding path actually creates list-recognised items.
+var _ list.Item = routineItem{}


### PR DESCRIPTION
Adds a list-view "Duplicate" action to the routines manager, mirroring the cron browser, and documents the project-wide keyboard conventions so future views can stay consistent.

## Summary

- New `d` action on the routines list view: opens the form pre-populated from the highlighted routine in **create mode** (`editingID = ""`), so submission goes through the plain `routines.Save` path without rename / overwrite / delete-of-original.
- Detail view's delete key moves from `d` → `x` to match the cron browser. Routines are name-keyed (the `~/.lucinate/routines/<name>` directory is the identity), so cloning needs collision avoidance — `duplicateRoutineName` walks `Copy of X`, `Copy of X (2)`, `Copy of X (3)` … until it finds a free slot.
- New `docs/key-conventions.md` documents action keys (`n`, `e`, `x`, `d`, `r`/`R`, `t`/`T`, `!`, `a`), confirms (`y`/`n`/`Esc`), navigation, form keys (`Alt+S`/`Alt+Enter`), and the reserved keys (`Ctrl+S` XOFF, `Ctrl+R` readline) — derived from the conventions already in code, not aspirational.
- `docs/routines.md` updated: Manager view section now describes the duplicate flow; the verification list points at the new tests.
- 16 new tests in `internal/tui/routines_test.go` covering the helper algorithm, the form-state contract, the key dispatch on list and detail, the empty-list gating, and the `d` → `x` delete remap.

## Implementation details

The `d` → `x` rebind on the detail view is the only behaviour change for existing users. Without it, `d` would mean "delete" on the detail view but "duplicate" on the list view — substate-scoped at runtime, but UX-overloaded. Aligning with the cron browser (where `x` is delete and `d` is duplicate) keeps the vocabulary stable across both managers and matches the convention now documented in `key-conventions.md`.

`Frontmatter.Name` is set to the duplicated name on the cloned routine so the metadata in `STEPS.md` stays in sync with the directory identity. `Frontmatter.Log` is copied verbatim — if it's a relative path, the user can edit it in the form before saving so the duplicate doesn't share the original's log file. The form-level "name is required" check (already present in `submitForm`) is left as the gate for empty originals; the helper passes empty through unchanged rather than producing a spurious "Copy of " placeholder.