### PR TITLE
feat(tui): rework routine keybindings and status row

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The gateway's exec security policy controls which remote commands are allowed. I
 
 Recurring prompt workflow you find yourself retyping every Tuesday? Save it as a routine. Each routine is an ordered list of steps; each step is a complete user message. Activate one with `/routine <name>` and lucinate fires the steps at the assistant in order, optionally auto-advancing after every reply.
 
-Manage them with `/routines` — list, view, add, edit, delete. The form has one textarea per step plus `Alt+↑` / `Alt+↓` to insert above/below and `Alt+Delete` to remove. `Alt+S` saves.
+Manage them with `/routines` — list, view, add, edit, delete. The form has one textarea per step plus `Alt+↑` / `Alt+↓` to insert above/below and `Alt+Delete` to remove. `Ctrl+S` saves.
 
 Routine files live at `~/.lucinate/routines/<name>/STEPS.md`. The format is plain markdown with optional YAML frontmatter and `---` between steps:
 
@@ -232,7 +232,7 @@ Useful keys mid-routine:
 
 | Key | Action |
 |-----|--------|
-| `Alt+M` | Cycle the mode (auto ↔ manual) |
+| `Shift+Tab` | Cycle the mode (auto ↔ manual) |
 | `Enter` (empty input) | Send the next step (manual / paused mode) |
 | `Esc` | Cancel the routine and any in-flight reply |
 

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -6,11 +6,10 @@
 |---|---|
 | Enter | Send message — or, on empty input with an active routine, advance the routine ([routines.md](routines.md)) |
 | Alt+Enter | Insert newline |
-| Alt+M | Cycle the active routine's mode (auto ↔ manual) — no-op when no routine is active |
 | Ctrl+W | Delete word backward |
 | Up arrow (empty input) | Recall last sent message for editing |
 | Tab | Open slash menu, extend to longest common prefix, then cycle |
-| Shift+Tab | Cycle backward through slash-menu candidates |
+| Shift+Tab | While slash-menu is cycling: cycle backward through candidates. Otherwise, with an active routine: cycle the routine's mode (auto ↔ manual) |
 | Page Up / Page Down | Scroll message history |
 | Esc | Cancel in-progress response — or, with an active routine, end the routine and (if streaming) cancel the turn |
 

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -77,7 +77,7 @@ Lifecycle entry points on `*chatModel`:
 |---|---|
 | `startRoutine(name)` | Load + parse from disk, open the log if configured, append the "Routine started" notification, return the `tea.Cmd` for step 0's send |
 | `sendNextRoutineStep()` | Read `Steps[ar.sent]`, increment `ar.sent`, append the user message + assistant placeholder to `m.messages`, set `m.sending=true`, log the user line, return `sendMessage(...)` |
-| `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Returns `nil` unless the routine is active, mode is auto, not paused, and a step remains. Otherwise returns `sendNextRoutineStep`. When all steps have been sent, calls `endRoutine("completed")` and returns nil. |
+| `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Completion fires first: when the answered step was the last, calls `endRoutine("completed")` regardless of mode and returns nil so the user always gets the same notification + cleared `activeRoutine`. Otherwise returns `sendNextRoutineStep` only when mode is auto and not paused; in manual or paused mid-routine it returns nil and the user drives the next step. |
 | `applyDirectives(reply)` | Scans the assistant reply for `/routine:` directives and applies them in order |
 | `endRoutine(reason)` | Closes the logger, clears `activeRoutine`, posts a "Routine X <reason>" notification |
 | `cycleRoutineMode()` | Bound to `Shift+Tab` (mirrors Claude Code's mode-cycle gesture) — flips between auto and manual; entering auto unsets `paused`. Yields to slash-menu cycling when the completion menu is active. |
@@ -254,12 +254,14 @@ Unit tests:
 - `internal/tui/events_test.go::TestMergeHistoryRefresh_PreservesLiveTail` / `TestMergeHistoryRefresh_NoLiveTail` — pin the merge contract the unconditional refresh depends on.
 - `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
 - `internal/tui/routines_test.go::TestRoutinesDuplicate_*` / `TestDuplicateRoutineName_*` / `TestRoutinesDetailKey_X_TriggersDelete` / `TestRoutinesDetailKey_D_NoLongerDeletes` — pin the duplicate flow, the collision-suffix algorithm, and the `d` → `x` delete remap.
+- `internal/tui/routines_chat_test.go::TestMaybeAdvanceRoutine_ManualCompletion` / `TestMaybeAdvanceRoutine_ManualMidStepIsNoOp` — pin that manual routines complete on their final reply and stay quiet between steps.
 
 Manual smoke:
 
-1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — next: …`.
+1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — ▶ Press Enter to send: …`.
 2. Press Enter on an empty input — step 1 dispatches.
-3. Shift+Tab flips status to `AUTO`. Subsequent step finals auto-advance.
-4. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
-5. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
-6. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.
+3. Step through to the end. After the final step's reply, a `Routine "demo" completed.` notification appears, the status row disappears, and the input returns to plain chat.
+4. Shift+Tab flips status to `AUTO`. Subsequent step finals auto-advance.
+5. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
+6. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
+7. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -80,7 +80,7 @@ Lifecycle entry points on `*chatModel`:
 | `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Returns `nil` unless the routine is active, mode is auto, not paused, and a step remains. Otherwise returns `sendNextRoutineStep`. When all steps have been sent, calls `endRoutine("completed")` and returns nil. |
 | `applyDirectives(reply)` | Scans the assistant reply for `/routine:` directives and applies them in order |
 | `endRoutine(reason)` | Closes the logger, clears `activeRoutine`, posts a "Routine X <reason>" notification |
-| `cycleRoutineMode()` | Bound to `Alt+M` — flips between auto and manual; entering auto unsets `paused` |
+| `cycleRoutineMode()` | Bound to `Shift+Tab` (mirrors Claude Code's mode-cycle gesture) — flips between auto and manual; entering auto unsets `paused`. Yields to slash-menu cycling when the completion menu is active. |
 
 Step indexing is strictly monotonic: only `sendNextRoutineStep` increments `ar.sent`, and it does so once per call. Auto-advance is gated solely on `ar.sent < len(Steps)` and the directive/pause flags — there is no path that decrements or skips.
 
@@ -171,7 +171,7 @@ The form has three textinputs (name, mode, log) plus a slice of `textarea.Model`
 | Key | Action |
 |---|---|
 | Tab / Shift+Tab | Cycle focus |
-| Alt+S (or Ctrl+S) | Save — Alt+S is the primary because Ctrl+S is XOFF on most terminals |
+| Ctrl+S (or Alt+S) | Save — Ctrl+S is the surfaced binding; Alt+S is kept as a fallback for terminals that intercept Ctrl+S as XOFF |
 | Alt+Up | Insert blank step above the focused step |
 | Alt+Down | Insert blank step below the focused step |
 | Alt+Delete (or Alt+Backspace) | Remove the focused step (y/n confirm) |
@@ -230,7 +230,7 @@ routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
 
 | Key | Behaviour |
 |---|---|
-| Alt+M | Cycle mode (auto ↔ manual). No-op when no routine is active. Alt is used because every Ctrl+letter has a readline binding (Ctrl+R reverse-search, Ctrl+S XOFF, etc.). |
+| Shift+Tab | Cycle mode (auto ↔ manual). No-op when no routine is active. Mirrors Claude Code's mode-cycle gesture. Yields to slash-menu cycling when the completion menu is active. |
 | Esc | When a routine is active: end the routine and (if streaming) cancel the in-flight turn. Otherwise behaves as before (`/cancel`-equivalent or transcript back). |
 | Enter (empty input) | When a routine is active and idle (manual or paused): send the next step. Otherwise no-op. |
 
@@ -253,7 +253,7 @@ Manual smoke:
 
 1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — next: …`.
 2. Press Enter on an empty input — step 1 dispatches.
-3. Alt+M flips status to `AUTO`. Subsequent step finals auto-advance.
+3. Shift+Tab flips status to `AUTO`. Subsequent step finals auto-advance.
 4. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
 5. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
 6. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -230,7 +230,7 @@ When the routine is awaiting user input — manual mode, or auto with `paused` s
 routine: demo — MANUAL — sent: 5/10 — ▶ Press Enter to send: <preview>
 ```
 
-`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`; the preview length is computed from `m.width` so it grows with the terminal (floor 20 chars, fallback 40 when width is not yet known). `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
+`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set. The row is coloured by mode — amber (`execClr`) for auto, cyan (`userClr`) for manual — so the driver is legible at a glance without the row competing with the purple chat header. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`; the preview length is computed from `m.width` so it grows with the terminal (floor 20 chars, fallback 40 when width is not yet known). `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
 
 ## Key bindings
 

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -218,13 +218,19 @@ Routine state changes (started, paused, ended) and routine errors are surfaced a
 
 ## Status row
 
-When `m.activeRoutine != nil`, the chat View renders a single styled row immediately above the input box:
+When `m.activeRoutine != nil`, the chat View renders a single styled row immediately above the input box. While auto-advancing or mid-turn the trailing segment is a passive preview:
 
 ```
-routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
+routine: demo — AUTO — sent: 5/10 — next: <preview>
 ```
 
-`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set; `next:` previews the next step body, single-lined and ellipsised. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`. `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
+When the routine is awaiting user input — manual mode, or auto with `paused` set, with no turn in flight and steps remaining — the trailing segment switches to a call-to-action so the user sees both what the next message is and that the routine is parked on them:
+
+```
+routine: demo — MANUAL — sent: 5/10 — ▶ Press Enter to send: <preview>
+```
+
+`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`; the preview length is computed from `m.width` so it grows with the terminal (floor 20 chars, fallback 40 when width is not yet known). `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
 
 ## Key bindings
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -1292,7 +1292,7 @@ func (m chatModel) View() string {
 
 	routineStatus := ""
 	if line := m.routineStatusLine(); line != "" {
-		routineStatus = routineStatusStyle.Width(m.width).Render(line)
+		routineStatus = m.routineStatusStyle().Width(m.width).Render(line)
 	}
 	notifications := m.renderNotifications()
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -722,12 +722,6 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				return m, func() tea.Msg { return goBackFromCronTranscriptMsg{} }
 			}
 			return m, nil
-		case "alt+m":
-			if m.activeRoutine != nil {
-				m.cycleRoutineMode()
-				m.updateViewport()
-			}
-			return m, nil
 		case "tab":
 			if ctx, ok := m.completionAtCursor(); ok {
 				m.handleCompletionTab(ctx)
@@ -743,6 +737,11 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 					newValue := value[:ctx.start] + pick + value[ctx.cursorByte:]
 					setTextareaToValueWithCursor(&m.textarea, newValue, ctx.start+len(pick))
 				}
+				return m, nil
+			}
+			if m.activeRoutine != nil {
+				m.cycleRoutineMode()
+				m.updateViewport()
 			}
 			return m, nil
 		case "up":

--- a/internal/tui/routines.go
+++ b/internal/tui/routines.go
@@ -391,7 +391,7 @@ func (m routinesModel) handleFormKey(msg tea.KeyPressMsg) (routinesModel, tea.Cm
 			m.refocus()
 		}
 		return m, nil
-	// alt+s is the primary save key; ctrl+s is kept as an alias defensively
+	// ctrl+s is the surfaced save key; alt+s is kept as an alias defensively
 	// because some terminals interpret ctrl+s as XOFF and never deliver it.
 	case "alt+s", "ctrl+s":
 		return m.submitForm()
@@ -700,7 +700,7 @@ func (m routinesModel) Actions() []Action {
 		}
 	case routinesSubForm:
 		return []Action{
-			{ID: "save", Label: "Save", Key: "alt+s"},
+			{ID: "save", Label: "Save", Key: "ctrl+s"},
 			{ID: "insert-above", Label: "Insert step above", Key: "alt+up"},
 			{ID: "insert-below", Label: "Insert step below", Key: "alt+down"},
 			{ID: "delete-step", Label: "Delete step", Key: "alt+delete"},
@@ -896,7 +896,7 @@ func (m routinesModel) viewForm() string {
 		return b.String()
 	}
 	if !m.hideHints {
-		b.WriteString(helpStyle.Render(" alt+s: save · alt+↑/↓: insert step · alt+delete: remove step · tab: next field · esc: cancel"))
+		b.WriteString(helpStyle.Render(" ctrl+s: save · alt+↑/↓: insert step · alt+delete: remove step · tab: next field · esc: cancel"))
 	}
 	return b.String()
 }

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -249,11 +249,31 @@ func (m *chatModel) routineStatusLine() string {
 	return status + prefix + previewLine(ar.routine.Steps[ar.sent], previewMax)
 }
 
-// routineStatusStyle styles the in-chat status row.
-var routineStatusStyle = lipgloss.NewStyle().
-	Foreground(accent).
+// routineStatusAutoStyle and routineStatusManualStyle differentiate the
+// in-chat status row by mode so the user can see at a glance who is
+// driving — amber when the routine auto-advances, cyan when it is parked
+// on the user. We reuse execClr/userClr from the shared palette rather
+// than introducing new colours.
+var routineStatusAutoStyle = lipgloss.NewStyle().
+	Foreground(execClr).
 	Bold(true).
 	Padding(0, 1)
+
+var routineStatusManualStyle = lipgloss.NewStyle().
+	Foreground(userClr).
+	Bold(true).
+	Padding(0, 1)
+
+// routineStatusStyle returns the style to apply to the in-chat status
+// row, picked by the active routine's mode. Falls back to the manual
+// style when no routine is active (callers should already gate on a
+// non-empty status line, but the fallback keeps the helper total).
+func (m *chatModel) routineStatusStyle() lipgloss.Style {
+	if m.activeRoutine != nil && m.activeRoutine.mode == routines.ModeAuto {
+		return routineStatusAutoStyle
+	}
+	return routineStatusManualStyle
+}
 
 // previewLine reduces text to a single-line, ellipsised preview.
 func previewLine(text string, max int) string {

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -14,7 +14,7 @@ import (
 // activeRoutine holds the in-flight state for a routine the user has
 // activated via /routine <name>. While set, the chatModel auto-advances in
 // auto mode after each assistant final, repurposes Enter on empty input to
-// send the next step, and binds Alt+M to mode cycling.
+// send the next step, and binds Shift+Tab to mode cycling.
 type activeRoutine struct {
 	routine routines.Routine
 	mode    routines.Mode

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -204,7 +204,11 @@ func (m *chatModel) appendSystemError(msg string) {
 
 // routineStatusLine renders the in-chat status row for the active routine.
 // Returns "" when no routine is active. The output is plain text scoped to
-// at most one display line; the View pads it to the chat width.
+// at most one display line; the View pads it to the chat width. When the
+// routine is awaiting user input (manual or paused, idle, with steps
+// remaining) the trailing segment switches from a passive "next:" preview
+// to a "▶ Press Enter to send:" call-to-action so the user can see both
+// what the next message is and that the routine is parked on them.
 func (m *chatModel) routineStatusLine() string {
 	ar := m.activeRoutine
 	if ar == nil {
@@ -215,12 +219,25 @@ func (m *chatModel) routineStatusLine() string {
 		mode += " (paused)"
 	}
 	total := len(ar.routine.Steps)
-	next := ""
-	if ar.sent < total {
-		next = " — next: " + previewLine(ar.routine.Steps[ar.sent], 40)
+	status := fmt.Sprintf("routine: %s — %s — sent: %d/%d", ar.routine.Name, mode, ar.sent, total)
+	if ar.sent >= total {
+		return status
 	}
-	return fmt.Sprintf("routine: %s — %s — sent: %d/%d%s",
-		ar.routine.Name, mode, ar.sent, total, next)
+	awaitingUser := !m.sending && (ar.mode == routines.ModeManual || ar.paused)
+	prefix := " — next: "
+	if awaitingUser {
+		prefix = " — ▶ Press Enter to send: "
+	}
+	// Size the preview to the remaining width so the user can read as much
+	// of the upcoming step as fits. Fall back to 40 when width is unknown.
+	previewMax := 40
+	if m.width > 0 {
+		previewMax = m.width - 2 - len(status) - len(prefix) // -2 for routineStatusStyle's horizontal padding
+		if previewMax < 20 {
+			previewMax = 20
+		}
+	}
+	return status + prefix + previewLine(ar.routine.Steps[ar.sent], previewMax)
 }
 
 // routineStatusStyle styles the in-chat status row.

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -94,17 +94,26 @@ func (m *chatModel) sendNextRoutineStep() tea.Cmd {
 	return tea.Batch(m.sendMessage(sent), m.ensureSpinnerTicking())
 }
 
-// maybeAdvanceRoutine returns a tea.Cmd that fires the next step when
-// auto-advance conditions are met. Callers invoke it after the user-message
-// queue has drained on a chat-final event so user-typed messages take
+// maybeAdvanceRoutine reacts to a chat-final event for an active routine:
+// it ends the routine when the last step has now been answered, or fires
+// the next step in auto mode. Returns nil for manual/paused mid-routine
+// finals, where the user drives the next step. Callers invoke it after
+// the user-message queue has drained so user-typed messages take
 // precedence over routine steps.
 func (m *chatModel) maybeAdvanceRoutine() tea.Cmd {
 	ar := m.activeRoutine
-	if ar == nil || ar.paused || ar.mode != routines.ModeAuto {
+	if ar == nil {
 		return nil
 	}
+	// Completion fires regardless of mode — a manual routine that just
+	// answered its final step is just as "done" as an auto one, and the
+	// user needs the same "Routine X completed." notification + cleared
+	// activeRoutine so the input returns to normal chat.
 	if ar.sent >= len(ar.routine.Steps) {
 		m.endRoutine("completed")
+		return nil
+	}
+	if ar.paused || ar.mode != routines.ModeAuto {
 		return nil
 	}
 	return m.sendNextRoutineStep()

--- a/internal/tui/routines_chat_test.go
+++ b/internal/tui/routines_chat_test.go
@@ -76,3 +76,56 @@ func TestRoutineStatusLine_PreviewGrowsWithWidth(t *testing.T) {
 		t.Errorf("expected wider terminal to yield longer preview: wide=%d narrow=%d", len(wide), len(narrow))
 	}
 }
+
+// TestMaybeAdvanceRoutine_ManualCompletion pins that the final step of a
+// manual routine ends the routine on its final event — the user otherwise
+// sees no "completed" notification and the input stays parked in routine
+// mode forever.
+func TestMaybeAdvanceRoutine_ManualCompletion(t *testing.T) {
+	m := &chatModel{
+		width: 120,
+		activeRoutine: &activeRoutine{
+			routine: routines.Routine{Name: "demo", Steps: []string{"a", "b"}},
+			mode:    routines.ModeManual,
+			sent:    2, // both steps already dispatched; this is the final reply
+		},
+	}
+	if cmd := m.maybeAdvanceRoutine(); cmd != nil {
+		t.Fatalf("manual completion should not dispatch a follow-up step (got cmd=%v)", cmd)
+	}
+	if m.activeRoutine != nil {
+		t.Fatalf("activeRoutine should be cleared after completion, got %+v", m.activeRoutine)
+	}
+	if len(m.notifications) == 0 {
+		t.Fatalf("expected a completion notification, got none")
+	}
+	last := m.notifications[len(m.notifications)-1]
+	if !strings.Contains(last.text, "completed") || !strings.Contains(last.text, "demo") {
+		t.Errorf("notification should announce 'demo completed', got %q", last.text)
+	}
+	if last.isError {
+		t.Errorf("completion notification should not be an error")
+	}
+}
+
+// TestMaybeAdvanceRoutine_ManualMidStepIsNoOp pins that mid-routine manual
+// finals stay quiet — the user, not the controller, drives the next step.
+func TestMaybeAdvanceRoutine_ManualMidStepIsNoOp(t *testing.T) {
+	m := &chatModel{
+		width: 120,
+		activeRoutine: &activeRoutine{
+			routine: routines.Routine{Name: "demo", Steps: []string{"a", "b"}},
+			mode:    routines.ModeManual,
+			sent:    1, // one of two steps dispatched; user must press Enter for step 2
+		},
+	}
+	if cmd := m.maybeAdvanceRoutine(); cmd != nil {
+		t.Fatalf("manual mid-routine final should not auto-advance (got cmd=%v)", cmd)
+	}
+	if m.activeRoutine == nil {
+		t.Fatalf("activeRoutine should still be set mid-routine")
+	}
+	if len(m.notifications) != 0 {
+		t.Errorf("manual mid-routine final should not emit a notification, got %+v", m.notifications)
+	}
+}

--- a/internal/tui/routines_chat_test.go
+++ b/internal/tui/routines_chat_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lucinate-ai/lucinate/internal/routines"
+)
+
+// TestRoutineStatusLine_AwaitingUserShowsCallToAction pins the manual-mode
+// "press Enter" cue: when the routine is parked on the user, the trailing
+// segment must surface the next message body alongside actionable wording.
+func TestRoutineStatusLine_AwaitingUserShowsCallToAction(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     routines.Mode
+		paused   bool
+		sending  bool
+		wantCue  bool // true => expect "Press Enter"; false => expect passive "next:"
+		wantSent string
+	}{
+		{name: "manual idle awaits user", mode: routines.ModeManual, wantCue: true, wantSent: "1/2"},
+		{name: "manual sending shows next", mode: routines.ModeManual, sending: true, wantCue: false, wantSent: "1/2"},
+		{name: "auto running shows next", mode: routines.ModeAuto, wantCue: false, wantSent: "1/2"},
+		{name: "auto paused awaits user", mode: routines.ModeAuto, paused: true, wantCue: true, wantSent: "1/2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &chatModel{
+				width:   120,
+				sending: tc.sending,
+				activeRoutine: &activeRoutine{
+					routine: routines.Routine{
+						Name:  "demo",
+						Steps: []string{"first step", "second step body"},
+					},
+					mode:   tc.mode,
+					paused: tc.paused,
+					sent:   1,
+				},
+			}
+			line := m.routineStatusLine()
+			if !strings.Contains(line, "sent: "+tc.wantSent) {
+				t.Errorf("missing progress %q in %q", tc.wantSent, line)
+			}
+			hasCue := strings.Contains(line, "▶ Press Enter to send:")
+			if hasCue != tc.wantCue {
+				t.Errorf("call-to-action presence: got %v, want %v (line=%q)", hasCue, tc.wantCue, line)
+			}
+			if tc.wantCue && !strings.Contains(line, "second step body") {
+				t.Errorf("awaiting-user line should preview the next step body, got %q", line)
+			}
+			if !tc.wantCue && !strings.Contains(line, "next: ") {
+				t.Errorf("non-awaiting line should use passive 'next:' segment, got %q", line)
+			}
+		})
+	}
+}
+
+// TestRoutineStatusLine_PreviewGrowsWithWidth pins that the preview length
+// scales with terminal width — the awaiting-user cue is only useful if the
+// user can actually read enough of the upcoming message.
+func TestRoutineStatusLine_PreviewGrowsWithWidth(t *testing.T) {
+	long := strings.Repeat("abcdefghij ", 30) // 330 chars
+	m := &chatModel{
+		width: 200,
+		activeRoutine: &activeRoutine{
+			routine: routines.Routine{Name: "demo", Steps: []string{long}},
+			mode:    routines.ModeManual,
+		},
+	}
+	wide := m.routineStatusLine()
+	m.width = 60
+	narrow := m.routineStatusLine()
+	if len(wide) <= len(narrow) {
+		t.Errorf("expected wider terminal to yield longer preview: wide=%d narrow=%d", len(wide), len(narrow))
+	}
+}


### PR DESCRIPTION
Bring the routine UX in line with what the user expects: claude-code-style mode cycling, a clearer save shortcut, a status row that reads "the routine is parked on you", and a completion handshake that fires for manual routines too.

## Summary
- Cycle routine modes with `Shift+Tab` (mirrors Claude Code) instead of `Alt+M`. Slash-menu cycling still wins when the completion menu is open.
- Surface `Ctrl+S` (rather than `Alt+S`) as the routine-form save key. `Alt+S` stays as a fallback for terminals that intercept Ctrl+S as XOFF.
- Switch the manual-mode status segment from a passive `next:` preview to a `▶ Press Enter to send: …` call-to-action, and size the preview to terminal width so the user can read more of the upcoming step.
- End manual routines on their final reply: `maybeAdvanceRoutine` now fires the `Routine X completed.` notification and clears `activeRoutine` regardless of mode.
- Colour the status row by mode — amber for auto, cyan for manual — using the existing `execClr`/`userClr` palette so it does not clash with the purple chat header.

## Implementation details
- `Shift+Tab` had to be layered on top of the existing slash-menu candidate-cycling handler. The new path returns early when `m.completion.cycling` is set, so the gesture only falls through to `cycleRoutineMode()` when the menu is not actively cycling.
- Manual completion was previously masked by `maybeAdvanceRoutine`'s early return on non-auto modes. The completion check now fires before the auto-only guard so the same `endRoutine("completed")` notification path is taken regardless of how the routine was driven.
- The status-row preview length is computed from `m.width` (floor 20, fallback 40 when width is not yet known) so the awaiting-user cue stays useful on wide terminals without breaking on narrow ones.