### PR TITLE
feat(tui): add transcript record/export and improve routine form

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [one-shot.md](one-shot.md) | One-shot CLI mode: `lucinate send` lifecycle, default session rule, detach semantics, embedding |
 | [chat-launch.md](chat-launch.md) | Pre-navigated TUI launch: `lucinate chat` override plumbing, consumption points, stale-clearing rules |
 | [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
+| [export-and-recording.md](export-and-recording.md) | `/record` and `/export` transcripts: canonical-history tap, dedup, file layout, lifecycle |
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
 | [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |
 | [message-rendering.md](message-rendering.md) | Message roles, `System:` prefix convention, history cleanup, markdown rendering |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,9 +23,15 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/crons` | Open the cron browser filtered to the current agent — see [crons.md](crons.md) — **OpenClaw only** |
 | `/crons all` | Open the cron browser unfiltered (jobs across all agents) — **OpenClaw only** |
 | `/exit`, `/quit` | Exit via `tea.Quit` |
+| `/export` | Write the current session's canonical history to a transcript file — see below |
+| `/export all` | Same as `/export` |
+| `/export routine` | Convert the session's user prompts into routine steps and open the form prepopulated — see below |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
+| `/record` | Show whether transcript capture is on, and where it's writing |
+| `/record on` | Begin streaming canonical conversation messages to a transcript file — see below |
+| `/record off` | Stop the active recording and report the file path |
 | `/reset` | Delete the session and start fresh — see [sessions.md](sessions.md#compact-and-reset) |
 | `/routine <name>` | Activate a stored routine in the current session — see [routines.md](routines.md) |
 | `/routines` | Open the routines manager (list/view/edit/delete) — see [routines.md](routines.md) |
@@ -49,6 +55,12 @@ Backend-only commands render a "not available on this connection" system message
 ### /stats
 
 Stats are loaded asynchronously via `client.SessionUsage()` on chat init and after each message exchange. `/stats` formats `m.stats` through `formatStatsTable()` in `internal/tui/render.go`, which produces a text table of input/output/cache tokens and cost breakdown.
+
+### /record and /export
+
+Both commands persist the session's canonical chat history to a Markdown file under `<dataDir>/transcripts/`. `/record on` streams new turns as they finalise; `/export [all]` dumps the current state in one shot; `/export routine` skips the file write and opens the routines manager prefilled with the session's user prompts.
+
+The canonical-history tap, dedup signature, file layout, and lifecycle are documented in [export-and-recording.md](export-and-recording.md).
 
 ## Tab completion
 

--- a/docs/export-and-recording.md
+++ b/docs/export-and-recording.md
@@ -1,0 +1,53 @@
+# Export and recording
+
+Two slash commands let the user persist a session's conversation to disk: `/record` for live capture and `/export` for an after-the-fact dump. The implementation lives in `internal/tui/recorder.go` and the handlers in `internal/tui/commands.go`.
+
+Both commands draw from the same source: the canonical chat history the backend reports, never the streaming deltas. Streaming placeholders, tool cards, system rows (compact/reset notices, exec output, error banners) and the inline separators inserted at session resume are intentionally excluded — the transcript is meant to be the conversation as the gateway / OpenAI-compat backend would replay it, not as the TUI rendered it.
+
+## Files on disk
+
+Transcripts are written to `<dataDir>/transcripts/` — `~/.lucinate/transcripts/` by default, or whatever `LUCINATE_DATA_DIR` / `config.SetDataDir` resolves to (see [connections.md](connections.md) for data-dir resolution). The directory is created on demand with mode `0o700`; individual files are mode `0o600`.
+
+Filenames follow `<kind>-<agent>-<session>-<UTCtimestamp>.md`, where `kind` is `record` or `export`. Agent and session names are passed through `sanitiseForPath`, which collapses anything outside `[A-Za-z0-9_-]` to `-` and trims separators — so `main session` becomes `main-session`, `Agent Name` becomes `Agent-Name`. The timestamp resolves to the second (`20060102T150405`); two recordings started inside the same second to the same session would collide and the second would truncate the first, which is fine in practice and avoided by `/record on` opening with `O_CREATE|O_TRUNC`.
+
+The body is plain Markdown: a header listing connection / agent / model / session / timestamp, a `---` divider, then one `## User` or `## Assistant` block per turn. When a per-message `timestampMs` is reported by the backend it's appended to the heading as ` · <RFC3339>`. Assistant messages preserve any thinking content as a leading `> _thinking_` blockquote so the file is self-contained even when the chat view collapses thinking.
+
+## Canonical-history tap
+
+The chat view receives canonical messages through two `tea.Msg` types, both produced by `fetchHistory` in `internal/tui/history.go`:
+
+- `historyLoadedMsg` — initial fetch on chat-view entry.
+- `historyRefreshMsg` — server-canonical resync issued from the chat-event `final`/`error`/`aborted` handlers in `internal/tui/events.go`. The merge boundary keeps the live tail intact (see `mergeHistoryRefresh` in `chat.go`) but the `messages` slice on the message itself is the authoritative gateway view of the conversation up to that point.
+
+Both arms call `chatModel.recordCanonical(msg.messages)` after consuming the message. When `chatModel.recorder` is `nil` (recording is off) this is a no-op; otherwise the slice is forwarded to `recorder.writeNew`, which iterates and writes any rows it hasn't seen before.
+
+## Dedup signature
+
+Each canonical refresh delivers the entire history (capped by `historyLimit`), so every row arrives repeatedly. `recorder.seenSig` is a `map[string]bool` keyed by `messageSignature(role, timestampMs, sourceText)`, where `sourceText` is `chatMessage.raw` when the row was glamour-rendered and `chatMessage.content` otherwise — preferring the markdown source guarantees the dedup key matches the bytes that get written, and avoids ANSI-rendered assistant turns leaking escape codes into the transcript. The hash is FNV-64a, formatted alongside role and timestamp as `role|ts|hex` so a user/assistant collision on identical content is impossible and a repeated user message at a later timestamp is recorded.
+
+The signature set lives only for the lifetime of one recording. A new `/record on` starts with an empty set and reseeds the file from scratch (the underlying `os.OpenFile` uses `O_TRUNC`).
+
+## Lifecycle
+
+`/record on` opens the file, writes the header, attaches a `*transcriptRecorder` to `chatModel`, then immediately calls `recordCanonical(m.messages)` so any history already loaded into the chat view is captured before the next refresh. The chat view does not re-fetch from the gateway at this point — the assumption is that `m.messages` reflects the most recent canonical state, since `historyLoadedMsg` and every `historyRefreshMsg` have already passed through.
+
+`/record off` and `chatModel.stopRecording()` close the writer and clear the field. The chat model's teardown sites in `app.go` — `sessionSelectedMsg`, `cronTranscriptMsg`, `newSessionCreatedMsg`, `sessionCreatedMsg` — call `stopRecording` before the field is reassigned, so a recording does not silently outlive its session. Recording does **not** resume on the new chat; the user has to opt in again.
+
+A write failure on `recordCanonical` (disk full, broken permissions, file removed under us) closes the recorder and surfaces a one-shot system error in the chat view. Subsequent canonical refreshes are no-ops because the field has been cleared — the alternative was repeated error rows on every turn, which would be more annoying than informative.
+
+## /export
+
+`exportTranscript` in `commands.go` is the synchronous one-shot path. It opens a fresh `export-...md` file, writes the same header (with `kind = "export"`), and walks the supplied `[]chatMessage` slice — typically `m.messages` — applying the same role and content filters as the recorder. Streaming rows are skipped explicitly (so an export issued mid-turn doesn't capture a half-typed assistant message); empty content is skipped; `raw` wins over `content` for rendered turns. The function returns the resolved path so the chat view can surface it.
+
+`/export routine` doesn't write a file. `extractUserPromptsForRoutine` walks `m.messages` for non-empty user rows (preferring `raw` over `content`) and the handler dispatches `showRoutinesMsg{prefillSteps: …}`. `app.go`'s `showRoutinesMsg` arm constructs the routines model, calls `routinesModel.openCreateFormWithSteps(steps)` to skip the list and drop straight into the create form, and pre-populates one step per prompt. The user fills in the name and mode, then saves through the normal routines flow (see [routines.md](routines.md)). An empty session reports a no-op error rather than opening an empty form.
+
+## Limitations
+
+- **Backend-agnostic but content-limited.** Both backends expose canonical history through the same `Backend.ChatHistory` RPC, so the recorder works against OpenClaw and OpenAI-compat alike. The OpenClaw gateway, however, does not expose tool call payloads in its history view — only the user/assistant turns survive the round-trip — so even if we wanted to surface tool I/O in the transcript today we couldn't pull it from the canonical fetch. Tool-card capture would need a separate event-side tee.
+- **No live tail capture.** Streaming deltas are intentionally excluded. A recording started mid-turn captures the assistant reply only after `final` lands and the refresh fires.
+- **History limit.** `historyLimit` (a chat-view preference, see [chat-ux.md](chat-ux.md#history-depth)) caps the canonical fetch. For very long sessions, older turns may have already fallen off the window when `/record on` runs — the recorder only sees what `fetchHistory` returns. `/export` has the same constraint.
+- **Filename collisions.** Two recordings started inside the same UTC second to the same session truncate the first. Practically impossible for `/record`, plausible only for tight scripted `/export` loops.
+
+## Tests
+
+`internal/tui/recorder_test.go` covers the header layout, dedup across refreshes, role/streaming filters, raw-vs-rendered fidelity, the export round-trip, routine extraction, path sanitisation, filename shape, and signature distinctness. The tests use `config.SetDataDir(t.TempDir())` so they don't touch the user's real `~/.lucinate`.

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -55,7 +55,10 @@ Resolved through `config.DataDir()`:
 | `Save(r)` | `MkdirAll(0o700)` + atomic `WriteFile`/`Rename` of `STEPS.md` |
 | `Delete(name)` | `os.RemoveAll(<dir>/<name>)` |
 
-`validName` rejects empty, `.`, `..`, leading-dot, and any name containing `/`, `\\`, or NUL — the same conservative shape used elsewhere for filesystem-derived identifiers.
+Two name predicates live in `internal/routines/`:
+
+- `validName` (path safety) rejects empty, `.`, `..`, leading-dot, and any name containing `/`, `\\`, or NUL. `Load` and `Delete` use this predicate so existing on-disk directories — including any non-kebab names left over from earlier versions — keep working.
+- `IsValidKebab` (form rule) tightens to lowercase ASCII letters, digits, and hyphens; no leading or trailing hyphen, no consecutive hyphens. `Save` enforces it, so any new save or rename lands on disk with a typeable, lowercase identifier. The companion `ToKebab(s string) string` produces a best-effort kebab version of arbitrary input — used by the form's submit error to suggest a fix when the user typed `My Routine!` or similar.
 
 ## Controller
 
@@ -188,6 +191,12 @@ Pressing `d` on the list view opens the form pre-populated from the highlighted 
 - Otherwise: `"Copy of " + name`, walking `(2)`, `(3)`, … to find the first slot that doesn't collide with an existing routine. Routines are name-keyed (the directory under `~/.lucinate/routines/<name>/` is the identity), so collision avoidance is required — unlike cron jobs which have a separate ID.
 
 `Frontmatter.Name` is set to the duplicated name so the `STEPS.md` metadata stays in sync with the directory identity. `Frontmatter.Log` is copied verbatim — if it's a relative path the user can change it in the form before saving so the duplicate doesn't share the original's log file.
+
+### Form layout
+
+The form's middle section (header inputs + step textareas) renders inside a scrollable `viewport.Model`; the title and the footer (error line + help line) stay pinned. `viewForm` records the line index where each focusable field starts as it builds the body content (`fieldLineStarts`), and `ensureFocusVisible` adjusts the viewport's `YOffset` so the focused field is fully on-screen — scrolling down when the user tabs past the bottom of the visible window, scrolling up when they shift-tab back. Without this, a routine with many steps used to push the help line off the terminal entirely.
+
+Step textareas are sized at a fixed 4 lines each rather than auto-fitting the available height: the previous "divide remaining space across all steps" heuristic squeezed every textarea down to a 1-line stub once step count grew, and the user couldn't see the content of any step. The viewport handles overflow now, so a fixed per-step size is friendlier to type into.
 
 ### Submission
 

--- a/internal/routines/naming.go
+++ b/internal/routines/naming.go
@@ -1,0 +1,71 @@
+package routines
+
+import "strings"
+
+// IsValidKebab reports whether name is a kebab-case routine identifier:
+// non-empty, lowercase ASCII letters / digits / hyphens, no leading or
+// trailing hyphen, no consecutive hyphens. Tightening the form-side
+// rule keeps the on-disk routine directory readable and predictable
+// for users typing /routine <name> in chat.
+//
+// Existing non-kebab directories still load through Load/Delete (which
+// only enforce path safety via validName) so nothing on disk breaks;
+// Save rejects them, so any edit will force a rename to a kebab name.
+func IsValidKebab(name string) bool {
+	if name == "" {
+		return false
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' {
+		return false
+	}
+	prevHyphen := false
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			prevHyphen = false
+		case c >= '0' && c <= '9':
+			prevHyphen = false
+		case c == '-':
+			if prevHyphen {
+				return false
+			}
+			prevHyphen = true
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ToKebab returns a best-effort kebab-case version of s: lowercased,
+// non-alphanumeric runs collapsed to a single hyphen, leading/trailing
+// hyphens trimmed. Useful for turning a user's typo ("My Routine!")
+// into a suggested fix ("my-routine") in form error messages.
+//
+// Returns "" when no usable characters remain (e.g. all punctuation).
+func ToKebab(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevHyphen := true // drop leading hyphens
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			prevHyphen = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			prevHyphen = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if prevHyphen {
+				continue
+			}
+			b.WriteByte('-')
+			prevHyphen = true
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}

--- a/internal/routines/naming_test.go
+++ b/internal/routines/naming_test.go
@@ -1,0 +1,76 @@
+package routines
+
+import "testing"
+
+func TestIsValidKebab(t *testing.T) {
+	good := []string{
+		"a",
+		"foo",
+		"foo-bar",
+		"deploy-staging-2",
+		"x-y-z",
+		"step1",
+		"123-abc",
+	}
+	bad := map[string]string{
+		"":            "empty",
+		"-foo":        "leading hyphen",
+		"foo-":        "trailing hyphen",
+		"foo--bar":    "consecutive hyphens",
+		"Foo":         "uppercase",
+		"foo_bar":     "underscore",
+		"foo bar":     "space",
+		"foo.bar":     "dot",
+		"foo/bar":     "slash",
+		"FOO-BAR":     "uppercase",
+		"-":           "single hyphen",
+		"--":          "double hyphen",
+		"foo.bar.baz": "dots",
+	}
+	for _, in := range good {
+		if !IsValidKebab(in) {
+			t.Errorf("IsValidKebab(%q) = false, want true", in)
+		}
+	}
+	for in, why := range bad {
+		if IsValidKebab(in) {
+			t.Errorf("IsValidKebab(%q) = true, want false (%s)", in, why)
+		}
+	}
+}
+
+func TestToKebab(t *testing.T) {
+	cases := map[string]string{
+		"":              "",
+		"foo":           "foo",
+		"Foo":           "foo",
+		"FOO BAR":       "foo-bar",
+		"My Routine!":   "my-routine",
+		"  spaced  ":    "spaced",
+		"foo_bar":       "foo-bar",
+		"foo--bar":      "foo-bar",
+		"--foo--":       "foo",
+		"foo.bar.baz":   "foo-bar-baz",
+		"!!!":           "",
+		"deploy/stage1": "deploy-stage1",
+		"a b c d":       "a-b-c-d",
+	}
+	for in, want := range cases {
+		if got := ToKebab(in); got != want {
+			t.Errorf("ToKebab(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestToKebab_RoundTripsThroughIsValidKebab(t *testing.T) {
+	inputs := []string{"My Routine", "FOO BAR", "deploy/stage1", "a b c"}
+	for _, in := range inputs {
+		got := ToKebab(in)
+		if got == "" {
+			continue
+		}
+		if !IsValidKebab(got) {
+			t.Errorf("ToKebab(%q) = %q which fails IsValidKebab", in, got)
+		}
+	}
+}

--- a/internal/routines/store.go
+++ b/internal/routines/store.go
@@ -78,9 +78,15 @@ func Load(name string) (Routine, error) {
 
 // Save writes the routine to disk. The directory <routines>/<name>/ is
 // created when missing. Existing STEPS.md is overwritten atomically.
+//
+// Save enforces kebab-case (see IsValidKebab) so any new or renamed
+// routine lands on disk with a typeable, lowercase identifier. Load
+// and Delete remain lenient — non-kebab directories left over from
+// earlier versions continue to work until they're edited, at which
+// point the rename in submitForm forces them onto a kebab name.
 func Save(r Routine) error {
-	if !validName(r.Name) {
-		return fmt.Errorf("invalid routine name %q", r.Name)
+	if !IsValidKebab(r.Name) {
+		return fmt.Errorf("invalid routine name %q: use kebab-case (lowercase letters, digits, hyphens)", r.Name)
 	}
 	root, err := Dir()
 	if err != nil {

--- a/internal/routines/store_test.go
+++ b/internal/routines/store_test.go
@@ -65,7 +65,15 @@ func TestStore_RoundTrip(t *testing.T) {
 }
 
 func TestStore_RejectsInvalidName(t *testing.T) {
-	cases := []string{"", ".", "..", ".hidden", "with/slash", "with\\back"}
+	// Path-unsafe and non-kebab names are both rejected by Save.
+	// validName (path safety) is unchanged; IsValidKebab adds the
+	// stricter form rule on top, so any name that fails either gate
+	// is rejected here.
+	cases := []string{
+		"", ".", "..", ".hidden", "with/slash", "with\\back",
+		"Mixed-Case", "with space", "snake_case", "trailing-",
+		"-leading", "double--hyphen",
+	}
 	for _, name := range cases {
 		if err := Save(Routine{Name: name, Steps: []string{"x"}}); err == nil {
 			t.Errorf("Save(%q) = nil, want error", name)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -595,6 +595,12 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.routinesModel = newRoutinesModel(m.hideActionHints, m.disableExitKeys)
 		m.routinesModel.setSize(m.width, m.height)
 		m.state = viewRoutines
+		if len(msg.prefillSteps) > 0 {
+			// Skip the routines list and drop straight into the
+			// create form. The list still loads in the background so
+			// the user can cancel back to a populated picker.
+			m.routinesModel.openCreateFormWithSteps(msg.prefillSteps)
+		}
 		return m, m.routinesModel.Init()
 
 	case goBackFromRoutinesMsg:
@@ -654,6 +660,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		if agentID == "" {
 			agentID = m.sessionsModel.agentID
 		}
+		_, _ = m.chatModel.stopRecording()
 		m.chatModel = newChatModel(m.backend, msg.sessionKey, agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), "", m.brightCursor)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
@@ -664,6 +671,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		// rebuild the transcript from the run log instead — that's the
 		// same data the run-history previews on the cron-detail page
 		// already use.
+		_, _ = m.chatModel.stopRecording()
 		m.chatModel = newChatModel(m.backend, "", msg.job.AgentID, msg.agentName, "", m.prefs, true, connectionLabel(m.activeConn), "", m.brightCursor)
 		m.chatModel.setSize(m.width, m.height)
 		m.chatModel.messages = buildCronTranscriptMessages(cronPayloadText(msg.job), msg.runs, m.chatModel.renderer)
@@ -683,6 +691,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 			m.sessionsModel.loading = false
 			return m, nil
 		}
+		_, _ = m.chatModel.stopRecording()
 		m.chatModel = newChatModel(m.backend, msg.sessionKey, m.sessionsModel.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), "", m.brightCursor)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat
@@ -718,6 +727,7 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		// for the agent they just opened.
 		m.selectModel.selecting = false
 		m.selectModel.selectingName = ""
+		_, _ = m.chatModel.stopRecording()
 		m.chatModel = newChatModel(m.backend, msg.sessionKey, msg.agentID, msg.agentName, msg.modelID, m.prefs, m.hideInput, connectionLabel(m.activeConn), initialMsg, m.brightCursor)
 		m.chatModel.setSize(m.width, m.height)
 		m.state = viewChat

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -188,6 +188,7 @@ type chatModel struct {
 	terminalFocused    bool   // tracks tea.FocusMsg/BlurMsg so the completion bell only rings when the user is looking elsewhere
 	updateLatest       string // populated by AppModel when the startup check finds a newer release; rendered as a header badge
 	activeRoutine      *activeRoutine
+	recorder           *transcriptRecorder // non-nil while /record on is active; closed and cleared on /record off, session switch, or quit
 }
 
 func spinnerTickCmd() tea.Cmd {
@@ -309,6 +310,39 @@ func (m *chatModel) replacePendingSystem(replacement chatMessage) {
 		}
 	}
 	m.appendMessage(replacement)
+}
+
+// recordCanonical forwards a canonical-history slice to the active
+// recorder, if one is attached. No-op when /record is off. Errors
+// from the underlying file write are surfaced as a one-shot system
+// note and the recorder is closed — repeated failures on the same
+// file would just spam the chat view.
+func (m *chatModel) recordCanonical(msgs []chatMessage) {
+	if m.recorder == nil || len(msgs) == 0 {
+		return
+	}
+	if err := m.recorder.writeNew(msgs); err != nil {
+		path := m.recorder.path
+		_ = m.recorder.close()
+		m.recorder = nil
+		m.appendMessage(chatMessage{
+			role:   "system",
+			errMsg: fmt.Sprintf("Recording stopped: write to %s failed: %v", path, err),
+		})
+	}
+}
+
+// stopRecording closes the active recorder if one is attached. Used
+// by /record off and by the chat-model teardown path so a recording
+// doesn't outlive its session.
+func (m *chatModel) stopRecording() (path string, stopped bool) {
+	if m.recorder == nil {
+		return "", false
+	}
+	path = m.recorder.path
+	_ = m.recorder.close()
+	m.recorder = nil
+	return path, true
 }
 
 // ensureSpinnerTicking starts the spinner animation if one is not already scheduled.
@@ -558,6 +592,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			// history-side and replaces them cleanly.
 			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
 			m.messages = append(hist, m.messages...)
+			m.recordCanonical(msg.messages)
 		}
 		m.updateViewport()
 		// If a caller pre-seeded pendingMessages (e.g. `lucinate chat`
@@ -688,6 +723,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			// while a tool card is in flight — scenarios where the old
 			// wholesale-replace would have wiped live state.
 			m.mergeHistoryRefresh(msg.messages, msg.boundary)
+			m.recordCanonical(msg.messages)
 			m.updateViewport()
 		}
 		// History refresh fires after each completed turn — pull a

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -48,7 +50,7 @@ type pendingNavConfirm struct {
 // hint surfaces the picker first, "/model" before "/models" likewise.
 // Tab now extends to the longest common prefix and the completion menu
 // shows every candidate, so the curated order no longer rules Tab.
-var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/help", "/model", "/models", "/quit", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/export", "/help", "/model", "/models", "/quit", "/record", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -290,7 +292,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		})
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -368,6 +370,18 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	// /think with optional level argument.
 	if command == "/think" || strings.HasPrefix(command, "/think ") {
 		return m.handleThinkCommand(text)
+	}
+
+	// /record toggles transcript capture for the current session. Bare
+	// /record reports state; /record on|off flips it.
+	if command == "/record" || strings.HasPrefix(command, "/record ") {
+		return m.handleRecordCommand(text)
+	}
+
+	// /export dumps the current canonical history to a transcript file
+	// (or to a routine, with `/export routine`).
+	if command == "/export" || strings.HasPrefix(command, "/export ") {
+		return m.handleExportCommand(text)
 	}
 
 	// Slash-prefixed input that isn't a built-in: if the first token names a
@@ -784,4 +798,152 @@ func (m *chatModel) handleThinkCommand(text string) (bool, tea.Cmd) {
 		err := thinking.SessionPatchThinking(context.Background(), sessionKey, level)
 		return thinkingChangedMsg{level: level, err: err}
 	}
+}
+
+// handleRecordCommand handles `/record`, `/record on`, `/record off`.
+// Bare /record reports current state. /record on opens a transcript
+// file under <dataDir>/transcripts and seeds it with whatever
+// canonical history is already in m.messages, so the file is
+// self-contained even if recording was started mid-session.
+func (m *chatModel) handleRecordCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	arg := ""
+	if len(parts) == 2 {
+		arg = strings.ToLower(strings.TrimSpace(parts[1]))
+	}
+	switch arg {
+	case "":
+		if m.recorder == nil {
+			m.appendMessage(chatMessage{role: "system", content: "Recording is off. Use /record on to start capturing this session."})
+		} else {
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Recording to %s", m.recorder.path)})
+		}
+		m.updateViewport()
+		return true, nil
+	case "on":
+		if m.recorder != nil {
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Already recording to %s", m.recorder.path)})
+			m.updateViewport()
+			return true, nil
+		}
+		rec, err := newTranscriptRecorder(m.sessionKey, m.agentName, m.modelID, m.connName, time.Now())
+		if err != nil {
+			m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("Could not start recording: %v", err)})
+			m.updateViewport()
+			return true, nil
+		}
+		m.recorder = rec
+		m.recordCanonical(m.messages)
+		// recordCanonical clears m.recorder on a write failure; check
+		// before reporting success so the user isn't told a recording
+		// is active when the seeding write already broke it.
+		if m.recorder == nil {
+			m.updateViewport()
+			return true, nil
+		}
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Recording to %s", m.recorder.path)})
+		m.updateViewport()
+		return true, nil
+	case "off":
+		path, stopped := m.stopRecording()
+		if !stopped {
+			m.appendMessage(chatMessage{role: "system", content: "Recording is already off."})
+		} else {
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Recording stopped. Transcript: %s", path)})
+		}
+		m.updateViewport()
+		return true, nil
+	default:
+		m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("unknown /record argument %q — use /record on, /record off, or /record", arg)})
+		m.updateViewport()
+		return true, nil
+	}
+}
+
+// handleExportCommand handles `/export`, `/export all`, `/export routine`.
+// `all` (the default) writes the current canonical history to a
+// transcript file. `routine` extracts user prompts and opens the
+// routine form prepopulated.
+func (m *chatModel) handleExportCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	arg := "all"
+	if len(parts) == 2 {
+		if got := strings.ToLower(strings.TrimSpace(parts[1])); got != "" {
+			arg = got
+		}
+	}
+	switch arg {
+	case "all":
+		path, err := exportTranscript(m.messages, m.sessionKey, m.agentName, m.modelID, m.connName, time.Now())
+		if err != nil {
+			m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("Export failed: %v", err)})
+			m.updateViewport()
+			return true, nil
+		}
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Exported transcript: %s", path)})
+		m.updateViewport()
+		return true, nil
+	case "routine":
+		if _, ok := m.backend.(backend.CronBackend); !ok {
+			// Routines are surfaced through the manager regardless of
+			// backend, but the routine machinery and the /routines
+			// nav assume an OpenClaw-style backend. The form opens
+			// fine without a CronBackend; the gate exists in case a
+			// future backend wants to opt out.
+			_ = ok
+		}
+		steps := extractUserPromptsForRoutine(m.messages)
+		if len(steps) == 0 {
+			m.appendMessage(chatMessage{role: "system", errMsg: "No user prompts in this session yet — nothing to export as a routine."})
+			m.updateViewport()
+			return true, nil
+		}
+		return true, m.gateNavigation("Exporting to routine", func() tea.Msg {
+			return showRoutinesMsg{prefillSteps: steps}
+		})
+	default:
+		m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("unknown /export argument %q — use /export, /export all, or /export routine", arg)})
+		m.updateViewport()
+		return true, nil
+	}
+}
+
+// exportTranscript writes the canonical user/assistant rows in msgs
+// to a freshly-created transcript file and returns its path. Any
+// non-canonical rows (separators, system, tool, streaming
+// placeholders) are filtered out by writeTranscriptEntry's role
+// guard, so callers can pass m.messages directly.
+func exportTranscript(msgs []chatMessage, sessionKey, agentName, modelID, connName string, now time.Time) (string, error) {
+	dir, err := transcriptsDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, transcriptFilename(sessionKey, agentName, "export", now))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if err := writeTranscriptHeader(f, sessionKey, agentName, modelID, connName, "export", now); err != nil {
+		return "", err
+	}
+	for _, msg := range msgs {
+		if !isRecordableRole(msg.role) {
+			continue
+		}
+		if msg.streaming {
+			continue
+		}
+		text := messageSourceText(msg)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		if err := writeTranscriptEntry(f, msg.role, msg.timestampMs, text, msg.thinking); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -186,7 +186,15 @@ type startRoutineMsg struct {
 }
 
 // showRoutinesMsg signals the AppModel to switch to the routines manager.
-type showRoutinesMsg struct{}
+//
+// prefillSteps, when non-empty, opens the manager directly into the
+// new-routine form with one step per element, name + mode + log left
+// blank for the user to fill in. Used by `/export routine` so the
+// session's user prompts become a saveable routine without leaving
+// the TUI.
+type showRoutinesMsg struct {
+	prefillSteps []string
+}
 
 // goBackFromRoutinesMsg signals the AppModel to return to the chat view
 // from the routines manager.

--- a/internal/tui/recorder.go
+++ b/internal/tui/recorder.go
@@ -1,0 +1,245 @@
+package tui
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// transcriptRecorder appends canonical conversation messages to a
+// markdown file. Lives on chatModel for the duration of a /record on
+// session; closed on /record off or when the chat model is torn down
+// (session switch, view change, quit).
+//
+// The recorder consumes the same []chatMessage slices the chat view
+// receives from fetchHistory — i.e. only canonical user/assistant rows
+// with text content, never streaming deltas, tool cards, or system
+// notes. Each refresh delivers the entire history (capped by
+// historyLimit), so seenSig dedups against rows already written.
+type transcriptRecorder struct {
+	w       io.WriteCloser
+	path    string
+	seenSig map[string]bool
+}
+
+// newTranscriptRecorder opens the target file (creating parent dirs)
+// and writes the markdown header. Returns the recorder + the resolved
+// path so the caller can surface it to the user.
+func newTranscriptRecorder(sessionKey, agentName, modelID, connName string, now time.Time) (*transcriptRecorder, error) {
+	dir, err := transcriptsDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, transcriptFilename(sessionKey, agentName, "record", now))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	r := &transcriptRecorder{w: f, path: path, seenSig: make(map[string]bool)}
+	if err := writeTranscriptHeader(f, sessionKey, agentName, modelID, connName, "record", now); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return r, nil
+}
+
+// writeNew appends every message in msgs whose signature has not been
+// recorded yet. Errors are returned so the chat view can surface them
+// once; subsequent failures on the same recorder are silently dropped
+// (the file is broken, recording is effectively over).
+func (r *transcriptRecorder) writeNew(msgs []chatMessage) error {
+	if r == nil || r.w == nil {
+		return nil
+	}
+	for _, msg := range msgs {
+		if !isRecordableRole(msg.role) {
+			continue
+		}
+		text := messageSourceText(msg)
+		if text == "" {
+			continue
+		}
+		sig := messageSignature(msg.role, msg.timestampMs, text)
+		if r.seenSig[sig] {
+			continue
+		}
+		r.seenSig[sig] = true
+		if err := writeTranscriptEntry(r.w, msg.role, msg.timestampMs, text, msg.thinking); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// close flushes and closes the underlying writer. Safe to call on a
+// nil recorder.
+func (r *transcriptRecorder) close() error {
+	if r == nil || r.w == nil {
+		return nil
+	}
+	err := r.w.Close()
+	r.w = nil
+	return err
+}
+
+// transcriptsDir returns the on-disk root for transcript files
+// (<dataDir>/transcripts).
+func transcriptsDir() (string, error) {
+	root, err := config.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "transcripts"), nil
+}
+
+// transcriptFilename builds a filesystem-safe filename for a transcript.
+// kind is "record" or "export" so the two flows are distinguishable on
+// disk; the timestamp resolves to the second.
+func transcriptFilename(sessionKey, agentName, kind string, now time.Time) string {
+	parts := []string{kind}
+	if a := sanitiseForPath(agentName); a != "" {
+		parts = append(parts, a)
+	}
+	if s := sanitiseForPath(sessionKey); s != "" {
+		parts = append(parts, s)
+	}
+	parts = append(parts, now.Format("20060102T150405"))
+	return strings.Join(parts, "-") + ".md"
+}
+
+// sanitiseForPath replaces filesystem-unsafe characters with '-' and
+// trims any leading/trailing separators. Empty input yields empty
+// output.
+func sanitiseForPath(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// writeTranscriptHeader emits the markdown front-matter for a
+// transcript file: title, key/value preamble, and a horizontal rule.
+func writeTranscriptHeader(w io.Writer, sessionKey, agentName, modelID, connName, kind string, now time.Time) error {
+	var sb strings.Builder
+	switch kind {
+	case "export":
+		sb.WriteString("# Lucinate transcript export\n\n")
+	default:
+		sb.WriteString("# Lucinate transcript\n\n")
+	}
+	if connName != "" {
+		fmt.Fprintf(&sb, "- connection: %s\n", connName)
+	}
+	if agentName != "" {
+		fmt.Fprintf(&sb, "- agent: %s\n", agentName)
+	}
+	if modelID != "" {
+		fmt.Fprintf(&sb, "- model: %s\n", modelID)
+	}
+	if sessionKey != "" {
+		fmt.Fprintf(&sb, "- session: %s\n", sessionKey)
+	}
+	fmt.Fprintf(&sb, "- %s: %s\n\n---\n\n", kind+"ed", now.Format(time.RFC3339))
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+// writeTranscriptEntry emits one role-prefixed message block. Thinking
+// content is rendered as a fenced thought block above the visible
+// reply so the file is self-contained.
+func writeTranscriptEntry(w io.Writer, role string, timestampMs int64, content, thinking string) error {
+	heading := strings.ToUpper(role[:1]) + role[1:]
+	stamp := ""
+	if timestampMs > 0 {
+		stamp = " · " + time.UnixMilli(timestampMs).Format(time.RFC3339)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "## %s%s\n\n", heading, stamp)
+	if t := strings.TrimSpace(thinking); t != "" {
+		sb.WriteString("> _thinking_\n")
+		for _, line := range strings.Split(t, "\n") {
+			sb.WriteString("> ")
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(strings.TrimRight(content, "\n"))
+	sb.WriteString("\n\n")
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+// isRecordableRole reports whether a chatMessage role belongs in the
+// transcript. System rows, separators, tool cards, and streaming
+// placeholders are excluded — the canonical history fetch only
+// surfaces user/assistant anyway, but this guard keeps the intent
+// explicit and protects against future changes upstream.
+func isRecordableRole(role string) bool {
+	return role == "user" || role == "assistant"
+}
+
+// messageSourceText returns the markdown source for a message,
+// preferring raw (the pre-glamour text) over content (the rendered
+// ANSI form). fetchHistory sets raw on assistant messages it ran
+// through the renderer; user messages and unrendered assistant
+// messages fall back to content.
+func messageSourceText(msg chatMessage) string {
+	if msg.rendered && msg.raw != "" {
+		return msg.raw
+	}
+	return msg.content
+}
+
+// messageSignature is the dedup key for the recorder. Combines role
+// (so a user/assistant collision on identical content is impossible),
+// timestampMs (when the gateway provides one — disambiguates a
+// repeated user message), and an FNV-64 hash of the source text
+// (cheap, collision-resistant enough for this purpose).
+func messageSignature(role string, timestampMs int64, text string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(text))
+	return fmt.Sprintf("%s|%d|%016x", role, timestampMs, h.Sum64())
+}
+
+// extractUserPromptsForRoutine walks msgs in order and returns the
+// non-empty user-message texts as routine step candidates. Source
+// text is preferred (so glamour rendering doesn't bleed ANSI into
+// step bodies); whitespace is trimmed per step.
+func extractUserPromptsForRoutine(msgs []chatMessage) []string {
+	var out []string
+	for _, msg := range msgs {
+		if msg.role != "user" {
+			continue
+		}
+		text := strings.TrimSpace(messageSourceText(msg))
+		if text == "" {
+			continue
+		}
+		out = append(out, text)
+	}
+	return out
+}

--- a/internal/tui/recorder_test.go
+++ b/internal/tui/recorder_test.go
@@ -1,0 +1,284 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// withTempDataDir points config.DataDir at a fresh temp directory for
+// the duration of the test, restoring the previous override on
+// cleanup. Using SetDataDir keeps the helper agnostic to whether the
+// surrounding test set LUCINATE_DATA_DIR explicitly.
+func withTempDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	config.SetDataDir(dir)
+	t.Cleanup(func() { config.SetDataDir("") })
+	return dir
+}
+
+func TestNewTranscriptRecorder_WritesHeader(t *testing.T) {
+	dir := withTempDataDir(t)
+	now := time.Date(2026, 5, 10, 14, 33, 21, 0, time.UTC)
+	rec, err := newTranscriptRecorder("main", "alice", "claude-opus-4-7", "local", now)
+	if err != nil {
+		t.Fatalf("newTranscriptRecorder: %v", err)
+	}
+	if !strings.HasPrefix(rec.path, filepath.Join(dir, "transcripts")) {
+		t.Errorf("path %q not under data dir %q", rec.path, dir)
+	}
+	if !strings.HasSuffix(rec.path, ".md") {
+		t.Errorf("expected .md suffix on %q", rec.path)
+	}
+	if err := rec.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	body, err := os.ReadFile(rec.path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{
+		"# Lucinate transcript",
+		"- agent: alice",
+		"- model: claude-opus-4-7",
+		"- session: main",
+		"- recorded:",
+		"---",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("transcript missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+func TestTranscriptRecorder_WriteNew_DeduplicatesAcrossRefreshes(t *testing.T) {
+	withTempDataDir(t)
+	now := time.Date(2026, 5, 10, 14, 33, 21, 0, time.UTC)
+	rec, err := newTranscriptRecorder("s", "a", "m", "c", now)
+	if err != nil {
+		t.Fatalf("newTranscriptRecorder: %v", err)
+	}
+	defer rec.close()
+
+	first := []chatMessage{
+		{role: "user", content: "hello", timestampMs: 1_000},
+		{role: "assistant", content: "hi", timestampMs: 1_500},
+	}
+	if err := rec.writeNew(first); err != nil {
+		t.Fatalf("writeNew first: %v", err)
+	}
+	// Second refresh resends the same two and adds one more.
+	second := []chatMessage{
+		{role: "user", content: "hello", timestampMs: 1_000},
+		{role: "assistant", content: "hi", timestampMs: 1_500},
+		{role: "user", content: "follow-up", timestampMs: 2_000},
+	}
+	if err := rec.writeNew(second); err != nil {
+		t.Fatalf("writeNew second: %v", err)
+	}
+	rec.close()
+
+	body, err := os.ReadFile(rec.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(body)
+	if c := strings.Count(got, "hello"); c != 1 {
+		t.Errorf("expected exactly one 'hello' in transcript, got %d\n%s", c, got)
+	}
+	if c := strings.Count(got, "follow-up"); c != 1 {
+		t.Errorf("expected one 'follow-up', got %d\n%s", c, got)
+	}
+	if c := strings.Count(got, "## User"); c != 2 {
+		t.Errorf("expected two user headings, got %d", c)
+	}
+	if c := strings.Count(got, "## Assistant"); c != 1 {
+		t.Errorf("expected one assistant heading, got %d", c)
+	}
+}
+
+func TestTranscriptRecorder_WriteNew_SkipsNonCanonicalRows(t *testing.T) {
+	withTempDataDir(t)
+	rec, err := newTranscriptRecorder("s", "a", "m", "c", time.Now())
+	if err != nil {
+		t.Fatalf("newTranscriptRecorder: %v", err)
+	}
+	defer rec.close()
+
+	msgs := []chatMessage{
+		{role: "system", content: "compacted"},
+		{role: "separator", timestampMs: 1},
+		{role: "tool", content: "tool stuff"},
+		{role: "user", content: ""}, // empty content
+		{role: "assistant", content: "kept", timestampMs: 5},
+	}
+	if err := rec.writeNew(msgs); err != nil {
+		t.Fatalf("writeNew: %v", err)
+	}
+	rec.close()
+
+	body, err := os.ReadFile(rec.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(body)
+	if strings.Contains(got, "compacted") {
+		t.Errorf("system rows must not be recorded:\n%s", got)
+	}
+	if strings.Contains(got, "tool stuff") {
+		t.Errorf("tool rows must not be recorded:\n%s", got)
+	}
+	if !strings.Contains(got, "kept") {
+		t.Errorf("expected assistant row to be recorded:\n%s", got)
+	}
+}
+
+func TestTranscriptRecorder_WriteNew_PrefersRawWhenRendered(t *testing.T) {
+	withTempDataDir(t)
+	rec, err := newTranscriptRecorder("s", "a", "m", "c", time.Now())
+	if err != nil {
+		t.Fatalf("newTranscriptRecorder: %v", err)
+	}
+	defer rec.close()
+
+	msgs := []chatMessage{{
+		role:        "assistant",
+		content:     "ANSI escapes here",
+		raw:         "**markdown** source",
+		rendered:    true,
+		timestampMs: 7,
+	}}
+	if err := rec.writeNew(msgs); err != nil {
+		t.Fatalf("writeNew: %v", err)
+	}
+	rec.close()
+
+	body, err := os.ReadFile(rec.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "**markdown** source") {
+		t.Errorf("expected raw markdown source in transcript:\n%s", got)
+	}
+	if strings.Contains(got, "ANSI escapes here") {
+		t.Errorf("rendered ANSI form leaked into transcript:\n%s", got)
+	}
+}
+
+func TestExportTranscript_WritesFullCanonicalSlice(t *testing.T) {
+	dir := withTempDataDir(t)
+	now := time.Date(2026, 5, 10, 14, 33, 21, 0, time.UTC)
+	msgs := []chatMessage{
+		{role: "user", content: "first", timestampMs: 1_000},
+		{role: "assistant", content: "reply", timestampMs: 1_500, thinking: "internal"},
+		{role: "system", content: "noise"}, // excluded
+		{role: "assistant", content: "still streaming", streaming: true},
+		{role: "user", content: "second", timestampMs: 2_500},
+	}
+	path, err := exportTranscript(msgs, "main", "alice", "claude-opus-4-7", "local", now)
+	if err != nil {
+		t.Fatalf("exportTranscript: %v", err)
+	}
+	if !strings.HasPrefix(path, filepath.Join(dir, "transcripts")) {
+		t.Errorf("path %q not under data dir", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "Lucinate transcript export") {
+		t.Errorf("expected export header in:\n%s", got)
+	}
+	for _, want := range []string{"first", "reply", "second", "internal"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "noise") {
+		t.Errorf("system row leaked into export:\n%s", got)
+	}
+	if strings.Contains(got, "still streaming") {
+		t.Errorf("streaming row leaked into export:\n%s", got)
+	}
+}
+
+func TestExtractUserPromptsForRoutine(t *testing.T) {
+	msgs := []chatMessage{
+		{role: "user", content: "first"},
+		{role: "assistant", content: "reply"},
+		{role: "user", content: "  spaced  "},
+		{role: "user", content: ""},
+		{role: "system", content: "ignored"},
+		{role: "user", content: "last", raw: "raw last", rendered: true},
+	}
+	got := extractUserPromptsForRoutine(msgs)
+	want := []string{"first", "spaced", "raw last"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d steps, got %d: %#v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("step %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSanitiseForPath(t *testing.T) {
+	cases := map[string]string{
+		"":              "",
+		"  ":            "",
+		"main":          "main",
+		"hello world":   "hello-world",
+		"a/b\\c":        "a-b-c",
+		"with:colons?":  "with-colons",
+		"---a---":       "a",
+		"abc.123":       "abc-123",
+		"alice@example": "alice-example",
+	}
+	for in, want := range cases {
+		if got := sanitiseForPath(in); got != want {
+			t.Errorf("sanitiseForPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTranscriptFilename_StableShape(t *testing.T) {
+	now := time.Date(2026, 5, 10, 14, 33, 21, 0, time.UTC)
+	got := transcriptFilename("main session", "Agent Name", "record", now)
+	if !strings.HasPrefix(got, "record-") {
+		t.Errorf("filename %q missing record- prefix", got)
+	}
+	if !strings.Contains(got, "Agent-Name") {
+		t.Errorf("filename %q missing sanitised agent name", got)
+	}
+	if !strings.Contains(got, "main-session") {
+		t.Errorf("filename %q missing sanitised session", got)
+	}
+	if !strings.HasSuffix(got, "-20260510T143321.md") {
+		t.Errorf("filename %q missing timestamp/extension", got)
+	}
+}
+
+func TestMessageSignature_DistinguishesRoleAndTimestamp(t *testing.T) {
+	a := messageSignature("user", 1_000, "hi")
+	b := messageSignature("assistant", 1_000, "hi")
+	c := messageSignature("user", 2_000, "hi")
+	d := messageSignature("user", 1_000, "hi")
+	if a == b {
+		t.Error("role must affect signature")
+	}
+	if a == c {
+		t.Error("timestamp must affect signature")
+	}
+	if a != d {
+		t.Error("identical inputs must hash equal")
+	}
+}

--- a/internal/tui/routines.go
+++ b/internal/tui/routines.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -116,6 +117,24 @@ type routineForm struct {
 	saving  bool
 	err     error
 
+	// body wraps the scrollable middle of the form (header inputs +
+	// step textareas) so a routine with many steps doesn't push the
+	// help line off the bottom of the terminal. The title line above
+	// and the footer (error + help) below the viewport stay pinned;
+	// only the body scrolls.
+	body viewport.Model
+
+	// fieldLineStarts holds the starting line index in the body
+	// content for each focusable field, in focus order (name, mode,
+	// log, step0, step1, …). Recomputed every render so
+	// ensureFocusVisible can scroll the focused field into view
+	// regardless of how many steps precede it.
+	fieldLineStarts []int
+
+	// bodyLines is the total line count of the most recently rendered
+	// body content; used to bound viewport scroll calculations.
+	bodyLines int
+
 	// pendingStepDelete is set when alt+delete is pressed on a step;
 	// the form view replaces help with a y/n prompt until resolved.
 	pendingStepDelete bool
@@ -176,36 +195,82 @@ func (m *routinesModel) setSize(w, h int) {
 	}
 }
 
-// sizeFormBody adjusts the visible height of every step textarea to fit
-// the available terminal vertical space. Header textinputs are always
-// single-line; the remaining height is divided across the step
-// textareas with a per-step floor of 3 lines so each step stays usable
-// even when the form is long.
+// sizeFormBody sizes every step textarea and the body viewport that
+// scrolls them. With the viewport in place we no longer try to make
+// every textarea visible at once (long forms would force them down to
+// 1-line stubs); instead each step gets a fixed 4-line textarea and
+// the viewport handles overflow by scrolling. The visible viewport
+// height is whatever the terminal leaves after the title + footer,
+// floored at 5 lines so at least one step is always at least
+// partially visible.
 func (m *routinesModel) sizeFormBody() {
-	if len(m.form.steps) == 0 {
-		return
-	}
-	const perStepFloor = 3
-	const reservedChrome = 14 // header + name/mode/log labels+inputs + help
-	available := m.height - reservedChrome
-	if available < perStepFloor*len(m.form.steps) {
-		available = perStepFloor * len(m.form.steps)
-	}
-	per := available / len(m.form.steps)
-	if per < perStepFloor {
-		per = perStepFloor
-	}
-	if per > 8 {
-		per = 8 // cap so a single tall textarea doesn't eat the form
-	}
+	const perStepHeight = 4
+	const titleLines = 2 // header line + trailing blank
+	const footerLines = 2 // help line + trailing margin (error squeezes in via shrink)
+	const minBodyHeight = 5
+
 	width := m.width - 4
 	if width < 20 {
 		width = 20
 	}
 	for i := range m.form.steps {
-		m.form.steps[i].SetHeight(per)
+		m.form.steps[i].SetHeight(perStepHeight)
 		m.form.steps[i].SetWidth(width)
 	}
+
+	bodyH := m.height - titleLines - footerLines
+	if bodyH < minBodyHeight {
+		bodyH = minBodyHeight
+	}
+	bodyW := m.width
+	if bodyW < 1 {
+		bodyW = 1
+	}
+	m.form.body.SetWidth(bodyW)
+	m.form.body.SetHeight(bodyH)
+}
+
+// ensureFocusVisible nudges the body viewport's YOffset so the
+// currently focused field's content is fully on-screen. With long
+// step lists this is what stops the focused textarea from being
+// invisible while still receiving keystrokes — the previous form
+// rendered every textarea inline and let the bottom of the document
+// scroll off the terminal, taking the help line with it.
+func (f *routineForm) ensureFocusVisible() {
+	if len(f.fieldLineStarts) == 0 || f.bodyLines == 0 {
+		return
+	}
+	idx := f.focused
+	if idx < 0 || idx >= len(f.fieldLineStarts) {
+		return
+	}
+	start := f.fieldLineStarts[idx]
+	end := f.bodyLines - 1
+	if idx+1 < len(f.fieldLineStarts) {
+		end = f.fieldLineStarts[idx+1] - 1
+	}
+	height := f.body.Height()
+	if height <= 0 {
+		return
+	}
+	offset := f.body.YOffset()
+	switch {
+	case start < offset:
+		offset = start
+	case end >= offset+height:
+		offset = end - height + 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	maxOffset := f.bodyLines - height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	f.body.SetYOffset(offset)
 }
 
 // routinesListLoadedMsg delivers the routines slice from disk.
@@ -509,6 +574,16 @@ func (m routinesModel) submitForm() (routinesModel, tea.Cmd) {
 		m.form.err = fmt.Errorf("name is required")
 		return m, nil
 	}
+	if !routines.IsValidKebab(name) {
+		// Suggest a kebab-form of what the user typed when one is
+		// recoverable, so the fix is a single keypress away.
+		if suggestion := routines.ToKebab(name); suggestion != "" && suggestion != name {
+			m.form.err = fmt.Errorf("name must be kebab-case (lowercase letters, digits, hyphens) — try %q", suggestion)
+		} else {
+			m.form.err = fmt.Errorf("name must be kebab-case (lowercase letters, digits, hyphens)")
+		}
+		return m, nil
+	}
 	mode := strings.ToLower(strings.TrimSpace(m.form.mFm.Value()))
 	if mode != "" && mode != string(routines.ModeAuto) && mode != string(routines.ModeManual) {
 		m.form.err = fmt.Errorf("mode must be 'auto' or 'manual'")
@@ -625,7 +700,7 @@ func duplicateRoutineName(original string, existing []routines.Routine) string {
 
 func newRoutineForm(editingID string, existing routines.Routine) routineForm {
 	name := textinput.New()
-	name.Placeholder = "routine-name"
+	name.Placeholder = "kebab-case-name"
 	name.SetValue(existing.Name)
 	name.Focus()
 
@@ -659,6 +734,7 @@ func newRoutineForm(editingID string, existing routines.Routine) routineForm {
 		log:       log,
 		steps:     steps,
 		focused:   fieldName,
+		body:      viewport.New(),
 	}
 }
 
@@ -883,49 +959,78 @@ func (m routinesModel) viewDetail() string {
 }
 
 func (m routinesModel) viewForm() string {
-	var b strings.Builder
 	title := " Routines · New"
 	if m.form.mode == "edit" {
 		title = " Routines · Edit " + m.form.editingID
 	}
-	b.WriteString(headerStyle.Width(m.width).Render(title))
-	b.WriteString("\n\n")
+	titleLine := headerStyle.Width(m.width).Render(title)
 
-	row := func(label string, field string) {
+	// Build body content + per-field line starts. lineCount counts
+	// the number of '\n' separators written so far; the next field's
+	// content starts at that index because line indices are 0-based
+	// and each field's section ends with a blank line.
+	var b strings.Builder
+	starts := make([]int, 0, fieldStepStart+len(m.form.steps))
+	lineCount := 0
+	writeSection := func(label, body string) {
+		starts = append(starts, lineCount)
 		b.WriteString(lipgloss.NewStyle().Bold(true).Render(label))
 		b.WriteString("\n")
-		b.WriteString(field)
+		lineCount++
+		b.WriteString(body)
 		b.WriteString("\n\n")
+		lineCount += strings.Count(body, "\n") + 2
 	}
-	row("Name", m.form.name.View())
-	row("Mode (auto|manual)", m.form.mFm.View())
-	row("Log path (optional)", m.form.log.View())
-
+	writeSection("Name (kebab-case)", m.form.name.View())
+	writeSection("Mode (auto|manual)", m.form.mFm.View())
+	writeSection("Log path (optional)", m.form.log.View())
 	for i, ta := range m.form.steps {
 		marker := "  "
 		if m.form.stepIndex() == i {
 			marker = "▶ "
 		}
 		label := lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%sStep %d", marker, i+1))
+		view := ta.View()
+		starts = append(starts, lineCount)
 		b.WriteString(label)
 		b.WriteString("\n")
-		b.WriteString(ta.View())
+		lineCount++
+		b.WriteString(view)
 		b.WriteString("\n\n")
+		lineCount += strings.Count(view, "\n") + 2
 	}
+	bodyContent := b.String()
 
+	// Stash line-start metadata on the form so ensureFocusVisible
+	// (called from refocus / step CRUD) can scroll the focused field
+	// into view on the next render. Update the viewport content here
+	// rather than in Update so the layout reflects the latest field
+	// values without an explicit refresh hop.
+	m.form.fieldLineStarts = starts
+	m.form.bodyLines = lineCount
+	m.form.body.SetContent(bodyContent)
+	m.form.ensureFocusVisible()
+
+	// Footer: error (when set) + either a pending-delete prompt or
+	// the help line. Help is always pinned so the user can always see
+	// how to operate the form, even with dozens of steps.
+	var footer strings.Builder
 	if m.form.err != nil {
-		b.WriteString(errorStyle.Render(m.form.err.Error()))
-		b.WriteString("\n\n")
+		footer.WriteString(errorStyle.Render(m.form.err.Error()))
+		footer.WriteString("\n")
 	}
 	if m.form.pendingStepDelete {
 		prompt := fmt.Sprintf("Delete step %d? (y/n)", m.form.pendingDeleteIdx+1)
-		b.WriteString(errorStyle.Render(prompt))
-		return b.String()
+		footer.WriteString(errorStyle.Render(prompt))
+	} else if !m.hideHints {
+		footer.WriteString(helpStyle.Render(" ctrl+s: save · alt+↑/↓: insert step · alt+delete: remove step · tab: next field · esc: cancel"))
 	}
-	if !m.hideHints {
-		b.WriteString(helpStyle.Render(" ctrl+s: save · alt+↑/↓: insert step · alt+delete: remove step · tab: next field · esc: cancel"))
+
+	parts := []string{titleLine, m.form.body.View()}
+	if footer.Len() > 0 {
+		parts = append(parts, footer.String())
 	}
-	return b.String()
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
 func (m routinesModel) viewConfirmDelete() string {

--- a/internal/tui/routines.go
+++ b/internal/tui/routines.go
@@ -155,6 +155,16 @@ func newRoutinesModel(hideHints bool, disableExitKeys bool) routinesModel {
 	}
 }
 
+// openCreateFormWithSteps switches the manager directly into the
+// create-routine form with the supplied step bodies pre-populated.
+// Used by the `/export routine` flow so a session's user prompts can
+// be turned into a routine without retyping.
+func (m *routinesModel) openCreateFormWithSteps(steps []string) {
+	m.form = newRoutineFormWithSteps(steps)
+	m.subset = routinesSubForm
+	m.sizeFormBody()
+}
+
 func (m routinesModel) Init() tea.Cmd { return loadRoutinesList() }
 
 func (m *routinesModel) setSize(w, h int) {
@@ -650,6 +660,23 @@ func newRoutineForm(editingID string, existing routines.Routine) routineForm {
 		steps:     steps,
 		focused:   fieldName,
 	}
+}
+
+// newRoutineFormWithSteps builds a fresh create-mode form with the
+// supplied step bodies pre-populated. Header fields stay empty so
+// the user picks the routine's name and mode before saving.
+func newRoutineFormWithSteps(stepBodies []string) routineForm {
+	form := newRoutineForm("", routines.Routine{})
+	if len(stepBodies) == 0 {
+		return form
+	}
+	steps := make([]textarea.Model, 0, len(stepBodies))
+	for _, body := range stepBodies {
+		steps = append(steps, newStepTextarea(body))
+	}
+	form.steps = steps
+	form.focused = fieldName
+	return form
 }
 
 // newStepTextarea constructs a textarea pre-configured for routine

--- a/internal/tui/routines_test.go
+++ b/internal/tui/routines_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/lucinate-ai/lucinate/internal/config"
 	"github.com/lucinate-ai/lucinate/internal/routines"
 )
 
@@ -301,3 +303,203 @@ func TestRoutinesDetailActions_DeleteKeyIsX(t *testing.T) {
 // list.Item interface is satisfied by routineItem; this is a compile-time
 // guard that the test seeding path actually creates list-recognised items.
 var _ list.Item = routineItem{}
+
+// withTempRoutinesDir reroutes config.DataDir at a temp directory so
+// Save/Load/Delete don't touch the user's real ~/.lucinate.
+func withTempRoutinesDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	config.SetDataDir(dir)
+	t.Cleanup(func() { config.SetDataDir("") })
+}
+
+func TestRoutinesForm_RejectsNonKebabName(t *testing.T) {
+	withTempRoutinesDir(t)
+	m := newRoutinesModel(true, true)
+	m.openCreateFormWithSteps([]string{"first prompt"})
+
+	m.form.name.SetValue("My Routine")
+	m, cmd := m.submitForm()
+
+	if cmd != nil {
+		t.Fatal("expected no save cmd when name fails kebab validation")
+	}
+	if m.form.err == nil {
+		t.Fatal("expected form err for non-kebab name")
+	}
+	got := m.form.err.Error()
+	if !strings.Contains(got, "kebab-case") {
+		t.Errorf("error %q should mention kebab-case", got)
+	}
+	if !strings.Contains(got, "my-routine") {
+		t.Errorf("error %q should suggest the kebab form", got)
+	}
+
+	listed, err := routines.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("rejected save still wrote %d routines: %+v", len(listed), listed)
+	}
+}
+
+func TestRoutinesForm_AcceptsKebabName(t *testing.T) {
+	withTempRoutinesDir(t)
+	m := newRoutinesModel(true, true)
+	m.openCreateFormWithSteps([]string{"do the thing"})
+
+	m.form.name.SetValue("my-routine")
+	_, cmd := m.submitForm()
+
+	if cmd == nil {
+		t.Fatal("expected save cmd for kebab-cased name")
+	}
+	// Drive the cmd so the routine actually lands on disk.
+	if msg := cmd(); msg == nil {
+		t.Fatal("save cmd returned nil")
+	}
+	listed, err := routines.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "my-routine" {
+		t.Errorf("expected one routine 'my-routine', got %+v", listed)
+	}
+}
+
+// makeFormWithLayout builds a routineForm with synthetic line-start
+// metadata so ensureFocusVisible can be exercised without rendering
+// real textareas. height is the viewport height; bodyLines is the
+// total content height; starts maps focusable-field index → starting
+// line. The viewport is given just enough fake content to satisfy
+// scroll bounds.
+func makeFormWithLayout(t *testing.T, height int, bodyLines int, starts []int) routineForm {
+	t.Helper()
+	vp := viewport.New()
+	vp.SetWidth(80)
+	vp.SetHeight(height)
+	// Fake content: bodyLines newlines so YOffset clamping has
+	// something realistic to clamp against.
+	vp.SetContent(strings.Repeat("x\n", bodyLines))
+	return routineForm{
+		body:            vp,
+		fieldLineStarts: starts,
+		bodyLines:       bodyLines,
+	}
+}
+
+func TestRoutineForm_EnsureFocusVisible_ScrollsDownToReachLaterField(t *testing.T) {
+	// 11 fields, sized so 9 of them sit below a 10-row window.
+	// Focused field starts at line 51, viewport height 10 → expected
+	// offset puts the focused field's last line on the bottom edge.
+	starts := []int{0, 5, 10, 15, 21, 27, 33, 39, 45, 51, 57}
+	form := makeFormWithLayout(t, 10, 63, starts)
+	form.focused = 9
+	form.body.SetYOffset(0)
+
+	form.ensureFocusVisible()
+
+	got := form.body.YOffset()
+	// Field 9 spans lines 51..56 (next start is 57). Window height 10.
+	// Acceptable offsets keep [51,56] inside [offset, offset+10).
+	if got < 47 || got > 51 {
+		t.Errorf("YOffset=%d, want in [47,51] so step 9 (lines 51..56) is visible", got)
+	}
+}
+
+func TestRoutineForm_EnsureFocusVisible_ScrollsUpToReachEarlierField(t *testing.T) {
+	starts := []int{0, 5, 10, 15, 21, 27, 33, 39, 45, 51, 57}
+	form := makeFormWithLayout(t, 10, 63, starts)
+	form.focused = 1 // field at line 5..9
+	form.body.SetYOffset(40) // start scrolled past it
+
+	form.ensureFocusVisible()
+
+	got := form.body.YOffset()
+	if got > 5 {
+		t.Errorf("YOffset=%d, want ≤5 so field 1 (line 5) is visible", got)
+	}
+}
+
+func TestRoutineForm_EnsureFocusVisible_NoOpWhenAlreadyVisible(t *testing.T) {
+	starts := []int{0, 5, 10, 15, 21, 27, 33, 39, 45, 51, 57}
+	form := makeFormWithLayout(t, 20, 63, starts)
+	form.focused = 4 // line 21..26
+	form.body.SetYOffset(15)
+
+	form.ensureFocusVisible()
+
+	if got := form.body.YOffset(); got != 15 {
+		t.Errorf("YOffset=%d, want 15 (already-visible focus shouldn't scroll)", got)
+	}
+}
+
+func TestRoutineForm_EnsureFocusVisible_ClampsToBodyLines(t *testing.T) {
+	// Focusing the very last field shouldn't try to push offset past
+	// the maximum scroll position — the viewport would just clamp it
+	// itself but ensureFocusVisible should produce a sane value too.
+	starts := []int{0, 5}
+	form := makeFormWithLayout(t, 10, 12, starts)
+	form.focused = 1 // line 5..11
+	form.body.SetYOffset(0)
+
+	form.ensureFocusVisible()
+
+	got := form.body.YOffset()
+	maxOffset := 12 - 10
+	if got > maxOffset {
+		t.Errorf("YOffset=%d, want ≤%d (clamped to bodyLines-height)", got, maxOffset)
+	}
+	// And the focus's start must still be inside the window.
+	if got > 5 {
+		t.Errorf("YOffset=%d hides field start at line 5", got)
+	}
+}
+
+func TestRoutinesForm_HelpLineAlwaysRendersWithManySteps(t *testing.T) {
+	// Regression: with 30 steps and a 24-row terminal the previous
+	// inline rendering pushed the help line off the bottom. The
+	// viewport-based form keeps title and footer pinned, so the help
+	// text must always appear in the rendered output.
+	withTempRoutinesDir(t)
+	steps := make([]string, 30)
+	for i := range steps {
+		steps[i] = "step body"
+	}
+	m := newRoutinesModel(false, true)
+	m.setSize(80, 24)
+	m.openCreateFormWithSteps(steps)
+	// Focus the last step — the worst case for the previous layout.
+	m.form.focused = fieldStepStart + 29
+
+	out := m.viewForm()
+
+	if !strings.Contains(out, "ctrl+s: save") {
+		t.Errorf("help line missing from rendered form with many steps:\n%s", out)
+	}
+	// And the title should still render at the top.
+	if !strings.Contains(out, "Routines · New") {
+		t.Errorf("title missing from rendered form:\n%s", out)
+	}
+}
+
+func TestRoutinesForm_RejectsEmptyAndPunctuationOnly(t *testing.T) {
+	withTempRoutinesDir(t)
+	m := newRoutinesModel(true, true)
+	m.openCreateFormWithSteps([]string{"step"})
+
+	cases := []string{"", "  ", "!!!", "   !!! "}
+	for _, in := range cases {
+		m.form.err = nil
+		m.form.name.SetValue(in)
+		var cmd tea.Cmd
+		m, cmd = m.submitForm()
+		if cmd != nil {
+			t.Errorf("%q: expected no cmd, got %v", in, cmd)
+		}
+		if m.form.err == nil {
+			t.Errorf("%q: expected form err", in)
+		}
+	}
+}


### PR DESCRIPTION
Add `/record` and `/export` for capturing session transcripts (closes #115), enforce kebab-case routine names, and stop the routine form from pushing its help line off the terminal when there are many steps.

## Summary
- New `/record on|off` and bare `/record` commands stream the session's canonical chat history to a Markdown file under `<dataDir>/transcripts/` while recording is on, deduplicated across the repeated `historyRefreshMsg` resyncs.
- New `/export [all]` writes the full current canonical history to a transcript file in one shot; `/export routine` extracts the user prompts and opens the routines manager directly into the create form, prepopulated.
- Routine names now have to be kebab-case. `IsValidKebab` is enforced by `Save`, the form validates on submit and suggests a kebab fix derived from `ToKebab`, and the placeholder + label make the rule visible before the user gets there.
- The create/edit form's body (header inputs + step textareas) lives inside a scrollable viewport. The title above and the help line below stay pinned, so the user can always see how to operate the form regardless of step count. Per-step textarea height is now a fixed 4 lines instead of being auto-fitted into the available terminal space.
- Documentation: new `docs/export-and-recording.md` covering the canonical-history tap, dedup signature, file layout, and lifecycle. `docs/routines.md` updated for the kebab/viewport changes; `docs/commands.md` table extended; `docs/README.md` index entry added.

## Implementation details
The transcript source is the canonical history fetched from the backend (`historyLoadedMsg` / `historyRefreshMsg`), never the streaming deltas — a `(role, timestampMs, fnv64(text))` signature dedups against rows already written, so repeated canonical refreshes don't double-write. When an assistant message has been glamour-rendered into ANSI, `messageSourceText` prefers `chatMessage.raw` over `chatMessage.content` so transcripts carry the original markdown rather than escape codes. Recording does not survive a chat-model replacement (session switch, agent change, cron transcript) — `chatModel.stopRecording` is called at every replacement site so the file handle doesn't leak across sessions; the user re-enables on the new chat.

`Load` and `Delete` deliberately keep the lenient `validName` predicate so existing on-disk routines with non-kebab names still load; only `Save` enforces `IsValidKebab`, so editing one of those routines forces a rename to a kebab identifier on the next save.

The form-overflow fix records each focusable field's starting line index in the body content (`fieldLineStarts`) as it builds; `ensureFocusVisible` adjusts the viewport's `YOffset` after every render so the focused field is fully on-screen — scrolling down when the user tabs past the bottom, up when they shift-tab back. The previous "divide remaining height across all steps" sizing is gone because it squeezed every textarea down to a 1-line stub once step count grew; with the viewport handling overflow, a fixed 4-line height per step is friendlier to type into.