### PR TITLE
fix(tui): scroll to bottom on input submit

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -889,6 +889,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.refreshCompletionMenu()
 				m.pendingMessages = append(m.pendingMessages, text)
 				m.updateViewport()
+				m.viewport.GotoBottom()
 				return m, nil
 			}
 
@@ -904,6 +905,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.appendMessage(chatMessage{role: "system", content: "running on gateway..."})
 				m.sending = true
 				m.updateViewport()
+				m.viewport.GotoBottom()
 				cmds = append(cmds, m.execCommand(command))
 				return m, tea.Batch(cmds...)
 			}
@@ -917,6 +919,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.appendMessage(chatMessage{role: "system", content: "running..."})
 				m.sending = true
 				m.updateViewport()
+				m.viewport.GotoBottom()
 				cmds = append(cmds, localExecCommand(command))
 				return m, tea.Batch(cmds...)
 			}
@@ -934,6 +937,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				ar.logger.WriteUser(text)
 			}
 			m.updateViewport()
+			m.viewport.GotoBottom()
 			cmds = append(cmds, m.sendMessage(sent), m.ensureSpinnerTicking())
 			return m, tea.Batch(cmds...)
 		}

--- a/internal/tui/routines_chat.go
+++ b/internal/tui/routines_chat.go
@@ -91,6 +91,7 @@ func (m *chatModel) sendNextRoutineStep() tea.Cmd {
 		ar.logger.WriteUser(text)
 	}
 	m.updateViewport()
+	m.viewport.GotoBottom()
 	return tea.Batch(m.sendMessage(sent), m.ensureSpinnerTicking())
 }
 


### PR DESCRIPTION
After the user scrolls up to read earlier history, submitting a new
message left the viewport stuck above the new content. Force GotoBottom
on every input-submission path — typed messages, !/!! exec, queued
messages, and routine steps — so the user always sees the message they
just sent and the response that follows.