### PR TITLE
feat(tui): add /header command to customise chat header colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
 - **Cron browser** — list, edit, run, create, and duplicate scheduled jobs without leaving the terminal (OpenClaw)
+- **Customisable header colour** — set the chat header background to any hex colour with `/header <hex>`; persisted across runs
 
 ## Install
 
@@ -157,6 +158,7 @@ Type these in the chat input. As soon as you type `/`, a menu shows every matchi
 | `/config` | Open preferences |
 | `/connections` | Switch backend connection |
 | `/crons` | List and manage gateway cron jobs (default: filter by current agent; `/crons all` shows global) — OpenClaw only |
+| `/header <hex>` | Set the chat header background to a hex colour (e.g. `#4FC3F7`); persisted across runs. Bare `/header` reports the current value, `/header reset` restores the default. |
 | `/models` | Open the model picker (filter as you type) |
 | `/model <name>` | Switch model (fuzzy match) |
 | `/reset` | Delete session and start fresh (with confirmation) |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Live token/cost stats** in the header bar (OpenClaw)
 - **Thinking level control** via `/think` — tune reasoning depth per session (OpenClaw)
 - **Cron browser** — list, edit, run, create, and duplicate scheduled jobs without leaving the terminal (OpenClaw)
-- **Customisable header colour** — set the chat header background to any hex colour with `/header <hex>`; persisted across runs
+- **Per-agent header colour** — set the chat header background to any hex colour with `/header <hex>` and the override sticks to that agent, persisted across runs
 
 ## Install
 
@@ -158,7 +158,7 @@ Type these in the chat input. As soon as you type `/`, a menu shows every matchi
 | `/config` | Open preferences |
 | `/connections` | Switch backend connection |
 | `/crons` | List and manage gateway cron jobs (default: filter by current agent; `/crons all` shows global) — OpenClaw only |
-| `/header <hex>` | Set the chat header background to a hex colour (e.g. `#4FC3F7`); persisted across runs. Bare `/header` reports the current value, `/header reset` restores the default. |
+| `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`); the override sticks to that agent and persists across runs. Bare `/header` reports the current agent's value, `/header reset` restores the default. |
 | `/models` | Open the model picker (filter as you type) |
 | `/model <name>` | Switch model (fuzzy match) |
 | `/reset` | Delete session and start fresh (with confirmation) |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -53,6 +53,8 @@ Two independent loads feed the right-hand side:
 
 The renderer caps the percentage at 999% so a runaway numerator never widens the header past three digits.
 
+The header background defaults to the accent purple but can be overridden with `/header <hex>` — see [commands.md → /header](commands.md#header). The chosen colour is stored in `prefs.HeaderColor` and applied to both `headerStyle` and the warn-badge background each render.
+
 The connection-status badge is rendered in the error colour and only appears when the gateway connection is degraded:
 
 | Badge | Meaning |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -53,7 +53,7 @@ Two independent loads feed the right-hand side:
 
 The renderer caps the percentage at 999% so a runaway numerator never widens the header past three digits.
 
-The header background defaults to the accent purple but can be overridden with `/header <hex>` — see [commands.md → /header](commands.md#header). The chosen colour is stored in `prefs.HeaderColor` and applied to both `headerStyle` and the warn-badge background each render.
+The header background defaults to the accent purple but can be overridden per agent with `/header <hex>` — see [commands.md → /header](commands.md#header). The override is stored against the agent ID under `prefs.Agents[agentID].HeaderColor`; the renderer calls `prefs.HeaderColorFor(m.agentID)` each frame and applies the colour to both `headerStyle` and the warn-badge background. Switching to another agent picks up that agent's own colour (or the default).
 
 The connection-status badge is rendered in the error colour and only appears when the gateway connection is degraded:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,9 +26,9 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/export` | Write the current session's canonical history to a transcript file — see below |
 | `/export all` | Same as `/export` |
 | `/export routine` | Convert the session's user prompts into routine steps and open the form prepopulated — see below |
-| `/header` | Show the current chat header background colour |
-| `/header <hex>` | Set the chat header background to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted across runs — see below |
-| `/header reset` | Restore the default header colour (also accepts `default` or `off`) |
+| `/header` | Show the chat header background colour for the current agent |
+| `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted per agent across runs — see below |
+| `/header reset` | Restore the default header colour for the current agent (also accepts `default` or `off`) |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
@@ -61,7 +61,9 @@ Stats are loaded asynchronously via `client.SessionUsage()` on chat init and aft
 
 ### /header
 
-`handleHeaderCommand()` parses the argument, runs it through `config.NormalizeHexColor()` (accepts `#RRGGBB`, `#RGB`, with or without the leading `#`), writes the canonical `#RRGGBB` value to `prefs.HeaderColor`, persists via `config.SavePreferences()`, and emits `prefsUpdatedMsg` so `AppModel.prefs` and `chatModel.prefs` stay in sync. The chat view's `View()` reads `m.prefs.HeaderColor` each render and overrides `headerStyle.Background()` (and the update-available warn-badge background, which sits inside the header) when the value is non-empty. Bare `/header` reports the current value; `/header reset` (also `default`, `off`) clears it. The colour is a global preference, not per-session.
+`handleHeaderCommand()` parses the argument, runs it through `config.NormalizeHexColor()` (accepts `#RRGGBB`, `#RGB`, with or without the leading `#`), then writes the canonical `#RRGGBB` value via `prefs.SetHeaderColor(agentID, hex)`, persists with `config.SavePreferences()`, and emits `prefsUpdatedMsg` so `AppModel.prefs` and `chatModel.prefs` stay in sync. The chat view's `View()` calls `m.prefs.HeaderColorFor(m.agentID)` each render and overrides `headerStyle.Background()` (and the update-available warn-badge background, which sits inside the header) when a value is set for the current agent. Bare `/header` reports the current agent's value; `/header reset` (also `default`, `off`) clears it.
+
+The colour is scoped per agent — switching to another agent shows that agent's own colour (or the built-in default). Per-agent overrides are stored under a nested `agents` sub-object in `config.json`, keyed by agent ID, so future per-agent settings can sit alongside `headerColor` without growing the file horizontally. When the active agent has no ID (e.g. an unbound chat), `/header` reports an error rather than falling back to a global setting.
 
 ### /record and /export
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,9 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/export` | Write the current session's canonical history to a transcript file — see below |
 | `/export all` | Same as `/export` |
 | `/export routine` | Convert the session's user prompts into routine steps and open the form prepopulated — see below |
+| `/header` | Show the current chat header background colour |
+| `/header <hex>` | Set the chat header background to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted across runs — see below |
+| `/header reset` | Restore the default header colour (also accepts `default` or `off`) |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
@@ -55,6 +58,10 @@ Backend-only commands render a "not available on this connection" system message
 ### /stats
 
 Stats are loaded asynchronously via `client.SessionUsage()` on chat init and after each message exchange. `/stats` formats `m.stats` through `formatStatsTable()` in `internal/tui/render.go`, which produces a text table of input/output/cache tokens and cost breakdown.
+
+### /header
+
+`handleHeaderCommand()` parses the argument, runs it through `config.NormalizeHexColor()` (accepts `#RRGGBB`, `#RGB`, with or without the leading `#`), writes the canonical `#RRGGBB` value to `prefs.HeaderColor`, persists via `config.SavePreferences()`, and emits `prefsUpdatedMsg` so `AppModel.prefs` and `chatModel.prefs` stay in sync. The chat view's `View()` reads `m.prefs.HeaderColor` each render and overrides `headerStyle.Background()` (and the update-available warn-badge background, which sits inside the header) when the value is non-empty. Bare `/header` reports the current value; `/header reset` (also `default`, `off`) clears it. The colour is a global preference, not per-session.
 
 ### /record and /export
 

--- a/internal/config/preferences.go
+++ b/internal/config/preferences.go
@@ -32,10 +32,51 @@ type Preferences struct {
 	CheckForUpdates       *bool  `json:"checkForUpdates,omitempty"`
 	LastUpdateCheck       int64  `json:"lastUpdateCheck,omitempty"`
 	LatestSeenVersion     string `json:"latestSeenVersion,omitempty"`
-	// HeaderColor is the user-chosen hex background for the chat
-	// header bar, normalised to "#RRGGBB". Empty means use the
-	// built-in default.
+	// Agents holds per-agent overrides, keyed by agent ID. Nested
+	// under one sub-object (rather than a parallel top-level map per
+	// setting) so future per-agent prefs can sit alongside HeaderColor
+	// without growing config.json horizontally.
+	Agents map[string]AgentPreferences `json:"agents,omitempty"`
+}
+
+// AgentPreferences holds settings that are scoped to a single agent.
+// Add new per-agent fields here rather than introducing more top-level
+// maps on Preferences.
+type AgentPreferences struct {
+	// HeaderColor is the chat header background for this agent,
+	// normalised to "#RRGGBB". Empty means use the built-in default.
 	HeaderColor string `json:"headerColor,omitempty"`
+}
+
+// HeaderColorFor returns the per-agent header colour override, or "" when
+// the agent has no entry. Safe to call on a zero-value Preferences.
+func (p Preferences) HeaderColorFor(agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	return p.Agents[agentID].HeaderColor
+}
+
+// SetHeaderColor stores hex as the header colour for agentID. An empty
+// hex clears the entry, restoring the default. The nested map is
+// allocated on demand so callers don't need to initialise it.
+func (p *Preferences) SetHeaderColor(agentID, hex string) {
+	if agentID == "" {
+		return
+	}
+	ap := p.Agents[agentID]
+	ap.HeaderColor = hex
+	if ap == (AgentPreferences{}) {
+		delete(p.Agents, agentID)
+		if len(p.Agents) == 0 {
+			p.Agents = nil
+		}
+		return
+	}
+	if p.Agents == nil {
+		p.Agents = map[string]AgentPreferences{}
+	}
+	p.Agents[agentID] = ap
 }
 
 // NormalizeHexColor validates a hex colour string and returns it in

--- a/internal/config/preferences.go
+++ b/internal/config/preferences.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -30,6 +32,32 @@ type Preferences struct {
 	CheckForUpdates       *bool  `json:"checkForUpdates,omitempty"`
 	LastUpdateCheck       int64  `json:"lastUpdateCheck,omitempty"`
 	LatestSeenVersion     string `json:"latestSeenVersion,omitempty"`
+	// HeaderColor is the user-chosen hex background for the chat
+	// header bar, normalised to "#RRGGBB". Empty means use the
+	// built-in default.
+	HeaderColor string `json:"headerColor,omitempty"`
+}
+
+// NormalizeHexColor validates a hex colour string and returns it in
+// canonical "#RRGGBB" form. Accepts inputs with or without a leading
+// "#" and the 3-digit "#RGB" shorthand. Returns an error when the
+// input is not a valid hex colour.
+func NormalizeHexColor(s string) (string, error) {
+	raw := strings.TrimSpace(s)
+	raw = strings.TrimPrefix(raw, "#")
+	if len(raw) != 3 && len(raw) != 6 {
+		return "", fmt.Errorf("invalid hex colour %q: expected 3 or 6 hex digits", s)
+	}
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return "", fmt.Errorf("invalid hex colour %q: non-hex digit %q", s, string(c))
+		}
+	}
+	if len(raw) == 3 {
+		raw = string([]byte{raw[0], raw[0], raw[1], raw[1], raw[2], raw[2]})
+	}
+	return "#" + strings.ToUpper(raw), nil
 }
 
 // UpdateChecksEnabled reports whether the user has the startup

--- a/internal/config/preferences_test.go
+++ b/internal/config/preferences_test.go
@@ -198,18 +198,53 @@ func TestNormalizeHexColor(t *testing.T) {
 	}
 }
 
-func TestSaveAndLoadPreferences_HeaderColor(t *testing.T) {
+func TestSaveAndLoadPreferences_HeaderColors(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
 	p := DefaultPreferences()
-	p.HeaderColor = "#4FC3F7"
+	p.SetHeaderColor("agent-one", "#4FC3F7")
+	p.SetHeaderColor("agent-two", "#FF6B6B")
 	if err := SavePreferences(p); err != nil {
 		t.Fatalf("SavePreferences: %v", err)
 	}
 	loaded := LoadPreferences()
-	if loaded.HeaderColor != "#4FC3F7" {
-		t.Errorf("expected HeaderColor %q after round-trip, got %q", "#4FC3F7", loaded.HeaderColor)
+	if got := loaded.HeaderColorFor("agent-one"); got != "#4FC3F7" {
+		t.Errorf("HeaderColorFor(agent-one) = %q, want %q", got, "#4FC3F7")
+	}
+	if got := loaded.HeaderColorFor("agent-two"); got != "#FF6B6B" {
+		t.Errorf("HeaderColorFor(agent-two) = %q, want %q", got, "#FF6B6B")
+	}
+	if got := loaded.HeaderColorFor("agent-missing"); got != "" {
+		t.Errorf("HeaderColorFor(missing) = %q, want empty", got)
+	}
+}
+
+func TestSetHeaderColor_ClearRemovesEntry(t *testing.T) {
+	p := DefaultPreferences()
+	p.SetHeaderColor("agent-one", "#112233")
+	p.SetHeaderColor("agent-two", "#445566")
+	p.SetHeaderColor("agent-one", "")
+	if _, ok := p.Agents["agent-one"]; ok {
+		t.Error("expected agent-one entry to be removed after clearing")
+	}
+	if got := p.HeaderColorFor("agent-two"); got != "#445566" {
+		t.Errorf("HeaderColorFor(agent-two) = %q, want %q", got, "#445566")
+	}
+	p.SetHeaderColor("agent-two", "")
+	if p.Agents != nil {
+		t.Errorf("expected Agents map to be nil after clearing the last entry, got %v", p.Agents)
+	}
+}
+
+func TestSetHeaderColor_EmptyAgentIDIsNoop(t *testing.T) {
+	p := DefaultPreferences()
+	p.SetHeaderColor("", "#112233")
+	if p.Agents != nil {
+		t.Errorf("expected Agents to stay nil for empty agentID, got %v", p.Agents)
+	}
+	if got := p.HeaderColorFor(""); got != "" {
+		t.Errorf("HeaderColorFor(\"\") = %q, want empty", got)
 	}
 }
 

--- a/internal/config/preferences_test.go
+++ b/internal/config/preferences_test.go
@@ -167,6 +167,52 @@ func TestSaveAndLoad_UpdateCheckFields(t *testing.T) {
 	}
 }
 
+func TestNormalizeHexColor(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"#aabbcc", "#AABBCC"},
+		{"aabbcc", "#AABBCC"},
+		{"#ABC", "#AABBCC"},
+		{"abc", "#AABBCC"},
+		{"  #112233  ", "#112233"},
+		{"#FfEeDd", "#FFEEDD"},
+	}
+	for _, c := range cases {
+		got, err := NormalizeHexColor(c.in)
+		if err != nil {
+			t.Errorf("NormalizeHexColor(%q) returned error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NormalizeHexColor(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	bad := []string{"", "#", "#1", "#12", "#12345", "#1234567", "ghijkl", "#xyzxyz", "red"}
+	for _, in := range bad {
+		if _, err := NormalizeHexColor(in); err == nil {
+			t.Errorf("NormalizeHexColor(%q) expected error, got nil", in)
+		}
+	}
+}
+
+func TestSaveAndLoadPreferences_HeaderColor(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	p := DefaultPreferences()
+	p.HeaderColor = "#4FC3F7"
+	if err := SavePreferences(p); err != nil {
+		t.Fatalf("SavePreferences: %v", err)
+	}
+	loaded := LoadPreferences()
+	if loaded.HeaderColor != "#4FC3F7" {
+		t.Errorf("expected HeaderColor %q after round-trip, got %q", "#4FC3F7", loaded.HeaderColor)
+	}
+}
+
 func TestLoadPreferences_FutureTimestampReset(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -1352,8 +1352,12 @@ func (m chatModel) View() string {
 	if badge := connectionBadge(m.connState); badge != "" {
 		left += " · " + badge
 	}
+	warnBadgeStyle := headerBadgeWarnStyle
+	if m.prefs.HeaderColor != "" {
+		warnBadgeStyle = warnBadgeStyle.Background(lipgloss.Color(m.prefs.HeaderColor))
+	}
 	if m.updateLatest != "" {
-		left += " · " + headerBadgeWarnStyle.Render("↑ "+m.updateLatest)
+		left += " · " + warnBadgeStyle.Render("↑ "+m.updateLatest)
 	}
 	right := ""
 	if m.contextWindow > 0 && m.promptTokens > 0 {
@@ -1382,7 +1386,11 @@ func (m chatModel) View() string {
 			title += strings.Repeat(" ", padding) + right
 		}
 	}
-	header := headerStyle.
+	hdrStyle := headerStyle
+	if m.prefs.HeaderColor != "" {
+		hdrStyle = hdrStyle.Background(lipgloss.Color(m.prefs.HeaderColor))
+	}
+	header := hdrStyle.
 		Width(m.width).
 		Render(title)
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -1352,9 +1352,10 @@ func (m chatModel) View() string {
 	if badge := connectionBadge(m.connState); badge != "" {
 		left += " · " + badge
 	}
+	headerColor := m.prefs.HeaderColorFor(m.agentID)
 	warnBadgeStyle := headerBadgeWarnStyle
-	if m.prefs.HeaderColor != "" {
-		warnBadgeStyle = warnBadgeStyle.Background(lipgloss.Color(m.prefs.HeaderColor))
+	if headerColor != "" {
+		warnBadgeStyle = warnBadgeStyle.Background(lipgloss.Color(headerColor))
 	}
 	if m.updateLatest != "" {
 		left += " · " + warnBadgeStyle.Render("↑ "+m.updateLatest)
@@ -1387,8 +1388,8 @@ func (m chatModel) View() string {
 		}
 	}
 	hdrStyle := headerStyle
-	if m.prefs.HeaderColor != "" {
-		hdrStyle = hdrStyle.Background(lipgloss.Color(m.prefs.HeaderColor))
+	if headerColor != "" {
+		hdrStyle = hdrStyle.Background(lipgloss.Color(headerColor))
 	}
 	header := hdrStyle.
 		Width(m.width).

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -877,29 +877,39 @@ func (m *chatModel) handleHeaderCommand(text string) (bool, tea.Cmd) {
 	if len(parts) == 2 {
 		arg = strings.TrimSpace(parts[1])
 	}
+	agentID := m.agentID
+	agentLabel := m.agentName
+	if agentLabel == "" {
+		agentLabel = agentID
+	}
+	if agentID == "" {
+		m.appendMessage(chatMessage{role: "system", errMsg: "/header: no active agent — colour overrides are scoped per agent"})
+		m.updateViewport()
+		return true, nil
+	}
 	if arg == "" {
-		current := m.prefs.HeaderColor
+		current := m.prefs.HeaderColorFor(agentID)
 		if current == "" {
-			m.appendMessage(chatMessage{role: "system", content: "Header colour: default. Use /header <hex> (e.g. /header #4FC3F7) to customise."})
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour for %s: default. Use /header <hex> (e.g. /header #4FC3F7) to customise.", agentLabel)})
 		} else {
-			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour: %s. Use /header reset to restore the default.", current)})
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour for %s: %s. Use /header reset to restore the default.", agentLabel, current)})
 		}
 		m.updateViewport()
 		return true, nil
 	}
 
 	prefs := m.prefs
-	if strings.EqualFold(arg, "reset") || strings.EqualFold(arg, "default") || strings.EqualFold(arg, "off") {
-		prefs.HeaderColor = ""
-	} else {
+	newColor := ""
+	if !(strings.EqualFold(arg, "reset") || strings.EqualFold(arg, "default") || strings.EqualFold(arg, "off")) {
 		hex, err := config.NormalizeHexColor(arg)
 		if err != nil {
 			m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("/header: %v — expected a hex colour like #4FC3F7 or #F0C", err)})
 			m.updateViewport()
 			return true, nil
 		}
-		prefs.HeaderColor = hex
+		newColor = hex
 	}
+	prefs.SetHeaderColor(agentID, newColor)
 
 	if err := config.SavePreferences(prefs); err != nil {
 		m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("/header: could not save preference: %v", err)})
@@ -907,10 +917,10 @@ func (m *chatModel) handleHeaderCommand(text string) (bool, tea.Cmd) {
 		return true, nil
 	}
 	m.prefs = prefs
-	if prefs.HeaderColor == "" {
-		m.appendMessage(chatMessage{role: "system", content: "Header colour restored to default."})
+	if newColor == "" {
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour for %s restored to default.", agentLabel)})
 	} else {
-		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour set to %s.", prefs.HeaderColor)})
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour for %s set to %s.", agentLabel, newColor)})
 	}
 	m.updateViewport()
 	return true, func() tea.Msg { return prefsUpdatedMsg{prefs: prefs} }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -15,6 +15,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
+	"github.com/lucinate-ai/lucinate/internal/config"
 	"github.com/lucinate-ai/lucinate/internal/routines"
 )
 
@@ -51,7 +52,7 @@ type pendingNavConfirm struct {
 // hint surfaces the picker first, "/model" before "/models" likewise.
 // Tab now extends to the longest common prefix and the completion menu
 // shows every candidate, so the curated order no longer rules Tab.
-var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/export", "/help", "/model", "/models", "/quit", "/record", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/export", "/help", "/header", "/model", "/models", "/quit", "/record", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -293,7 +294,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		})
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/header — show current chat header colour\n/header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)\n/header reset — restore the default header colour\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -377,6 +378,12 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	// /record reports state; /record on|off flips it.
 	if command == "/record" || strings.HasPrefix(command, "/record ") {
 		return m.handleRecordCommand(text)
+	}
+
+	// /header sets the chat header background colour. Bare /header
+	// reports state; /header <hex> sets it; /header reset clears it.
+	if command == "/header" || strings.HasPrefix(command, "/header ") {
+		return m.handleHeaderCommand(text)
 	}
 
 	// /export dumps the current canonical history to a transcript file
@@ -859,6 +866,54 @@ func (m *chatModel) handleRecordCommand(text string) (bool, tea.Cmd) {
 		m.updateViewport()
 		return true, nil
 	}
+}
+
+// handleHeaderCommand handles `/header`, `/header <hex>`, and
+// `/header reset`. The colour is stored in preferences and persists
+// across runs. A bare `/header` reports the current value.
+func (m *chatModel) handleHeaderCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	arg := ""
+	if len(parts) == 2 {
+		arg = strings.TrimSpace(parts[1])
+	}
+	if arg == "" {
+		current := m.prefs.HeaderColor
+		if current == "" {
+			m.appendMessage(chatMessage{role: "system", content: "Header colour: default. Use /header <hex> (e.g. /header #4FC3F7) to customise."})
+		} else {
+			m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour: %s. Use /header reset to restore the default.", current)})
+		}
+		m.updateViewport()
+		return true, nil
+	}
+
+	prefs := m.prefs
+	if strings.EqualFold(arg, "reset") || strings.EqualFold(arg, "default") || strings.EqualFold(arg, "off") {
+		prefs.HeaderColor = ""
+	} else {
+		hex, err := config.NormalizeHexColor(arg)
+		if err != nil {
+			m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("/header: %v — expected a hex colour like #4FC3F7 or #F0C", err)})
+			m.updateViewport()
+			return true, nil
+		}
+		prefs.HeaderColor = hex
+	}
+
+	if err := config.SavePreferences(prefs); err != nil {
+		m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("/header: could not save preference: %v", err)})
+		m.updateViewport()
+		return true, nil
+	}
+	m.prefs = prefs
+	if prefs.HeaderColor == "" {
+		m.appendMessage(chatMessage{role: "system", content: "Header colour restored to default."})
+	} else {
+		m.appendMessage(chatMessage{role: "system", content: fmt.Sprintf("Header colour set to %s.", prefs.HeaderColor)})
+	}
+	m.updateViewport()
+	return true, func() tea.Msg { return prefsUpdatedMsg{prefs: prefs} }
 }
 
 // handleExportCommand handles `/export`, `/export all`, `/export routine`.


### PR DESCRIPTION
Lets the user persistently override the chat view's top header bar
background via /header <hex>. The colour is normalised to #RRGGBB and
saved to preferences so it survives restarts; /header reset restores
the default. The update-available warn badge tracks the same
background so it blends into a custom header.