### PR TITLE
fix(tui): surface gateway chat errors instead of hanging

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -342,7 +342,10 @@ func (c *Client) buildOptions() ([]gateway.Option, error) {
 			select {
 			case c.events <- ev:
 			default:
-				// drop event if channel is full
+				// Drop the event if the channel is full. The TUI consumer
+				// is too slow or stuck; without this log a dropped error
+				// event would silently hang the next turn.
+				slog.Warn("gateway event channel full, dropped event", "name", ev.EventName, "payload_len", len(ev.Payload))
 			}
 		}),
 		gateway.WithIdentity(id, deviceToken),

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -224,6 +224,13 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 	var chatEv protocol.ChatEvent
 	if err := json.Unmarshal(ev.Payload, &chatEv); err != nil {
 		slog.Debug("chat event parse error", "err", err, "payload", string(ev.Payload))
+		// A malformed chat event for an in-flight turn is functionally a
+		// hang — clear sending and tell the user, so the spinner stops.
+		if m.sending {
+			m.runID = ""
+			m.notifyError(fmt.Sprintf("gateway sent malformed chat event: %v", err))
+			return m.drainQueue()
+		}
 		return nil
 	}
 
@@ -346,20 +353,29 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 	case "error":
 		slog.Debug("chat error", "message", chatEv.ErrorMessage)
 		m.runID = ""
-		finalised := false
+		m.finalisedRuns.add(chatEv.RunID)
+		attached := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
 			if last.role == "assistant" && last.streaming {
 				last.streaming = false
 				last.errMsg = chatEv.ErrorMessage
-				finalised = true
-				m.finalisedRuns.add(chatEv.RunID)
+				attached = true
 			}
 		}
-		m.updateViewport()
-		if !finalised {
-			return nil
+		if !attached {
+			// No streaming row to surface the error on (the placeholder
+			// was already finalised, or never appeared). Without this
+			// fallback the spinner would tick forever and the user
+			// would never see the gateway's error.
+			msg := chatEv.ErrorMessage
+			if msg == "" {
+				msg = "gateway returned an error"
+			}
+			m.notifyError(msg)
+			slog.Debug("error not attached, surfaced via notification", "run_id", chatEv.RunID)
 		}
+		m.updateViewport()
 		// Bump so any subsequent refresh treats the errored turn as
 		// history-side. The error row itself was stamped with the
 		// pre-bump gen (still streaming when we mutated it in place),
@@ -375,20 +391,21 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 	case "aborted":
 		slog.Debug("chat aborted")
 		m.runID = ""
-		finalised := false
+		m.finalisedRuns.add(chatEv.RunID)
+		attached := false
 		if len(m.messages) > 0 {
 			last := &m.messages[len(m.messages)-1]
 			if last.role == "assistant" && last.streaming {
 				last.streaming = false
 				last.content += "\n[aborted]"
-				finalised = true
-				m.finalisedRuns.add(chatEv.RunID)
+				attached = true
 			}
 		}
-		m.updateViewport()
-		if !finalised {
-			return nil
+		if !attached {
+			m.notify("Run aborted.")
+			slog.Debug("aborted not attached, surfaced via notification", "run_id", chatEv.RunID)
 		}
+		m.updateViewport()
 		// Same rationale as the error branch — keep the boundary
 		// monotonic so cancelled turns don't pollute the next merge.
 		m.bumpGen()
@@ -396,6 +413,9 @@ func (m *chatModel) handleEvent(ev protocol.Event) tea.Cmd {
 			m.activeRoutine.paused = true
 		}
 		return m.drainQueue()
+
+	default:
+		slog.Debug("unknown chat state", "state", chatEv.State, "run_id", chatEv.RunID)
 	}
 	return nil
 }


### PR DESCRIPTION
End any in-flight chat turn when the gateway emits an error event, instead of leaving the spinner running forever.

## Summary
- Always terminate the turn on a `chat` `error` / `aborted` event: when there is no streaming row to attach to, surface the gateway's message via `notifyError()` (or `notify()` for `aborted`) so the user sees it and the spinner stops.
- Treat a malformed in-flight chat event as terminal: clear `m.sending` and surface the parse error rather than swallowing it.
- Add defensive logging at every previously-silent drop site: unhandled top-level event names, unknown chat states, and gateway events dropped because the TUI events channel is full. All land in `/tmp/lucinate-events.log` (or stderr for the channel-full case).
- Hoist the routine-pause into the unconditional path of the `error` branch so a transient gateway error never auto-loops the next routine step.

## Implementation details
The hang was triggered by a fragile pattern in `handleEvent`: the `error` / `aborted` branches only finalised the turn when the most recent message was a streaming assistant placeholder. Outside that exact shape (placeholder already finalised, role mismatch, no messages yet, or runID mismatch) the event was logged and dropped, leaving `m.sending = true` and the spinner ticking indefinitely.

The fix decouples "did we attach the error to a row?" from "should we end the turn?" — the turn always ends, and the error is shown either on the row (when one matches) or as a styled notification above the input. Adding the runID to `finalisedRuns` in both paths keeps the existing duplicate-event dedupe behaviour intact.

The diagnostic logging is purely additive but valuable: until now, none of the silent-drop sites left a trace, which made the original hang invisible even with the events log open. Future regressions will be one `tail` away.

A watchdog/timeout for the case where the gateway truly never replies is intentionally out of scope and will be revisited if real hangs persist after this lands.