### PR TITLE
fix(tui): stop scrolling chat on up/down, add bash-style history recall

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -161,6 +161,8 @@ type chatModel struct {
 	finalisedRuns      finalisedRunSet // bounded LRU of run IDs we have already finalised; chat events still bearing one of these IDs are stale duplicates emitted by the gateway after final and must not corrupt the next run's placeholder
 	gen                uint64 // generation counter stamped onto every newly-appended chatMessage; bumped after each turn finalises so the just-finalised turn can be replaced by a server-canonical refresh while the next turn's live state survives the merge
 	pendingMessages    []string
+	historyBrowseIndex int    // bash-style up-arrow recall position; -1 when not browsing, 0 = most recent user message, N = N user messages back
+	historyBrowseValue string // textarea contents last placed by history navigation; lets repeated up/down keep walking until the user edits
 	width              int
 	height             int
 	renderer           *glamour.TermRenderer
@@ -233,6 +235,57 @@ func (m *chatModel) appendMessage(msg chatMessage) *chatMessage {
 	msg.gen = m.gen
 	m.messages = append(m.messages, msg)
 	return &m.messages[len(m.messages)-1]
+}
+
+// userMessageAt returns the content of the user-role message at the given
+// reverse-chronological index — 0 is the most recent submission, 1 is the
+// one before it, and so on. ok is false when index exceeds the number of
+// user messages on record. Powers the bash-style up/down recall in the
+// chat input.
+func (m *chatModel) userMessageAt(index int) (string, bool) {
+	if index < 0 {
+		return "", false
+	}
+	seen := 0
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].role != "user" {
+			continue
+		}
+		if seen == index {
+			return m.messages[i].content, true
+		}
+		seen++
+	}
+	return "", false
+}
+
+// recallUserMessageAt loads the user message at the given reverse-chronological
+// index into the textarea and remembers the browse position so a follow-up
+// up/down press can keep walking. Returns true when a message was loaded.
+func (m *chatModel) recallUserMessageAt(index int) bool {
+	val, ok := m.userMessageAt(index)
+	if !ok {
+		return false
+	}
+	setTextareaToValueWithCursor(&m.textarea, val, len(val))
+	m.historyBrowseIndex = index
+	m.historyBrowseValue = m.textarea.Value()
+	return true
+}
+
+// inHistoryBrowse reports whether the textarea still holds the exact value
+// the last history recall placed in it. As soon as the user edits the recalled
+// text, browsing ends and up/down revert to ordinary cursor movement.
+func (m *chatModel) inHistoryBrowse() bool {
+	return m.historyBrowseIndex >= 0 && m.textarea.Value() == m.historyBrowseValue
+}
+
+// exitHistoryBrowse forgets the current browse position. Called whenever the
+// textarea is consumed (submit, slash-command, queued, cancelled) so the next
+// up press starts a fresh walk from the most recent message.
+func (m *chatModel) exitHistoryBrowse() {
+	m.historyBrowseIndex = -1
+	m.historyBrowseValue = ""
 }
 
 // bumpGen captures the current generation and advances the counter.
@@ -421,7 +474,8 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 		historyLoading:  true,
 		hideInput:       hideInput,
 		terminalFocused: true,
-		pendingMessages: pending,
+		pendingMessages:    pending,
+		historyBrowseIndex: -1,
 		// Start at gen=1 so the zero value on chatMessage.gen reads as
 		// "older than any live turn" — server-history imports keep that
 		// default and are always replaceable on subsequent refreshes.
@@ -791,9 +845,51 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 				m.textarea.Reset()
 				m.textarea.SetValue(text)
 				m.textarea.CursorEnd()
+				m.exitHistoryBrowse()
 				m.refreshCompletionMenu()
 				m.updateViewport()
 				return m, nil
+			}
+			// Bash-style history recall: walk back through previously submitted
+			// user messages when the input is empty (start a fresh walk) or the
+			// textarea still holds the last value we placed there (continue
+			// walking). When neither applies the keystroke falls through so the
+			// textarea can move the cursor within multi-line content.
+			if m.textarea.Value() == "" {
+				if m.recallUserMessageAt(0) {
+					m.refreshCompletionMenu()
+					m.updateViewport()
+					return m, nil
+				}
+			} else if m.inHistoryBrowse() {
+				if m.recallUserMessageAt(m.historyBrowseIndex + 1) {
+					m.refreshCompletionMenu()
+					m.updateViewport()
+					return m, nil
+				}
+				// Already at the oldest user message — stay put rather than
+				// fall through, otherwise the textarea would move the cursor
+				// to the start of the recalled line and the next up press
+				// would no longer match historyBrowseValue.
+				return m, nil
+			}
+		case "down":
+			// Bash-style history walk forward. Only meaningful while browsing;
+			// otherwise the keystroke falls through so the textarea can move
+			// the cursor within multi-line content.
+			if m.inHistoryBrowse() {
+				if m.historyBrowseIndex == 0 {
+					m.textarea.Reset()
+					m.exitHistoryBrowse()
+					m.refreshCompletionMenu()
+					m.updateViewport()
+					return m, nil
+				}
+				if m.recallUserMessageAt(m.historyBrowseIndex - 1) {
+					m.refreshCompletionMenu()
+					m.updateViewport()
+					return m, nil
+				}
 			}
 		case "enter":
 			text := strings.TrimSpace(m.textarea.Value())
@@ -1034,8 +1130,11 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	case tea.KeyPressMsg:
 		km := msg.(tea.KeyPressMsg)
 		switch km.Code {
-		case tea.KeyPgUp, tea.KeyPgDown, tea.KeyUp, tea.KeyDown:
-			// Allow scrolling keys through.
+		case tea.KeyPgUp, tea.KeyPgDown:
+			// Allow scrolling keys through. Up/Down are reserved for
+			// pending-message recall and bash-style history walking;
+			// scrolling the conversation viewport with them would compete
+			// with that and dump the user out of their history walk.
 		default:
 			passToViewport = false
 		}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -88,6 +88,7 @@ func fetchHistory(b backend.Backend, sessionKey string, renderer *glamour.TermRe
 			continue
 		}
 		if role == "user" {
+			text = stripInternalContextBlocks(text)
 			text = stripLocalAgentSkillBlocks(text)
 			text = stripSystemLines(text)
 			if text == "" {
@@ -196,6 +197,42 @@ func stripSystemLines(s string) string {
 		kept = append(kept, line)
 	}
 	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+// internalContextBegin / internalContextEnd delimit the gateway-injected
+// context envelope. The gateway prepends it to the user turn it sends to
+// the model; it is plumbing, not anything the human typed, so it must not
+// surface in the rendered transcript or be offered up by the up-arrow
+// history recall.
+const (
+	internalContextBegin = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>"
+	internalContextEnd   = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>"
+)
+
+// stripInternalContextBlocks removes every BEGIN/END internal-context span
+// (inclusive) from a user message, returning only the human-authored
+// remainder. A BEGIN with no matching END strips to end of string — better
+// to drop a malformed envelope entirely than leak gateway plumbing into the
+// input. Handles markers that share a line with real text, not just the
+// own-line form, so a stray prefix can't slip the recall.
+func stripInternalContextBlocks(s string) string {
+	if !strings.Contains(s, internalContextBegin) {
+		return s
+	}
+	for {
+		start := strings.Index(s, internalContextBegin)
+		if start < 0 {
+			break
+		}
+		rest := s[start+len(internalContextBegin):]
+		endRel := strings.Index(rest, internalContextEnd)
+		if endRel < 0 {
+			s = s[:start]
+			break
+		}
+		s = s[:start] + rest[endRel+len(internalContextEnd):]
+	}
+	return strings.TrimSpace(s)
 }
 
 // stripLocalAgentSkillBlocks removes the <local-agent-skill> envelope so it

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -238,6 +238,66 @@ func TestStripLocalAgentSkillBlocks(t *testing.T) {
 	}
 }
 
+func TestStripInternalContextBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no envelope",
+			in:   "just plain text",
+			want: "just plain text",
+		},
+		{
+			name: "block then user text",
+			in: "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+				"injected gateway context\n" +
+				"<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+				"what's the weather?",
+			want: "what's the weather?",
+		},
+		{
+			name: "user text then block",
+			in: "do the thing\n" +
+				"<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>ctx<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+			want: "do the thing",
+		},
+		{
+			name: "only the envelope",
+			in: "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+				"nothing but plumbing\n" +
+				"<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+			want: "",
+		},
+		{
+			name: "two blocks around text",
+			in: "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>a<<<END_OPENCLAW_INTERNAL_CONTEXT>>>" +
+				"real message" +
+				"<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>b<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+			want: "real message",
+		},
+		{
+			name: "unterminated block strips to end",
+			in: "hello\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+				"truncated context with no end marker",
+			want: "hello",
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripInternalContextBlocks(tt.in); got != tt.want {
+				t.Errorf("stripInternalContextBlocks() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSystemLine(t *testing.T) {
 	tests := []struct {
 		line string

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -70,7 +70,7 @@ func TestUpKey_RecallsLastQueuedMessage(t *testing.T) {
 	}
 }
 
-func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
+func TestUpKey_NoQueuedAndNoHistoryLeavesInputEmpty(t *testing.T) {
 	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "", false)
 	m.viewport = viewport.New()
 	m.width = 80
@@ -80,7 +80,128 @@ func TestUpKey_NoQueuedMessagesLeavesInputEmpty(t *testing.T) {
 	m, _ = m.Update(up)
 
 	if got := m.textarea.Value(); got != "" {
-		t.Errorf("textarea should remain empty, got %q", got)
+		t.Errorf("textarea should remain empty with no queue and no history, got %q", got)
+	}
+}
+
+func TestUpKey_NoQueuedRecallsLastUserMessage(t *testing.T) {
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "", false)
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.messages = []chatMessage{
+		{role: "user", content: "first"},
+		{role: "assistant", content: "reply 1"},
+		{role: "user", content: "second"},
+		{role: "assistant", content: "reply 2"},
+		{role: "user", content: "third"},
+		{role: "assistant", content: "reply 3"},
+	}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "third"; got != want {
+		t.Fatalf("first up: got %q, want %q", got, want)
+	}
+
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "second"; got != want {
+		t.Fatalf("second up: got %q, want %q", got, want)
+	}
+
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "first"; got != want {
+		t.Fatalf("third up: got %q, want %q", got, want)
+	}
+
+	// At oldest — further up is a no-op (still shows the oldest message).
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "first"; got != want {
+		t.Errorf("fourth up: got %q, want %q", got, want)
+	}
+}
+
+func TestDownKey_WalksForwardThroughHistory(t *testing.T) {
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "", false)
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.messages = []chatMessage{
+		{role: "user", content: "first"},
+		{role: "user", content: "second"},
+		{role: "user", content: "third"},
+	}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	down := tea.KeyPressMsg{Code: tea.KeyDown}
+
+	// Walk all the way back.
+	m, _ = m.Update(up)
+	m, _ = m.Update(up)
+	m, _ = m.Update(up)
+	if got, want := m.textarea.Value(), "first"; got != want {
+		t.Fatalf("walked back: got %q, want %q", got, want)
+	}
+
+	// Then forward.
+	m, _ = m.Update(down)
+	if got, want := m.textarea.Value(), "second"; got != want {
+		t.Fatalf("first down: got %q, want %q", got, want)
+	}
+
+	m, _ = m.Update(down)
+	if got, want := m.textarea.Value(), "third"; got != want {
+		t.Fatalf("second down: got %q, want %q", got, want)
+	}
+
+	// One more down from the latest clears the textarea (bash-style).
+	m, _ = m.Update(down)
+	if got := m.textarea.Value(); got != "" {
+		t.Errorf("down past latest should clear, got %q", got)
+	}
+}
+
+func TestUpKey_PendingTakesPriorityOverHistory(t *testing.T) {
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "", false)
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.messages = []chatMessage{{role: "user", content: "old"}}
+	m.pendingMessages = []string{"queued"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if got, want := m.textarea.Value(), "queued"; got != want {
+		t.Errorf("textarea: got %q, want %q (pending should win over history)", got, want)
+	}
+	if len(m.pendingMessages) != 0 {
+		t.Errorf("pendingMessages should be empty after pop, got %v", m.pendingMessages)
+	}
+}
+
+func TestUpKey_DoesNotScrollViewport(t *testing.T) {
+	m := newChatModel(nil, "main", "", "test", "", config.DefaultPreferences(), false, "", "", false)
+	m.viewport = viewport.New()
+	m.width = 80
+	m.height = 30
+	m.viewport.SetWidth(80)
+	m.viewport.SetHeight(5)
+	for i := 0; i < 30; i++ {
+		m.messages = append(m.messages, chatMessage{role: "assistant", content: "filler line"})
+	}
+	m.updateViewport()
+
+	if !m.viewport.AtBottom() {
+		t.Fatalf("precondition: viewport should start at bottom")
+	}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	m, _ = m.Update(up)
+
+	if !m.viewport.AtBottom() {
+		t.Errorf("up arrow must not scroll the conversation viewport (YOffset=%d)", m.viewport.YOffset())
 	}
 }
 


### PR DESCRIPTION
Up and down arrows used to pass through to the conversation viewport,
scrolling the scrollback whenever the user was already at the input.
That fought the existing pending-message recall (queued messages
already commandeer up when the textarea is empty) and made the input
feel inconsistent.

The keys are now reserved for the input:
- Up still pops the most recently queued pending message into the
  textarea, unchanged.
- With no pending messages, up walks backward through previously
  submitted user messages, bash-style. Repeated ups continue walking
  as long as the textarea still holds the value we placed there, so
  editing the recall cleanly exits browse mode.
- Down walks forward; one step past the most recent clears the input.
- PgUp/PgDn (and mouse wheel) still scroll the viewport.