### PR TITLE
docs: add brew trust command to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 With [Homebrew](https://brew.sh) (macOS / Linux):
 
 ```sh
+brew trust --formula lucinate-ai/tap/lucinate
 brew install lucinate-ai/tap/lucinate
 ```
 


### PR DESCRIPTION
## Summary
Updated the Homebrew installation instructions in the README to include the `brew trust` command before installing the formula.

## Changes
- Added `brew trust --formula lucinate-ai/tap/lucinate` command to the installation steps
- This command is required before installing from the custom tap to ensure the formula is trusted

## Details
The `brew trust` command is necessary when installing from third-party taps to verify and trust the formula source. This ensures users are aware of and explicitly approve the installation from the lucinate-ai tap before proceeding with the installation.