### PR TITLE
fix(tui): stop capturing mouse so terminal selection works (#14)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -170,16 +170,6 @@ type RunOptions struct {
 	// terminal that can't otherwise dismiss it, leaves this false.
 	DisableExitKeys bool
 
-	// DisableMouse stops the program from emitting the
-	// alt-screen mouse-tracking enable sequence. Embedders driving the
-	// program through a virtual terminal whose host wants to handle
-	// pan/swipe gestures natively (translating them into PgUp/PgDown
-	// keystrokes for example) should set this so the host's gesture
-	// recogniser doesn't capture pans into mouse motion events that the
-	// program then ignores. The CLI relies on mouse tracking for
-	// selection and should leave it false.
-	DisableMouse bool
-
 	// BrightCursor pins the chat composer's textarea cursor on-frame to
 	// ANSI 15 (bright white) instead of Bubbles' default ANSI 7 (light
 	// grey). Bubbles renders the on-frame as `Style.Reverse(true)` over
@@ -324,7 +314,6 @@ func New(opts RunOptions) (*Program, error) {
 		HideInputArea:         opts.HideInputArea,
 		HideActionHints:       opts.HideActionHints,
 		DisableExitKeys:       opts.DisableExitKeys,
-		DisableMouse:          opts.DisableMouse,
 		BrightCursor:          opts.BrightCursor,
 		OnInputFocusChanged:   opts.OnInputFocusChanged,
 		OnActionsChanged:      opts.OnActionsChanged,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -40,7 +40,6 @@ type AppOptions struct {
 	HideInputArea   bool
 	HideActionHints bool
 	DisableExitKeys bool
-	DisableMouse    bool
 
 	// BrightCursor pins the chat textarea cursor's on-frame to ANSI 15
 	// (bright white) instead of Bubbles' default ANSI 7. See
@@ -128,7 +127,6 @@ type AppModel struct {
 	hideInput        bool
 	hideActionHints  bool
 	disableExitKeys  bool
-	disableMouse     bool
 	brightCursor     bool
 	managed          bool
 
@@ -175,7 +173,6 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		hideInput:             opts.HideInputArea,
 		hideActionHints:       opts.HideActionHints,
 		disableExitKeys:       opts.DisableExitKeys,
-		disableMouse:          opts.DisableMouse,
 		brightCursor:          opts.BrightCursor,
 		store:                 opts.Store,
 		backendFactory:        opts.BackendFactory,
@@ -1050,9 +1047,6 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView("")
 	}
 	v.AltScreen = true
-	if !m.disableMouse {
-		v.MouseMode = tea.MouseModeCellMotion
-	}
 	v.KeyboardEnhancements.ReportEventTypes = true
 	v.ReportFocus = true
 	return v

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -130,6 +130,14 @@ type AppModel struct {
 	brightCursor     bool
 	managed          bool
 
+	// mouseCapture toggles SGR mouse tracking. Off by default so a plain
+	// click-drag runs the terminal's native text selection (the fix for
+	// lucinate-ai/lucinate#14); the user opts in via /mouse on to get
+	// mouse-wheel scrolling of the chat history, accepting that native
+	// selection then needs a Shift/Option modifier. Owned here because the
+	// View() that emits the mode lives on AppModel.
+	mouseCapture bool
+
 	onInputFocusChanged func(bool)
 	lastWantsInput      bool
 	inputFocusReported  bool
@@ -474,6 +482,21 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		m.configModel = newConfigModel(m.prefs, m.hideActionHints)
 		m.configModel.setSize(m.width, m.height)
 		m.state = viewConfig
+		return m, nil
+
+	case mouseModeMsg:
+		switch msg.action {
+		case "on":
+			m.mouseCapture = true
+		case "off":
+			m.mouseCapture = false
+		case "toggle":
+			m.mouseCapture = !m.mouseCapture
+		}
+		// "status" reports without changing state. Feedback is a chat
+		// system row, so route it through the chat model (the /mouse
+		// command that raises this msg only fires from the chat view).
+		m.chatModel.reportMouseMode(m.mouseCapture)
 		return m, nil
 
 	case goBackFromConfigMsg:
@@ -1047,6 +1070,9 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView("")
 	}
 	v.AltScreen = true
+	if m.mouseCapture {
+		v.MouseMode = tea.MouseModeCellMotion
+	}
 	v.KeyboardEnhancements.ReportEventTypes = true
 	v.ReportFocus = true
 	return v

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"github.com/a3tai/openclaw-go/protocol"
 
@@ -311,6 +312,48 @@ func runCmd(t *testing.T, cmd tea.Cmd) {
 // frozen on the loading line forever. Without this, the user would be
 // staring at "Loading <agent>..." with no way to retry — selecting
 // would still gate every keystroke into a no-op.
+// TestAppModel_MouseMode_TogglesCaptureAndView verifies the /mouse
+// command path: a mouseModeMsg flips the authoritative mouseCapture flag,
+// View() emits MouseModeCellMotion only when capture is on, and the chat
+// model gets a feedback row. Capture must default off so click-drag runs
+// the terminal's native selection (lucinate-ai/lucinate#14).
+func TestAppModel_MouseMode_TogglesCaptureAndView(t *testing.T) {
+	m := AppModel{state: viewChat}
+	// hideInput skips the textarea render so View() doesn't touch the
+	// zero-valued composer; the mouse-mode gating under test is applied
+	// after the per-view switch and is independent of the chat body.
+	m.chatModel = chatModel{viewport: viewport.New(), hideInput: true}
+
+	if got := m.View(); got.MouseMode != tea.MouseModeNone {
+		t.Fatalf("default MouseMode = %v, want MouseModeNone (selection must work out of the box)", got.MouseMode)
+	}
+
+	on, _ := m.update(mouseModeMsg{action: "on"})
+	m = on
+	if !m.mouseCapture {
+		t.Fatal("expected mouseCapture true after /mouse on")
+	}
+	if got := m.View(); got.MouseMode != tea.MouseModeCellMotion {
+		t.Errorf("MouseMode after on = %v, want MouseModeCellMotion", got.MouseMode)
+	}
+
+	tog, _ := m.update(mouseModeMsg{action: "toggle"})
+	m = tog
+	if m.mouseCapture {
+		t.Fatal("expected mouseCapture false after toggle")
+	}
+	if got := m.View(); got.MouseMode != tea.MouseModeNone {
+		t.Errorf("MouseMode after toggle-off = %v, want MouseModeNone", got.MouseMode)
+	}
+
+	// "status" reports without changing state.
+	before := m.mouseCapture
+	st, _ := m.update(mouseModeMsg{action: "status"})
+	if st.mouseCapture != before {
+		t.Errorf("status changed capture: before=%v after=%v", before, st.mouseCapture)
+	}
+}
+
 func TestAppModel_SessionCreatedError_ClearsSelectingLock(t *testing.T) {
 	m := AppModel{state: viewSelect}
 	m.selectModel = newSelectModel(nil, false, false, nil, false, "")

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -57,6 +57,39 @@ var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/command
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
 
+// helpBody is the static body of the /help and /commands output. Kept as a
+// raw string literal (one command per line) so the list stays readable and
+// easy to amend; the /skills hint is appended at render time when skills
+// are loaded.
+const helpBody = `/quit, /exit — quit lucinate
+/agents — return to agent picker
+/agent <name> — switch agent directly
+/cancel — cancel the current response (also: Esc)
+/clear — clear chat display
+/compact — compact session context
+/config — open preferences
+/connections — switch gateway connection
+/crons — list and manage cron jobs (use /crons all for global)
+/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)
+/header — show current chat header colour
+/header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)
+/header reset — restore the default header colour
+/models — open model picker (filter as you type)
+/model <name> — switch model directly
+/mouse on|off — toggle mouse capture (on = wheel scrolls history; off = native click-drag text selection)
+/record on|off — toggle live transcript capture for this session (bare /record shows state)
+/reset — delete session and start fresh
+/sessions — browse and restore previous sessions
+/stats — show session statistics
+/status — show gateway health and agent status
+/skills — list available agent skills
+/think — show current thinking level
+/think <level> — set thinking level (off/minimal/low/medium/high)
+/help — show this help
+
+!<command> — run command locally
+!!<command> — run command on gateway host`
+
 // findSlashTokenAt locates the slash-prefixed token whose end coincides with
 // the cursor at byteOffset in value. Returns ok=false when the cursor is not
 // at the end of a slash token (e.g. mid-token, or no slash preceding the
@@ -294,7 +327,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		})
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/header — show current chat header colour\n/header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)\n/header reset — restore the default header colour\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/mouse on|off — toggle mouse capture (on = wheel scrolls history; off = native click-drag text selection)\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := helpBody
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -52,7 +52,7 @@ type pendingNavConfirm struct {
 // hint surfaces the picker first, "/model" before "/models" likewise.
 // Tab now extends to the longest common prefix and the completion menu
 // shows every candidate, so the curated order no longer rules Tab.
-var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/export", "/help", "/header", "/model", "/models", "/quit", "/record", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
+var slashCommands = []string{"/agents", "/agent", "/cancel", "/clear", "/commands", "/compact", "/config", "/connections", "/crons", "/exit", "/export", "/help", "/header", "/model", "/models", "/mouse", "/quit", "/record", "/reset", "/routines", "/routine", "/sessions", "/skills", "/stats", "/status", "/think"}
 
 // thinkingLevels is the ordered list of valid thinking levels.
 var thinkingLevels = []string{"off", "minimal", "low", "medium", "high"}
@@ -294,7 +294,7 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 			}
 		})
 	case "/help", "/commands":
-		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/header — show current chat header colour\n/header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)\n/header reset — restore the default header colour\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
+		helpText := "/quit, /exit — quit lucinate\n/agents — return to agent picker\n/agent <name> — switch agent directly\n/cancel — cancel the current response (also: Esc)\n/clear — clear chat display\n/compact — compact session context\n/config — open preferences\n/connections — switch gateway connection\n/crons — list and manage cron jobs (use /crons all for global)\n/export — write the current session's canonical history to a transcript file (/export routine opens the routine form prefilled with the user prompts)\n/header — show current chat header colour\n/header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)\n/header reset — restore the default header colour\n/models — open model picker (filter as you type)\n/model <name> — switch model directly\n/mouse on|off — toggle mouse capture (on = wheel scrolls history; off = native click-drag text selection)\n/record on|off — toggle live transcript capture for this session (bare /record shows state)\n/reset — delete session and start fresh\n/sessions — browse and restore previous sessions\n/stats — show session statistics\n/status — show gateway health and agent status\n/skills — list available agent skills\n/think — show current thinking level\n/think <level> — set thinking level (off/minimal/low/medium/high)\n/help — show this help\n\n!<command> — run command locally\n!!<command> — run command on gateway host"
 		if len(m.skills) > 0 {
 			helpText += fmt.Sprintf("\n\n%d agent skill(s) available — type /skills to list", len(m.skills))
 		}
@@ -384,6 +384,12 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	// reports state; /header <hex> sets it; /header reset clears it.
 	if command == "/header" || strings.HasPrefix(command, "/header ") {
 		return m.handleHeaderCommand(text)
+	}
+
+	// /mouse toggles terminal mouse capture. Bare /mouse reports state;
+	// /mouse on|off|toggle changes it.
+	if command == "/mouse" || strings.HasPrefix(command, "/mouse ") {
+		return m.handleMouseCommand(text)
 	}
 
 	// /export dumps the current canonical history to a transcript file
@@ -924,6 +930,45 @@ func (m *chatModel) handleHeaderCommand(text string) (bool, tea.Cmd) {
 	}
 	m.updateViewport()
 	return true, func() tea.Msg { return prefsUpdatedMsg{prefs: prefs} }
+}
+
+// handleMouseCommand handles `/mouse`, `/mouse on`, `/mouse off`, and
+// `/mouse toggle`. The actual state lives on AppModel (its View emits the
+// mode), so the command only validates the argument and raises a
+// mouseModeMsg; AppModel applies it and calls reportMouseMode to append
+// the system feedback row.
+func (m *chatModel) handleMouseCommand(text string) (bool, tea.Cmd) {
+	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
+	arg := ""
+	if len(parts) == 2 {
+		arg = strings.ToLower(strings.TrimSpace(parts[1]))
+	}
+	action := ""
+	switch arg {
+	case "":
+		action = "status"
+	case "on", "off", "toggle":
+		action = arg
+	default:
+		m.appendMessage(chatMessage{role: "system", errMsg: fmt.Sprintf("unknown /mouse argument %q — use /mouse on, /mouse off, /mouse toggle, or /mouse", arg)})
+		m.updateViewport()
+		return true, nil
+	}
+	return true, func() tea.Msg { return mouseModeMsg{action: action} }
+}
+
+// reportMouseMode appends a system row describing the current mouse-capture
+// state and how it trades off against native text selection. Called by
+// AppModel after it applies a mouseModeMsg.
+func (m *chatModel) reportMouseMode(on bool) {
+	var content string
+	if on {
+		content = "Mouse capture is ON — the wheel scrolls chat history. Native click-drag selection is disabled; hold Shift (or Option on macOS) to select & copy. Use /mouse off to restore native selection."
+	} else {
+		content = "Mouse capture is OFF — click-drag selects & copies text natively. Use /mouse on to enable mouse-wheel scrolling of the chat history."
+	}
+	m.appendMessage(chatMessage{role: "system", content: content})
+	m.updateViewport()
 }
 
 // handleExportCommand handles `/export`, `/export all`, `/export routine`.

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -113,6 +113,60 @@ func TestSlashCommand_Agent_NoMatchReturnsFailureMsg(t *testing.T) {
 	}
 }
 
+func TestSlashCommand_Mouse_OnOffEmitMsg(t *testing.T) {
+	for _, action := range []string{"on", "off", "toggle"} {
+		m := newSlashTestModel()
+		handled, cmd := m.handleSlashCommand("/mouse " + action)
+		if !handled {
+			t.Fatalf("/mouse %s: expected handled", action)
+		}
+		if cmd == nil {
+			t.Fatalf("/mouse %s: expected a cmd", action)
+		}
+		msg, ok := cmd().(mouseModeMsg)
+		if !ok {
+			t.Fatalf("/mouse %s: expected mouseModeMsg, got %T", action, cmd())
+		}
+		if msg.action != action {
+			t.Errorf("/mouse %s: expected action %q, got %q", action, action, msg.action)
+		}
+	}
+}
+
+func TestSlashCommand_Mouse_BareReportsStatus(t *testing.T) {
+	m := newSlashTestModel()
+	handled, cmd := m.handleSlashCommand("/mouse")
+	if !handled || cmd == nil {
+		t.Fatal("expected bare /mouse to be handled with a cmd")
+	}
+	msg, ok := cmd().(mouseModeMsg)
+	if !ok {
+		t.Fatalf("expected mouseModeMsg, got %T", cmd())
+	}
+	if msg.action != "status" {
+		t.Errorf("expected status action, got %q", msg.action)
+	}
+}
+
+func TestSlashCommand_Mouse_UnknownArgErrors(t *testing.T) {
+	m := newSlashTestModel()
+	before := len(m.messages)
+	handled, cmd := m.handleSlashCommand("/mouse wat")
+	if !handled {
+		t.Fatal("expected /mouse wat to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for invalid /mouse argument")
+	}
+	if len(m.messages) != before+1 {
+		t.Fatalf("expected one error row appended, got %d new", len(m.messages)-before)
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.errMsg == "" || !strings.Contains(last.errMsg, "unknown /mouse argument") {
+		t.Errorf("expected unknown-argument error, got %+v", last)
+	}
+}
+
 func TestSlashCommand_Clear(t *testing.T) {
 	m := newSlashTestModel()
 	handled, cmd := m.handleSlashCommand("/clear")

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -259,6 +259,15 @@ type newSessionCreatedMsg struct {
 // showConfigMsg signals the AppModel to switch to the config view.
 type showConfigMsg struct{}
 
+// mouseModeMsg asks the AppModel to change (or report) terminal mouse
+// capture. The CLI leaves capture off by default so click-drag runs the
+// terminal's native text selection; turning it on enables mouse-wheel
+// scrolling of the chat history at the cost of native selection. action is
+// one of "on", "off", "toggle", or "status" (report only, no change).
+type mouseModeMsg struct {
+	action string
+}
+
 // goBackFromConfigMsg signals the AppModel to return to the chat view from config.
 type goBackFromConfigMsg struct{}
 


### PR DESCRIPTION
The CellMotion mouse mode emits the SGR mouse-tracking enable sequence,
which makes the terminal forward button/drag events to the app instead
of running its native text-selection gesture. The "works only when
unfocused" symptom reported in #14 matches macOS terminals that locally
suspend mouse-tracking reporting while a window is in the background.

Drop MouseMode entirely. Keyboard scrolling already works in the chat
viewport, and most modern terminals translate the mouse wheel to arrow
keys when no app-level mouse capture is in effect. The vestigial
DisableMouse knob on AppOptions / RunOptions goes with it.