### PR TITLE
ci: remove local openclaw-go SDK checkout from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout openclaw-go SDK
-        uses: actions/checkout@v6
-        with:
-          repository: a3tai/openclaw-go
-          path: openclaw-go
-
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-
-      - name: Point go.mod replace at checked-out SDK
-        run: go mod edit -replace github.com/a3tai/openclaw-go=./openclaw-go
 
       - name: Mint Homebrew tap token
         id: tap-token


### PR DESCRIPTION
## Summary
Simplifies the release workflow by removing the local checkout and path replacement of the openclaw-go SDK dependency. The workflow now relies on the published SDK version specified in go.mod instead of building against a locally checked-out copy.

## Changes
- Removed the checkout step for the `a3tai/openclaw-go` repository
- Removed the `go mod edit` command that replaced the module path to point to the local checkout
- Kept the standard Go setup step that reads the version from go.mod

## Benefits
- Reduces workflow complexity and execution time
- Ensures the release process uses the published SDK version from go.mod, improving reproducibility
- Eliminates the need to maintain SDK repository access in the release workflow