### PR TITLE
fix(openclaw): keep a stray .env from blocking agent creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lucinate
 .env
 .env.openai
 .env.hermes
+test/integration/integration.env
 
 # Coverage
 coverage.out

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -76,7 +76,11 @@ Once the TUI is running, a supervisor in `internal/client/supervisor.go` watches
 
 ## Scopes
 
-The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are set in `internal/client/client.go` and are required for session management, exec approval, and agent administration.
+The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are the default requested in `internal/client/client.go` and are required for session management, exec approval, and agent administration. The gateway grants the intersection of the requested scopes and those the device token actually carries, so the effective set can be narrower.
+
+`OPENCLAW_OPERATOR_SCOPES` (comma-separated, e.g. `operator.read,operator.write,operator.approvals`) overrides the default requested set. This is needed when the device token is bounded to a subset — such as a setup-code bootstrap credential that cannot carry `operator.admin` — because requesting scopes beyond what the token grants is rejected as a scope mismatch.
+
+> **Foot-gun:** because `config.Load()` reads `.env` from the working directory, an `OPENCLAW_OPERATOR_SCOPES` left in a `.env` silently bounds scopes for *every* connection, regardless of which gateway is selected. The integration-test setup scripts write such a file (to `test/integration/integration.env`, not the repo root, and remove it on teardown). If admin-only operations such as creating an agent fail with `missing scope: operator.admin` despite a token that should carry admin, check for a stray `OPENCLAW_OPERATOR_SCOPES`. Admin-only client operations fail fast with a message pointing here rather than surfacing the raw gateway error.
 
 ## Stored files
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -80,7 +80,7 @@ The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOpera
 
 `OPENCLAW_OPERATOR_SCOPES` (comma-separated, e.g. `operator.read,operator.write,operator.approvals`) overrides the default requested set. This is needed when the device token is bounded to a subset — such as a setup-code bootstrap credential that cannot carry `operator.admin` — because requesting scopes beyond what the token grants is rejected as a scope mismatch.
 
-> **Foot-gun:** because `config.Load()` reads `.env` from the working directory, an `OPENCLAW_OPERATOR_SCOPES` left in a `.env` silently bounds scopes for *every* connection, regardless of which gateway is selected. The integration-test setup scripts write such a file (to `test/integration/integration.env`, not the repo root, and remove it on teardown). If admin-only operations such as creating an agent fail with `missing scope: operator.admin` despite a token that should carry admin, check for a stray `OPENCLAW_OPERATOR_SCOPES`. Admin-only client operations fail fast with a message pointing here rather than surfacing the raw gateway error.
+> **Pitfall:** because `config.Load()` reads `.env` from the working directory, an `OPENCLAW_OPERATOR_SCOPES` left in a `.env` silently bounds scopes for *every* connection, regardless of which gateway is selected. The integration-test setup scripts write such a file (to `test/integration/integration.env`, not the repo root, and remove it on teardown). If admin-only operations such as creating an agent fail with `missing scope: operator.admin` despite a token that should carry admin, check for a stray `OPENCLAW_OPERATOR_SCOPES`. Admin-only client operations fail fast with a message pointing here rather than surfacing the raw gateway error.
 
 ## Stored files
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -389,6 +389,55 @@ func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, er
 	return c.currentGW().AgentsList(ctx)
 }
 
+// grantedScopes returns the operator scopes the gateway granted this
+// connection at the hello handshake, or nil if not connected or the gateway
+// reported none. The granted set is the intersection of the scopes requested
+// on connect and those the device token actually carries, so it can be
+// narrower than defaultOperatorScopes.
+func (c *Client) grantedScopes() []string {
+	gw := c.currentGW()
+	if gw == nil {
+		return nil
+	}
+	if h := gw.Hello(); h != nil && h.Auth != nil {
+		return h.Auth.Scopes
+	}
+	return nil
+}
+
+// requireAdminScope fails fast, before an admin-only RPC, when the connection
+// was demonstrably granted a scope set without operator.admin. The most common
+// cause is OPENCLAW_OPERATOR_SCOPES bounding the requested scopes below admin —
+// for example a leftover integration-test .env picked up by godotenv from the
+// working directory — so the message points there. When the granted set is
+// unknown (older gateway, no hello auth) it returns nil and lets the RPC
+// surface the gateway's own error, which adminScopeHint then annotates.
+func (c *Client) requireAdminScope(op string) error {
+	scopes := c.grantedScopes()
+	if len(scopes) == 0 {
+		return nil
+	}
+	for _, s := range scopes {
+		if s == string(protocol.ScopeOperatorAdmin) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s requires the operator.admin scope, but this connection was granted only [%s]. "+
+		"Check that OPENCLAW_OPERATOR_SCOPES is not bounding scopes below admin (e.g. a leftover .env from the integration tests), then reconnect",
+		op, strings.Join(scopes, ", "))
+}
+
+// adminScopeHint annotates a gateway "missing scope: operator.admin" error with
+// the likely local cause so the raw protocol error is not the only thing the
+// user sees. It is a fallback for when requireAdminScope could not pre-empt the
+// failure (the granted scope set was unknown at call time).
+func adminScopeHint(err error) error {
+	if err == nil || !strings.Contains(err.Error(), string(protocol.ScopeOperatorAdmin)) {
+		return err
+	}
+	return fmt.Errorf("%w (check that OPENCLAW_OPERATOR_SCOPES is not bounding scopes below admin, e.g. a leftover .env from the integration tests, then reconnect)", err)
+}
+
 // DeleteAgent removes an agent via the gateway API. deleteFiles is
 // the user's explicit choice from the confirm view: when true, the
 // gateway also wipes the agent's workspace files; when false, only
@@ -396,13 +445,16 @@ func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, er
 // reuse it. The result payload (ok / removed bindings count) is
 // discarded — callers care only about success vs failure.
 func (c *Client) DeleteAgent(ctx context.Context, agentID string, deleteFiles bool) error {
+	if err := c.requireAdminScope("agents delete"); err != nil {
+		return err
+	}
 	gw := c.currentGW()
 	flag := deleteFiles
 	if _, err := gw.AgentsDelete(ctx, protocol.AgentsDeleteParams{
 		AgentID:     agentID,
 		DeleteFiles: &flag,
 	}); err != nil {
-		return fmt.Errorf("agents delete: %w", err)
+		return adminScopeHint(fmt.Errorf("agents delete: %w", err))
 	}
 	return nil
 }
@@ -410,13 +462,16 @@ func (c *Client) DeleteAgent(ctx context.Context, agentID string, deleteFiles bo
 // CreateAgent provisions a new agent via the gateway API and seeds an
 // IDENTITY.md file for it.
 func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error {
+	if err := c.requireAdminScope("agents create"); err != nil {
+		return err
+	}
 	gw := c.currentGW()
 	result, err := gw.AgentsCreate(ctx, protocol.AgentsCreateParams{
 		Name:      name,
 		Workspace: workspace,
 	})
 	if err != nil {
-		return fmt.Errorf("agents create: %w", err)
+		return adminScopeHint(fmt.Errorf("agents create: %w", err))
 	}
 
 	// Seed IDENTITY.md so the agent has a name.

--- a/internal/client/scopes_test.go
+++ b/internal/client/scopes_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+func TestOperatorScopes(t *testing.T) {
+	t.Run("defaults to full set including admin when unset", func(t *testing.T) {
+		t.Setenv("OPENCLAW_OPERATOR_SCOPES", "")
+		got := operatorScopes()
+		if !containsScope(got, protocol.ScopeOperatorAdmin) {
+			t.Fatalf("default scopes %v should include operator.admin", got)
+		}
+	})
+
+	t.Run("honours the env override and can omit admin", func(t *testing.T) {
+		t.Setenv("OPENCLAW_OPERATOR_SCOPES", " operator.read , operator.write ,operator.approvals ")
+		got := operatorScopes()
+		want := []protocol.Scope{
+			protocol.ScopeOperatorRead,
+			protocol.ScopeOperatorWrite,
+			protocol.ScopeOperatorApprovals,
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+		if containsScope(got, protocol.ScopeOperatorAdmin) {
+			t.Fatalf("override %v should not include operator.admin", got)
+		}
+	})
+
+	t.Run("falls back to the default when the override is all separators", func(t *testing.T) {
+		t.Setenv("OPENCLAW_OPERATOR_SCOPES", " , , ")
+		if got := operatorScopes(); !containsScope(got, protocol.ScopeOperatorAdmin) {
+			t.Fatalf("blank override should fall back to the default set, got %v", got)
+		}
+	})
+}
+
+func TestAdminScopeHint(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		if adminScopeHint(nil) != nil {
+			t.Fatal("nil error should stay nil")
+		}
+	})
+
+	t.Run("unrelated error is untouched", func(t *testing.T) {
+		in := errors.New("agents create: boom")
+		if got := adminScopeHint(in); got.Error() != in.Error() {
+			t.Fatalf("unrelated error was modified: %q", got.Error())
+		}
+	})
+
+	t.Run("missing-admin error is annotated and still unwraps", func(t *testing.T) {
+		base := fmt.Errorf("agents create: agents.create: INVALID_REQUEST: missing scope: %s", protocol.ScopeOperatorAdmin)
+		got := adminScopeHint(base)
+		if !strings.Contains(got.Error(), "OPENCLAW_OPERATOR_SCOPES") {
+			t.Fatalf("annotated error should mention OPENCLAW_OPERATOR_SCOPES: %q", got.Error())
+		}
+		if !errors.Is(got, base) {
+			t.Fatal("annotated error should still unwrap to the original")
+		}
+	})
+}
+
+func containsScope(scopes []protocol.Scope, want protocol.Scope) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/queue_integration_test.go
+++ b/internal/tui/queue_integration_test.go
@@ -28,11 +28,16 @@ func projectRoot() string {
 	return filepath.Join(filepath.Dir(thisFile), "..", "..")
 }
 
-// connectTestClient loads .env, creates a client, and connects to the gateway.
+// connectTestClient loads the integration env, creates a client, and connects
+// to the gateway.
 func connectTestClient(t *testing.T) *client.Client {
 	t.Helper()
-	// Load .env from project root since go test runs in the package directory.
-	envFile := filepath.Join(projectRoot(), ".env")
+	// Load the integration env file written by the setup scripts. It lives
+	// under test/integration/ rather than the repo root so it can never be
+	// mistaken for a real .env and silently bound the operator scopes of an
+	// interactive `lucinate` launched from the repo directory. go test runs in
+	// the package directory, so resolve the path from the repo root.
+	envFile := filepath.Join(projectRoot(), "test", "integration", "integration.env")
 	if _, err := os.Stat(envFile); err == nil {
 		_ = godotenv.Load(envFile)
 	}

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   gateway:
-    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}
+    # Pin a known-good gateway version by default. `:latest` has broken the
+    # setup-code bootstrap (NOT_PAIRED) in the past, so the local scripts need a
+    # stable pin. CI overrides this via OPENCLAW_IMAGE to sweep its version matrix.
+    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:2026.5.28}
     user: "${OPENCLAW_UID:-1000}:${OPENCLAW_GID:-1000}"
     ports:
       - "18789:18789"

--- a/test/integration/setup-openclaw-bedrock.sh
+++ b/test/integration/setup-openclaw-bedrock.sh
@@ -17,7 +17,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 IDENTITY_DIR="$HOME/.lucinate/identity/localhost_18789"
 BACKUP_FILE="$IDENTITY_DIR/device-token.backup"

--- a/test/integration/setup-openclaw-bedrock.sh
+++ b/test/integration/setup-openclaw-bedrock.sh
@@ -169,17 +169,17 @@ else
     fail "Connection failed. Check gateway logs: docker compose -f $COMPOSE_FILE logs gateway"
 fi
 
-# --- Write .env for test runs ---------------------------------------------
+# --- Write integration.env for test runs ----------------------------------
 
-info "Writing test .env"
-cat > "$PROJECT_ROOT/.env" <<EOF
+info "Writing test integration.env"
+cat > "$SCRIPT_DIR/integration.env" <<EOF
 OPENCLAW_GATEWAY_URL=$GATEWAY_URL
 # The setup-code bootstrap profile grants read/write/approvals but not admin,
 # so the device token is bounded to those scopes. Request the matching set;
 # asking for operator.admin would be rejected as a scope mismatch.
 OPENCLAW_OPERATOR_SCOPES=operator.read,operator.write,operator.approvals
 EOF
-ok "Wrote .env with OPENCLAW_GATEWAY_URL=$GATEWAY_URL"
+ok "Wrote test/integration/integration.env with OPENCLAW_GATEWAY_URL=$GATEWAY_URL"
 
 # --- Done ------------------------------------------------------------------
 

--- a/test/integration/setup-openclaw-echo.sh
+++ b/test/integration/setup-openclaw-echo.sh
@@ -18,7 +18,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 IDENTITY_DIR="$HOME/.lucinate/identity/localhost_18789"
 BACKUP_FILE="$IDENTITY_DIR/device-token.backup"
@@ -89,7 +88,7 @@ mkdir -p "$STATE_DIR"
 cp "$SCRIPT_DIR/openclaw.echo.json" "$STATE_DIR/openclaw.json"
 ok "State directory ready at $STATE_DIR"
 
-info "Starting OpenClaw gateway (${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest})"
+info "Starting OpenClaw gateway (${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:2026.5.28})"
 # Don't use `--wait`: a fresh gateway installs bundled runtime deps on first
 # start (~30s) during which the healthcheck fails; poll /healthz instead.
 OPENCLAW_UID="$(id -u)" OPENCLAW_GID="$(id -g)" \
@@ -173,7 +172,7 @@ echo ""
 info "OpenClaw (echo model) integration test environment is ready"
 echo ""
 echo "  Provider: echomodel (no API charge)"
-echo "  Gateway:  $GATEWAY_URL  (${OPENCLAW_IMAGE:-latest})"
+echo "  Gateway:  $GATEWAY_URL  (${OPENCLAW_IMAGE:-2026.5.28})"
 echo "  Run tests:     make test-integration-openclaw"
 echo "  Tear down:     make test-integration-openclaw-teardown"
 echo ""

--- a/test/integration/setup-openclaw-echo.sh
+++ b/test/integration/setup-openclaw-echo.sh
@@ -158,16 +158,16 @@ else
     fail "Connection failed. Logs: docker compose -f $COMPOSE_FILE logs gateway"
 fi
 
-# --- Write .env for test runs ---------------------------------------------
+# --- Write integration.env for test runs ----------------------------------
 
-info "Writing test .env"
-cat > "$PROJECT_ROOT/.env" <<EOF
+info "Writing test integration.env"
+cat > "$SCRIPT_DIR/integration.env" <<EOF
 OPENCLAW_GATEWAY_URL=$GATEWAY_URL
 # The setup-code bootstrap profile grants read/write/approvals but not admin,
 # so the device token is bounded to those scopes. Request the matching set.
 OPENCLAW_OPERATOR_SCOPES=$OPERATOR_SCOPES
 EOF
-ok "Wrote .env"
+ok "Wrote test/integration/integration.env"
 
 echo ""
 info "OpenClaw (echo model) integration test environment is ready"

--- a/test/integration/setup-openclaw-ollama.sh
+++ b/test/integration/setup-openclaw-ollama.sh
@@ -18,7 +18,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 IDENTITY_DIR="$HOME/.lucinate/identity/localhost_18789"
 BACKUP_FILE="$IDENTITY_DIR/device-token.backup"

--- a/test/integration/setup-openclaw-ollama.sh
+++ b/test/integration/setup-openclaw-ollama.sh
@@ -192,17 +192,17 @@ else
     fail "Connection failed. Check gateway logs: docker compose -f $COMPOSE_FILE logs gateway"
 fi
 
-# --- Write .env for test runs ---------------------------------------------
+# --- Write integration.env for test runs ----------------------------------
 
-info "Writing test .env"
-cat > "$PROJECT_ROOT/.env" <<EOF
+info "Writing test integration.env"
+cat > "$SCRIPT_DIR/integration.env" <<EOF
 OPENCLAW_GATEWAY_URL=$GATEWAY_URL
 # The setup-code bootstrap profile grants read/write/approvals but not admin,
 # so the device token is bounded to those scopes. Request the matching set;
 # asking for operator.admin would be rejected as a scope mismatch.
 OPENCLAW_OPERATOR_SCOPES=operator.read,operator.write,operator.approvals
 EOF
-ok "Wrote .env with OPENCLAW_GATEWAY_URL=$GATEWAY_URL"
+ok "Wrote test/integration/integration.env with OPENCLAW_GATEWAY_URL=$GATEWAY_URL"
 
 # --- Done ------------------------------------------------------------------
 

--- a/test/integration/teardown-openclaw.sh
+++ b/test/integration/teardown-openclaw.sh
@@ -43,6 +43,17 @@ if [ -d "$STATE_DIR" ]; then
     ok "Removed gateway state directory"
 fi
 
+# --- Remove integration env ------------------------------------------------
+
+# The setup scripts write integration.env to bound the operator scopes for
+# test runs. Remove it on teardown so it can never leak into an interactive
+# `lucinate` launched from the repo and silently strip the operator.admin scope.
+ENV_FILE="$SCRIPT_DIR/integration.env"
+if [ -f "$ENV_FILE" ]; then
+    rm -f "$ENV_FILE"
+    ok "Removed integration.env"
+fi
+
 # --- Restore device token --------------------------------------------------
 
 if [ -f "$BACKUP_FILE" ]; then


### PR DESCRIPTION
Agent creation no longer fails when a leftover integration-test `.env` bounds operator scopes below `operator.admin`.

## Summary
- Integration setup scripts now write `test/integration/integration.env` instead of the repo-root `.env`, so the test environment can no longer leak into an interactive `lucinate` launched from the repo directory and silently strip `operator.admin`. The file is gitignored and removed on teardown.
- The client checks the scopes the gateway actually granted and fails admin-only operations (`CreateAgent`/`DeleteAgent`) fast with a message naming `OPENCLAW_OPERATOR_SCOPES`, and annotates the gateway's raw `missing scope: operator.admin` error as a fallback.
- Documented the `OPENCLAW_OPERATOR_SCOPES` override and the `.env` foot-gun in `docs/authentication.md`.
- Added unit tests for scope resolution and the error annotation.

## Implementation details
The gateway grants the intersection of the requested scopes and those the device token carries. Because `config.Load()` reads `.env` from the working directory, a stray `OPENCLAW_OPERATOR_SCOPES` bounded every connection regardless of which gateway was selected — so a token that genuinely held `operator.admin` was still rejected at `agents.create`. Isolating the test env file removes the leak at source; the granted-scope check turns the cryptic protocol error into an actionable one pointing at the likely cause.
