### PR TITLE
fix(tui): accept string content in chat history turns

### DIFF
--- a/internal/tui/backend_fake_test.go
+++ b/internal/tui/backend_fake_test.go
@@ -70,6 +70,11 @@ type fakeBackend struct {
 	// statusHook overrides the default /status payload so tests can
 	// inject backend-specific shapes (gateway block, history, thread).
 	statusHook func(ctx context.Context, agentID, sessionKey string) (*backend.BackendStatus, error)
+
+	// chatHistoryHook, when non-nil, replaces the default empty
+	// chat.history response so tests can stage the various gateway
+	// content shapes (string content, block arrays, mixed turns).
+	chatHistoryHook func(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error)
 }
 
 func newFakeBackend() *fakeBackend {
@@ -124,6 +129,9 @@ func (f *fakeBackend) ChatSend(ctx context.Context, sessionKey string, params ba
 }
 func (f *fakeBackend) ChatAbort(ctx context.Context, sessionKey, runID string) error { return nil }
 func (f *fakeBackend) ChatHistory(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
+	if f.chatHistoryHook != nil {
+		return f.chatHistoryHook(ctx, sessionKey, limit)
+	}
 	return json.RawMessage(`{"messages":[]}`), nil
 }
 func (f *fakeBackend) ModelsList(ctx context.Context) (*protocol.ModelsListResult, error) {

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -23,6 +23,47 @@ type historyMessage struct {
 	Timestamp int64              `json:"timestamp,omitempty"` // unix millis, when present
 }
 
+// UnmarshalJSON normalizes the message's content field, which the gateway
+// sends in either of the two Anthropic shapes: a plain string (the short
+// form) or an array of typed content blocks. A string payload is wrapped
+// in a single text block so the rest of the history pipeline can treat
+// both shapes uniformly. An unrecognised content shape leaves Content nil
+// rather than failing the whole load — one odd message must not blank the
+// entire conversation history.
+func (hm *historyMessage) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Role      string          `json:"role"`
+		Content   json.RawMessage `json:"content"`
+		Timestamp int64           `json:"timestamp,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	hm.Role = raw.Role
+	hm.Timestamp = raw.Timestamp
+	hm.Content = nil
+	if len(raw.Content) == 0 {
+		return nil
+	}
+	// Array form: typed content blocks.
+	var blocks []chatContentBlock
+	if err := json.Unmarshal(raw.Content, &blocks); err == nil {
+		hm.Content = blocks
+		return nil
+	}
+	// String form: wrap the text in a single text block.
+	var s string
+	if err := json.Unmarshal(raw.Content, &s); err == nil {
+		if s != "" {
+			hm.Content = []chatContentBlock{{Type: "text", Text: s}}
+		}
+		return nil
+	}
+	// Unknown shape — leave content empty so the message is skipped
+	// downstream instead of aborting the whole history load.
+	return nil
+}
+
 func (m chatModel) loadHistory() tea.Cmd {
 	sessionKey := m.sessionKey
 	b := m.backend

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -104,6 +106,167 @@ func TestBuildCronTranscriptMessages_DedupesIdenticalRunAndDeliveryError(t *test
 	}
 	if got := msgs[2].errMsg; got != "Run error: boom" {
 		t.Errorf("expected dedup'd 'Run error: boom'; got %q", got)
+	}
+}
+
+// TestHistoryMessageUnmarshalJSON pins the content-field normalisation
+// against the two Anthropic wire shapes a history turn may carry — a
+// plain string (the short form) and an array of typed blocks — plus the
+// empty/null/unknown fallbacks that must never abort the decode. The
+// string case is the direct regression guard for the gateway sending
+// content as a bare string, which previously failed the whole history
+// load with "cannot unmarshal string into ... []tui.chatContentBlock".
+func TestHistoryMessageUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantRole  string
+		wantTs    int64
+		wantBlock []chatContentBlock
+		wantErr   bool
+	}{
+		{
+			name:      "string content wrapped in text block",
+			raw:       `{"role":"user","content":"hello there"}`,
+			wantRole:  "user",
+			wantBlock: []chatContentBlock{{Type: "text", Text: "hello there"}},
+		},
+		{
+			name:      "string content preserves timestamp",
+			raw:       `{"role":"assistant","content":"hi","timestamp":1700000000000}`,
+			wantRole:  "assistant",
+			wantTs:    1700000000000,
+			wantBlock: []chatContentBlock{{Type: "text", Text: "hi"}},
+		},
+		{
+			name:     "empty string content yields no blocks",
+			raw:      `{"role":"user","content":""}`,
+			wantRole: "user",
+		},
+		{
+			name:     "array content preserved",
+			raw:      `{"role":"assistant","content":[{"type":"thinking","text":"hmm"},{"type":"text","text":"answer"}]}`,
+			wantRole: "assistant",
+			wantBlock: []chatContentBlock{
+				{Type: "thinking", Text: "hmm"},
+				{Type: "text", Text: "answer"},
+			},
+		},
+		{
+			name:     "empty array content",
+			raw:      `{"role":"user","content":[]}`,
+			wantRole: "user",
+		},
+		{
+			name:     "missing content key",
+			raw:      `{"role":"user"}`,
+			wantRole: "user",
+		},
+		{
+			name:     "null content",
+			raw:      `{"role":"user","content":null}`,
+			wantRole: "user",
+		},
+		{
+			name:     "unknown content shape left empty not error",
+			raw:      `{"role":"user","content":42}`,
+			wantRole: "user",
+		},
+		{
+			name:    "malformed json errors",
+			raw:     `{not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var hm historyMessage
+			err := json.Unmarshal([]byte(tc.raw), &hm)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hm.Role != tc.wantRole {
+				t.Errorf("role = %q, want %q", hm.Role, tc.wantRole)
+			}
+			if hm.Timestamp != tc.wantTs {
+				t.Errorf("timestamp = %d, want %d", hm.Timestamp, tc.wantTs)
+			}
+			if len(hm.Content) != len(tc.wantBlock) {
+				t.Fatalf("content = %+v, want %+v", hm.Content, tc.wantBlock)
+			}
+			for i, b := range hm.Content {
+				if b != tc.wantBlock[i] {
+					t.Errorf("content[%d] = %+v, want %+v", i, b, tc.wantBlock[i])
+				}
+			}
+		})
+	}
+}
+
+// TestFetchHistory_StringContentTurn reproduces the reported bug: a
+// gateway history payload whose turns carry content as a bare string
+// (rather than a block array) must load cleanly instead of failing the
+// whole conversation with an unmarshal error.
+func TestFetchHistory_StringContentTurn(t *testing.T) {
+	payload := `{"messages":[` +
+		`{"role":"user","content":"turn the lights on"},` +
+		`{"role":"assistant","content":"Done — lights are on."}` +
+		`]}`
+	fb := &fakeBackend{
+		chatHistoryHook: func(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
+			return json.RawMessage(payload), nil
+		},
+	}
+
+	msgs, err := fetchHistory(fb, "sess", nil, 50)
+	if err != nil {
+		t.Fatalf("fetchHistory returned error: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].role != "user" || msgs[0].content != "turn the lights on" {
+		t.Errorf("msgs[0] = %+v, want user 'turn the lights on'", msgs[0])
+	}
+	if msgs[1].role != "assistant" || msgs[1].content != "Done — lights are on." {
+		t.Errorf("msgs[1] = %+v, want assistant 'Done — lights are on.'", msgs[1])
+	}
+}
+
+// TestFetchHistory_MixedStringAndBlockTurns guards the realistic case
+// where a single conversation interleaves string-content and
+// block-array turns — a string turn must not break decoding of the
+// block turns around it.
+func TestFetchHistory_MixedStringAndBlockTurns(t *testing.T) {
+	payload := `{"messages":[` +
+		`{"role":"user","content":"first"},` +
+		`{"role":"assistant","content":[{"type":"thinking","text":"reasoning"},{"type":"text","text":"second"}]},` +
+		`{"role":"user","content":"third"}` +
+		`]}`
+	fb := &fakeBackend{
+		chatHistoryHook: func(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
+			return json.RawMessage(payload), nil
+		},
+	}
+
+	msgs, err := fetchHistory(fb, "sess", nil, 50)
+	if err != nil {
+		t.Fatalf("fetchHistory returned error: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[1].content != "second" {
+		t.Errorf("msgs[1].content = %q, want %q", msgs[1].content, "second")
+	}
+	if msgs[1].thinking != "reasoning" {
+		t.Errorf("msgs[1].thinking = %q, want %q", msgs[1].thinking, "reasoning")
 	}
 }
 


### PR DESCRIPTION
Loads conversation history correctly when the gateway sends a turn's content as a bare string rather than an array of typed blocks.

## Summary
- Opening an agent's conversation failed with `json: cannot unmarshal string into Go struct field historyMessage.messages.content of type []tui.chatContentBlock` whenever a history turn carried `content` as a plain string (the Anthropic short form) instead of a block array.
- Add a custom `historyMessage.UnmarshalJSON` that normalises both wire shapes: a string payload is wrapped in a single text block, while the existing block-array form is preserved. An unrecognised shape leaves the turn's content empty rather than aborting the whole load, so one odd message can never blank the entire conversation.
- Add regression tests covering the content-shape normalisation directly and an end-to-end `fetchHistory` test reproducing the reported failure, including a mixed string/block conversation.

## Implementation details
This mirrors the wire-boundary normalisation already used for chat events in `internal/backend/chatevent.go`, keeping the string-or-array handling at the decode boundary so the downstream history pipeline can treat every turn uniformly.