### PR TITLE
fix(client): stop disconnected-gateway send from crashing or hanging the TUI

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -18,6 +19,14 @@ import (
 
 	"github.com/lucinate-ai/lucinate/internal/config"
 )
+
+// ErrNotConnected is returned by RPC methods when the gateway client is
+// not currently attached — either before the first Connect, after Close,
+// or while the supervisor is between Reconnect attempts (the underlying
+// transport is rebuilt from scratch, so c.gw is briefly nil during each
+// retry). Surfaces as a clean error in the TUI's chat-send error path
+// instead of a nil-pointer panic.
+var ErrNotConnected = errors.New("gateway not connected")
 
 // IdentityStore abstracts persistence of the device keypair and device token.
 //
@@ -376,17 +385,58 @@ func (c *Client) Events() <-chan protocol.Event {
 	return c.events
 }
 
-// gw returns the current gateway client under read-lock. Callers must
-// handle nil (returned only before the first Connect succeeds).
-func (c *Client) currentGW() *gateway.Client {
+// currentGW returns the current gateway client under read-lock, or
+// ErrNotConnected when none is attached (before the first Connect, after
+// Close, or briefly between Reconnect attempts while the supervisor
+// retries a failed dial). Callers MUST propagate the error rather than
+// dereferencing the gw — Reconnect nils gw out before re-dialing so a
+// dial failure (e.g. tunnel drop) leaves it nil for the full backoff
+// window, and a stray dereference there is what panics the TUI.
+func (c *Client) currentGW() (*gateway.Client, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.gw
+	if c.gw == nil {
+		return nil, ErrNotConnected
+	}
+	return c.gw, nil
+}
+
+// defaultRPCTimeout bounds any gateway RPC whose caller did not already
+// set a deadline. It exists because a silently-dropped transport (a
+// tunnel that vanishes without a TCP close) leaves the SDK's request
+// loop waiting on a response that never arrives: the write succeeds into
+// the kernel send buffer, but the gateway is gone, and the SDK's internal
+// "connection closed" signal only fires once the OS TCP timeout lapses
+// minutes later. Without a deadline the calling goroutine — a chat send,
+// the post-send history refresh, a stats poll — would block for that
+// whole window. The bound turns the silent hang into a prompt error the
+// TUI can surface, while staying well above any healthy round-trip.
+const defaultRPCTimeout = 30 * time.Second
+
+// rpc is the single funnel every gateway RPC method goes through. It
+// returns the live gateway client (or ErrNotConnected) together with a
+// context bounded by defaultRPCTimeout, unless the caller already set its
+// own deadline. The returned cancel must always be called.
+func (c *Client) rpc(ctx context.Context) (*gateway.Client, context.Context, context.CancelFunc, error) {
+	gw, err := c.currentGW()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return gw, ctx, func() {}, nil
+	}
+	cctx, cancel := context.WithTimeout(ctx, defaultRPCTimeout)
+	return gw, cctx, cancel, nil
 }
 
 // ListAgents returns the list of available agents.
 func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, error) {
-	return c.currentGW().AgentsList(ctx)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.AgentsList(ctx)
 }
 
 // grantedScopes returns the operator scopes the gateway granted this
@@ -395,8 +445,8 @@ func (c *Client) ListAgents(ctx context.Context) (*protocol.AgentsListResult, er
 // on connect and those the device token actually carries, so it can be
 // narrower than defaultOperatorScopes.
 func (c *Client) grantedScopes() []string {
-	gw := c.currentGW()
-	if gw == nil {
+	gw, err := c.currentGW()
+	if err != nil {
 		return nil
 	}
 	if h := gw.Hello(); h != nil && h.Auth != nil {
@@ -448,7 +498,11 @@ func (c *Client) DeleteAgent(ctx context.Context, agentID string, deleteFiles bo
 	if err := c.requireAdminScope("agents delete"); err != nil {
 		return err
 	}
-	gw := c.currentGW()
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 	flag := deleteFiles
 	if _, err := gw.AgentsDelete(ctx, protocol.AgentsDeleteParams{
 		AgentID:     agentID,
@@ -465,7 +519,11 @@ func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error 
 	if err := c.requireAdminScope("agents create"); err != nil {
 		return err
 	}
-	gw := c.currentGW()
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 	result, err := gw.AgentsCreate(ctx, protocol.AgentsCreateParams{
 		Name:      name,
 		Workspace: workspace,
@@ -490,9 +548,14 @@ func (c *Client) CreateAgent(ctx context.Context, name, workspace string) error 
 
 // SessionsList lists sessions for the given agent.
 func (c *Client) SessionsList(ctx context.Context, agentID string) (json.RawMessage, error) {
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 	includeTitles := true
 	includeLastMsg := true
-	return c.currentGW().SessionsList(ctx, protocol.SessionsListParams{
+	return gw.SessionsList(ctx, protocol.SessionsListParams{
 		AgentID:              agentID,
 		IncludeDerivedTitles: &includeTitles,
 		IncludeLastMessage:   &includeLastMsg,
@@ -502,7 +565,12 @@ func (c *Client) SessionsList(ctx context.Context, agentID string) (json.RawMess
 // CreateSession creates or resumes a session for the given agent and returns
 // the gateway-assigned session key.
 func (c *Client) CreateSession(ctx context.Context, agentID, key string) (string, error) {
-	raw, err := c.currentGW().SessionsCreate(ctx, protocol.SessionsCreateParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer cancel()
+	raw, err := gw.SessionsCreate(ctx, protocol.SessionsCreateParams{
 		Key:     key,
 		AgentID: agentID,
 	})
@@ -520,7 +588,12 @@ func (c *Client) CreateSession(ctx context.Context, agentID, key string) (string
 
 // ChatSend sends a chat message and returns the initial ack.
 func (c *Client) ChatSend(ctx context.Context, sessionKey, message, idemKey string) (*protocol.ChatSendResult, error) {
-	return c.currentGW().ChatSend(ctx, protocol.ChatSendParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.ChatSend(ctx, protocol.ChatSendParams{
 		SessionKey:     sessionKey,
 		Message:        message,
 		IdempotencyKey: idemKey,
@@ -529,7 +602,12 @@ func (c *Client) ChatSend(ctx context.Context, sessionKey, message, idemKey stri
 
 // ChatHistory retrieves recent chat history for a session.
 func (c *Client) ChatHistory(ctx context.Context, sessionKey string, limit int) (json.RawMessage, error) {
-	return c.currentGW().ChatHistory(ctx, protocol.ChatHistoryParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.ChatHistory(ctx, protocol.ChatHistoryParams{
 		SessionKey: sessionKey,
 		Limit:      &limit,
 	})
@@ -537,8 +615,13 @@ func (c *Client) ChatHistory(ctx context.Context, sessionKey string, limit int) 
 
 // SessionUsage retrieves usage data for a session.
 func (c *Client) SessionUsage(ctx context.Context, sessionKey string) (json.RawMessage, error) {
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 	includeContext := true
-	return c.currentGW().SessionsUsage(ctx, protocol.SessionsUsageParams{
+	return gw.SessionsUsage(ctx, protocol.SessionsUsageParams{
 		Key:                  sessionKey,
 		IncludeContextWeight: &includeContext,
 	})
@@ -546,12 +629,22 @@ func (c *Client) SessionUsage(ctx context.Context, sessionKey string) (json.RawM
 
 // ModelsList returns the available models.
 func (c *Client) ModelsList(ctx context.Context) (*protocol.ModelsListResult, error) {
-	return c.currentGW().ModelsList(ctx)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.ModelsList(ctx)
 }
 
 // SessionPatchModel changes the model for a session.
 func (c *Client) SessionPatchModel(ctx context.Context, sessionKey, modelID string) error {
-	return c.currentGW().SessionsPatch(ctx, protocol.SessionsPatchParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.SessionsPatch(ctx, protocol.SessionsPatchParams{
 		Key:   sessionKey,
 		Model: &modelID,
 	})
@@ -559,7 +652,12 @@ func (c *Client) SessionPatchModel(ctx context.Context, sessionKey, modelID stri
 
 // SessionPatchThinking sets the thinking level for a session.
 func (c *Client) SessionPatchThinking(ctx context.Context, sessionKey, level string) error {
-	return c.currentGW().SessionsPatch(ctx, protocol.SessionsPatchParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.SessionsPatch(ctx, protocol.SessionsPatchParams{
 		Key:           sessionKey,
 		ThinkingLevel: &level,
 	})
@@ -569,8 +667,13 @@ func (c *Client) SessionPatchThinking(ctx context.Context, sessionKey, level str
 // TwoPhase is set so the gateway returns immediately with status "accepted"
 // and the decision arrives asynchronously via an exec.approval.resolved event.
 func (c *Client) ExecRequest(ctx context.Context, command, sessionKey string) (*protocol.ExecApprovalRequestResult, error) {
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 	twoPhase := true
-	return c.currentGW().ExecApprovalRequest(ctx, protocol.ExecApprovalRequestParams{
+	return gw.ExecApprovalRequest(ctx, protocol.ExecApprovalRequestParams{
 		Command:    command,
 		SessionKey: &sessionKey,
 		TwoPhase:   &twoPhase,
@@ -579,7 +682,12 @@ func (c *Client) ExecRequest(ctx context.Context, command, sessionKey string) (*
 
 // ExecResolve approves or denies a pending exec approval.
 func (c *Client) ExecResolve(ctx context.Context, id, decision string) (*protocol.ExecApprovalResolveResult, error) {
-	return c.currentGW().ExecApprovalResolve(ctx, protocol.ExecApprovalResolveParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.ExecApprovalResolve(ctx, protocol.ExecApprovalResolveParams{
 		ID:       id,
 		Decision: decision,
 	})
@@ -587,7 +695,12 @@ func (c *Client) ExecResolve(ctx context.Context, id, decision string) (*protoco
 
 // ChatAbort aborts a running chat turn.
 func (c *Client) ChatAbort(ctx context.Context, sessionKey, runID string) error {
-	return c.currentGW().ChatAbort(ctx, protocol.ChatAbortParams{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.ChatAbort(ctx, protocol.ChatAbortParams{
 		SessionKey: sessionKey,
 		RunID:      runID,
 	})
@@ -595,13 +708,23 @@ func (c *Client) ChatAbort(ctx context.Context, sessionKey, runID string) error 
 
 // SessionCompact compacts (summarises) the session context.
 func (c *Client) SessionCompact(ctx context.Context, sessionKey string) error {
-	return c.currentGW().SessionsCompact(ctx, protocol.SessionsCompactParams{Key: sessionKey})
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.SessionsCompact(ctx, protocol.SessionsCompactParams{Key: sessionKey})
 }
 
 // SessionDelete deletes a session and its transcript.
 func (c *Client) SessionDelete(ctx context.Context, sessionKey string) error {
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 	deleteTranscript := true
-	return c.currentGW().SessionsDelete(ctx, protocol.SessionsDeleteParams{
+	return gw.SessionsDelete(ctx, protocol.SessionsDeleteParams{
 		Key:              sessionKey,
 		DeleteTranscript: &deleteTranscript,
 	})
@@ -609,7 +732,12 @@ func (c *Client) SessionDelete(ctx context.Context, sessionKey string) error {
 
 // GatewayHealth retrieves the gateway health snapshot.
 func (c *Client) GatewayHealth(ctx context.Context) (*protocol.HealthEvent, error) {
-	raw, err := c.currentGW().Health(ctx)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	raw, err := gw.Health(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("health: %w", err)
 	}
@@ -623,8 +751,8 @@ func (c *Client) GatewayHealth(ctx context.Context) (*protocol.HealthEvent, erro
 // HelloUptimeMs returns the gateway uptime in milliseconds from the connect
 // handshake, or 0 if not connected.
 func (c *Client) HelloUptimeMs() int64 {
-	gw := c.currentGW()
-	if gw == nil {
+	gw, err := c.currentGW()
+	if err != nil {
 		return 0
 	}
 	if h := gw.Hello(); h != nil {
@@ -636,8 +764,8 @@ func (c *Client) HelloUptimeMs() int64 {
 // HelloServerVersion returns the gateway's reported version string from the
 // connect handshake, or "" if not connected or unknown.
 func (c *Client) HelloServerVersion() string {
-	gw := c.currentGW()
-	if gw == nil {
+	gw, err := c.currentGW()
+	if err != nil {
 		return ""
 	}
 	if h := gw.Hello(); h != nil {
@@ -649,8 +777,8 @@ func (c *Client) HelloServerVersion() string {
 // HelloProtocol returns the protocol (API) version negotiated with the gateway
 // during the connect handshake, or 0 if not connected/unknown.
 func (c *Client) HelloProtocol() int {
-	gw := c.currentGW()
-	if gw == nil {
+	gw, err := c.currentGW()
+	if err != nil {
 		return 0
 	}
 	if h := gw.Hello(); h != nil {
@@ -693,22 +821,42 @@ func (c *Client) StoreToken(token string) error {
 
 // CronsList lists cron jobs on the gateway.
 func (c *Client) CronsList(ctx context.Context, params protocol.CronListParams) (*protocol.CronListResult, error) {
-	return c.currentGW().CronList(ctx, params)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.CronList(ctx, params)
 }
 
 // CronRuns retrieves the run history for a cron job (or all jobs).
 func (c *Client) CronRuns(ctx context.Context, params protocol.CronRunsParams) (*protocol.CronRunsResult, error) {
-	return c.currentGW().CronRuns(ctx, params)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.CronRuns(ctx, params)
 }
 
 // CronAdd creates a new cron job.
 func (c *Client) CronAdd(ctx context.Context, params protocol.CronAddParams) (json.RawMessage, error) {
-	return c.currentGW().CronAdd(ctx, params)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return gw.CronAdd(ctx, params)
 }
 
 // CronUpdate updates an existing cron job.
 func (c *Client) CronUpdate(ctx context.Context, params protocol.CronUpdateParams) error {
-	return c.currentGW().CronUpdate(ctx, params)
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.CronUpdate(ctx, params)
 }
 
 // CronUpdateRaw updates an existing cron job using a raw patch map.
@@ -719,7 +867,12 @@ func (c *Client) CronUpdate(ctx context.Context, params protocol.CronUpdateParam
 // The form-edit flow uses this so clearing the model or description
 // fields actually persists.
 func (c *Client) CronUpdateRaw(ctx context.Context, jobID string, patch map[string]any) error {
-	resp, err := c.currentGW().Send(ctx, string(protocol.MethodCronUpdate), map[string]any{
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	resp, err := gw.Send(ctx, string(protocol.MethodCronUpdate), map[string]any{
 		"id":    jobID,
 		"patch": patch,
 	})
@@ -734,23 +887,37 @@ func (c *Client) CronUpdateRaw(ctx context.Context, jobID string, patch map[stri
 
 // CronRemove deletes a cron job.
 func (c *Client) CronRemove(ctx context.Context, jobID string) error {
-	return c.currentGW().CronRemove(ctx, protocol.CronRemoveParams{ID: jobID})
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	return gw.CronRemove(ctx, protocol.CronRemoveParams{ID: jobID})
 }
 
 // CronRun manually triggers a cron job. When force is true, the job runs
 // regardless of its schedule; otherwise it only runs if currently due.
 func (c *Client) CronRun(ctx context.Context, jobID string, force bool) error {
+	gw, ctx, cancel, err := c.rpc(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 	mode := "due"
 	if force {
 		mode = "force"
 	}
-	return c.currentGW().CronRun(ctx, protocol.CronRunParams{ID: jobID, Mode: mode})
+	return gw.CronRun(ctx, protocol.CronRunParams{ID: jobID, Mode: mode})
 }
 
 // GW returns the underlying gateway client (for direct RPC access).
 // May return nil if no connection has been established yet, or briefly
-// during a reconnect cycle.
-func (c *Client) GW() *gateway.Client { return c.currentGW() }
+// during a reconnect cycle — callers must handle the nil case (the TUI's
+// capability-assertion sites already do).
+func (c *Client) GW() *gateway.Client {
+	gw, _ := c.currentGW()
+	return gw
+}
 
 // Close closes the gateway connection.
 func (c *Client) Close() error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/a3tai/openclaw-go/gateway"
 	"github.com/a3tai/openclaw-go/identity"
 
 	"github.com/lucinate-ai/lucinate/internal/config"
@@ -197,6 +200,87 @@ func TestDone_PreClosedWhenNotConnected(t *testing.T) {
 	case <-ch:
 	case <-time.After(50 * time.Millisecond):
 		t.Fatal("Done() channel was not pre-closed when no gateway is attached")
+	}
+}
+
+// TestRPCsReturnErrNotConnectedWhenGWNil pins the contract that RPC
+// methods surface a clean ErrNotConnected when the gateway client is
+// not attached, instead of dereferencing nil. The original bug: a
+// dropped tailscale tunnel left the supervisor mid-reconnect with
+// c.gw == nil; ChatSend then panicked when the user hit Enter.
+func TestRPCsReturnErrNotConnectedWhenGWNil(t *testing.T) {
+	c := NewWithIdentityStore(&config.Config{}, &fakeIdentityStore{})
+
+	if _, err := c.ChatSend(context.Background(), "sess", "hi", "idem"); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("ChatSend: got %v, want ErrNotConnected", err)
+	}
+	if err := c.ChatAbort(context.Background(), "sess", "run"); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("ChatAbort: got %v, want ErrNotConnected", err)
+	}
+	if _, err := c.ListAgents(context.Background()); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("ListAgents: got %v, want ErrNotConnected", err)
+	}
+	if _, err := c.CreateSession(context.Background(), "agent", "main"); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("CreateSession: got %v, want ErrNotConnected", err)
+	}
+}
+
+// TestRPC_BoundsContextWhenNoDeadline pins the anti-hang contract: an RPC
+// whose caller passed a deadline-less context (every TUI background cmd
+// uses context.Background()) is given defaultRPCTimeout, so a silently
+// dropped transport cannot park the calling goroutine forever waiting on
+// a reply that never comes.
+func TestRPC_BoundsContextWhenNoDeadline(t *testing.T) {
+	c := NewWithIdentityStore(&config.Config{}, &fakeIdentityStore{})
+	// A non-nil gateway is required to reach the context-bounding path;
+	// rpc makes no network call, so an unconnected client is fine here.
+	c.gw = gateway.NewClient()
+
+	_, ctx, cancel, err := c.rpc(context.Background())
+	if err != nil {
+		t.Fatalf("rpc: unexpected error %v", err)
+	}
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("rpc did not bound a deadline-less context")
+	}
+	if d := time.Until(deadline); d <= 0 || d > defaultRPCTimeout+time.Second {
+		t.Errorf("deadline %v out of expected ~%v window", d, defaultRPCTimeout)
+	}
+}
+
+// TestRPC_RespectsCallerDeadline pins that rpc does not override a
+// deadline the caller already set (so a caller wanting a tighter or
+// looser bound keeps it).
+func TestRPC_RespectsCallerDeadline(t *testing.T) {
+	c := NewWithIdentityStore(&config.Config{}, &fakeIdentityStore{})
+	c.gw = gateway.NewClient()
+
+	caller, callerCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer callerCancel()
+
+	_, ctx, cancel, err := c.rpc(caller)
+	if err != nil {
+		t.Fatalf("rpc: unexpected error %v", err)
+	}
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("rpc dropped the caller's deadline")
+	}
+	if d := time.Until(deadline); d > 3*time.Second {
+		t.Errorf("rpc widened the caller's 2s deadline to %v", d)
+	}
+}
+
+// TestRPC_ReturnsErrNotConnected pins that rpc surfaces ErrNotConnected
+// (and a no-op cancel is unnecessary because cancel is nil) when no
+// gateway is attached.
+func TestRPC_ReturnsErrNotConnected(t *testing.T) {
+	c := NewWithIdentityStore(&config.Config{}, &fakeIdentityStore{})
+	if _, _, _, err := c.rpc(context.Background()); !errors.Is(err, ErrNotConnected) {
+		t.Errorf("rpc with no gateway: got %v, want ErrNotConnected", err)
 	}
 }
 

--- a/internal/tui/send_disconnect_integration_test.go
+++ b/internal/tui/send_disconnect_integration_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package tui
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	openclawBackend "github.com/lucinate-ai/lucinate/internal/backend/openclaw"
+	"github.com/lucinate-ai/lucinate/internal/client"
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// dockerGatewayContainer is the compose service container name for the local
+// integration gateway. The repro drops it mid-session to mimic the gateway
+// becoming unreachable under an established WebSocket.
+const dockerGatewayContainer = "integration-gateway-1"
+
+// dockerCmd runs a docker subcommand and fails the test on error.
+func dockerCmd(t *testing.T, args ...string) {
+	t.Helper()
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker %v: %v\n%s", args, err, out)
+	}
+	t.Logf("docker %v: %s", args, out)
+}
+
+// TestSendWhileDisconnected_Integration reproduces the crash report: with an
+// established connection to the gateway, the transport drops and the user
+// submits a message.
+//
+// LUCINATE_DROP_MODE selects how the gateway goes away:
+//   - "stop" (default): `docker stop` — a clean WebSocket close. The SDK read
+//     loop ends, the supervisor nils out the gateway client and re-dials (which
+//     fails while the container is down), so the submission lands while
+//     c.gw == nil. This is the path the original panic came from.
+//   - "pause": `docker pause` — freezes the container with no FIN/RST, exactly
+//     like a tailscale tunnel disappearing. The write blocks indefinitely; the
+//     submission goroutine hangs rather than returning.
+//
+// It drives the same plumbing app.go runs: an events pump and the connection
+// supervisor, both feeding tea messages into the model, with submission going
+// through the full chatModel.Update path. The submission runs in a goroutine
+// with NO panic recover, so any nil-deref crashes the test process with a full
+// stack trace; a hang is detected by timeout instead of blocking the suite.
+//
+// Run with:
+//
+//	docker compose -f test/integration/docker-compose.yml up -d --wait
+//	go test -tags integration -run TestSendWhileDisconnected ./internal/tui/ -v -count=1
+func TestSendWhileDisconnected_Integration(t *testing.T) {
+	dropMode := os.Getenv("LUCINATE_DROP_MODE")
+	if dropMode == "" {
+		dropMode = "stop"
+	}
+
+	// Always restore the gateway on exit so the next run finds it healthy.
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "unpause", dockerGatewayContainer).Run()
+		_ = exec.Command("docker", "start", dockerGatewayContainer).Run()
+	})
+
+	c := connectTestClient(t)
+	defer c.Close()
+
+	agents, err := c.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("list agents: %v", err)
+	}
+	if len(agents.Agents) == 0 {
+		t.Fatal("no agents available on gateway")
+	}
+	agentName := agents.Agents[0].Name
+	if agentName == "" {
+		agentName = agents.Agents[0].ID
+	}
+
+	// Build the model through the production constructor so the textarea,
+	// viewport and renderer are fully initialised — chatModel.Update has a
+	// value receiver returning a value, so we drive a chatModel value.
+	b := openclawBackend.New(c)
+	m := newChatModel(b, agents.MainKey, agents.Agents[0].ID, agentName, "", config.Preferences{}, false, "localhost", "", false)
+	m.historyLoading = false
+	m.connState = ConnStateMsg{Status: client.StatusConnected}
+
+	// msgCh carries every tea.Msg the model would receive in the real app:
+	// gateway events and connection-state transitions.
+	msgCh := make(chan tea.Msg, 64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Events pump — mirrors app.go's first driver goroutine.
+	go func() {
+		defer wg.Done()
+		events := c.Events()
+		for {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					return
+				}
+				select {
+				case msgCh <- GatewayEventMsg(ev):
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Supervisor — mirrors app.go's second driver goroutine. On the transport
+	// drop this nils out the gateway client and emits Disconnected/Reconnecting.
+	go func() {
+		defer wg.Done()
+		c.Supervise(ctx, func(s client.ConnState) {
+			select {
+			case msgCh <- ConnStateMsg{Status: s.Status, Attempt: s.Attempt, Err: s.Err}:
+			case <-ctx.Done():
+			}
+		})
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	// observed receives every non-batch tea.Msg runCmd produces, so the
+	// submission can assert on the send's own result (chatSentMsg) rather
+	// than on the whole transitive cmd chain — the post-send history refresh
+	// is a separate, independently-bounded RPC and would otherwise stack its
+	// own timeout onto the measurement.
+	observed := make(chan tea.Msg, 64)
+
+	// runCmd executes a tea.Cmd the way the program loop would, fanning out
+	// batches sequentially, and routes any produced msg back into the model.
+	// No recover(): a panic here is the bug we are hunting and should abort
+	// the test with a stack trace.
+	var runCmd func(cmd tea.Cmd)
+	runCmd = func(cmd tea.Cmd) {
+		if cmd == nil {
+			return
+		}
+		msg := cmd()
+		if msg == nil {
+			return
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				runCmd(sub)
+			}
+			return
+		}
+		select {
+		case observed <- msg:
+		default:
+		}
+		m, cmd = m.Update(msg)
+		runCmd(cmd)
+	}
+
+	// Drop the gateway.
+	switch dropMode {
+	case "pause":
+		t.Log(">>> pausing gateway container (silent freeze, no clean close)")
+		dockerCmd(t, "pause", dockerGatewayContainer)
+	default:
+		t.Log(">>> stopping gateway container (clean WebSocket close)")
+		dockerCmd(t, "stop", dockerGatewayContainer)
+	}
+
+	// Wait until the supervisor reports a non-connected state, draining msgCh
+	// through Update as the program loop would. For the "stop" path this is
+	// deterministic (clean close → Disconnected within ~1s). For "pause" it
+	// may never fire before the TCP keepalive lapses, so cap the wait.
+	deadline := time.After(20 * time.Second)
+	sawDrop := false
+waitDrop:
+	for !sawDrop {
+		select {
+		case msg := <-msgCh:
+			if cs, ok := msg.(ConnStateMsg); ok && cs.Status != client.StatusConnected {
+				sawDrop = true
+			}
+			var cmd tea.Cmd
+			m, cmd = m.Update(msg)
+			runCmd(cmd)
+		case <-deadline:
+			t.Logf("note: no disconnect state observed within deadline (drop mode %q)", dropMode)
+			break waitDrop
+		}
+	}
+
+	// Now the user types a message and hits Enter while disconnected. Run it in
+	// a goroutine so a hung write (the "pause" path) does not block the suite;
+	// a panic still crashes the process with a stack trace.
+	t.Logf(">>> submitting message while disconnected (sending=%v connState=%v sawDrop=%v)", m.sending, m.connState.Status, sawDrop)
+	m.textarea.SetValue("hello while disconnected")
+
+	go func() {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+		runCmd(cmd)
+	}()
+
+	// The send must produce its chatSentMsg result — panic-free, and bounded.
+	// On the "stop" path it returns almost immediately via ErrNotConnected; on
+	// the "pause" path it blocks on the dead transport until the client's
+	// defaultRPCTimeout turns it into an error. The guard sits above that one
+	// timeout with margin; before the fix the send blocked forever. Follow-up
+	// RPCs (the history refresh) are each independently bounded and run on in
+	// the background — not part of this measurement.
+	const sendGuard = 45 * time.Second
+	for {
+		select {
+		case msg := <-observed:
+			if sent, ok := msg.(chatSentMsg); ok {
+				t.Logf(">>> send returned without panic or unbounded hang (err=%v)", sent.err)
+				return
+			}
+		case <-time.After(sendGuard):
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			t.Logf("goroutine dump at hang:\n%s", buf[:n])
+			t.Fatal("send hung past the RPC timeout — a gateway call blocked on a dead transport without a deadline")
+		}
+	}
+}


### PR DESCRIPTION
Sending a chat message while the gateway connection is down no longer crashes the TUI with a nil-pointer panic, nor hangs the send forever — both now surface a clean, prompt error.

## Summary
- **Panic fix:** `Client.currentGW()` returns `(*gateway.Client, error)` with a new `ErrNotConnected` sentinel when no gateway is attached — before the first connect, after close, or (the reported case) while the supervisor is between reconnect attempts and has nilled out the client. The original crash was a nil `*gateway.Client` receiver in `ChatSend`.
- **Hang fix:** every gateway RPC now funnels through `Client.rpc()`, which bounds a deadline-less context with `defaultRPCTimeout` (30s). On a silently-dropped transport (a tunnel that vanishes without a TCP close) the gateway's ack never arrives and the SDK's request loop would otherwise block until the OS TCP timeout lapses minutes later.
- The TUI's existing chat-send error path renders the resulting error inline and unlocks the input, so a send while disconnected shows a message instead of a crash or an endless spinner.
- Added unit coverage for both contracts (`ErrNotConnected` propagation; `rpc()` deadline behaviour) and an integration repro that drops the local gateway mid-session — both a clean close (`docker stop`) and a silent freeze (`docker pause`).

## Implementation details
Two distinct failure modes share one root: the chat-send path assumed a live gateway.

The panic was a nil receiver: when a tunnel drops, the supervisor calls `Reconnect`, which sets `c.gw = nil` before re-dialing; while the dial keeps failing, `c.gw` stays nil for the whole backoff window and `c.currentGW().ChatSend(...)` segfaulted in the SDK. Routing every caller through the error return closes the entire class, not just `ChatSend`.

The hang is subtler and only appears on a *silent* drop, where the supervisor never sees a close so `c.gw` stays non-nil: the write buffers into the dead socket and the SDK waits on a reply that never comes. The post-send history refresh (`drainQueue → ChatHistory`) hit this too, which is why the fix is centralised at `rpc()` rather than at the send call site — it bounds the whole RPC surface uniformly.

Verified against the local openclaw+ollama integration gateway: `docker stop` reproduces the original panic on pre-fix code with the exact reported stack and passes with the fix; `docker pause` (silent freeze) hangs forever pre-fix and now returns a `context deadline exceeded` error within the timeout.