### PR TITLE
fix(tui): restore originating chat on esc from crons list

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -138,6 +138,15 @@ type AppModel struct {
 	// View() that emits the mode lives on AppModel.
 	mouseCapture bool
 
+	// cronsReturnChat preserves the chat the user was viewing when they
+	// opened the cron browser. Opening a run transcript rebuilds chatModel
+	// in place (see cronTranscriptMsg), so without this the esc-from-crons
+	// path would strand the user on the transcript instead of the screen
+	// they came from. Captured the first time a transcript replaces the
+	// live chat and restored when leaving the cron browser.
+	cronsReturnChat  chatModel
+	cronsReturnValid bool
+
 	onInputFocusChanged func(bool)
 	lastWantsInput      bool
 	inputFocusReported  bool
@@ -652,10 +661,22 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		}
 		m.cronsModel = newCronsModel(cron, msg.filterAgentID, msg.filterLabel, m.hideActionHints, m.activeConn, m.disableExitKeys)
 		m.cronsModel.setSize(m.width, m.height)
+		// Fresh excursion: forget any chat preserved by a prior one.
+		m.cronsReturnValid = false
 		m.state = viewCrons
 		return m, m.cronsModel.Init()
 
 	case goBackFromCronsMsg:
+		// If a transcript replaced the live chat during this excursion,
+		// restore the chat the user opened the crons list from so esc
+		// lands them back on the screen they came from.
+		if m.cronsReturnValid {
+			m.chatModel = m.cronsReturnChat
+			m.cronsReturnChat = chatModel{}
+			m.cronsReturnValid = false
+			m.chatModel.setSize(m.width, m.height)
+			m.chatModel.updateViewport()
+		}
 		m.state = viewChat
 		return m, nil
 
@@ -692,6 +713,13 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 		// same data the run-history previews on the cron-detail page
 		// already use.
 		_, _ = m.chatModel.stopRecording()
+		// Preserve the chat the user came from (only the first time, so a
+		// second transcript view doesn't overwrite it with a transcript)
+		// so esc out of the crons list can restore it.
+		if !m.cronsReturnValid {
+			m.cronsReturnChat = m.chatModel
+			m.cronsReturnValid = true
+		}
 		m.chatModel = newChatModel(m.backend, "", msg.job.AgentID, msg.agentName, "", m.prefs, true, connectionLabel(m.activeConn), "", m.brightCursor)
 		m.chatModel.setSize(m.width, m.height)
 		m.chatModel.messages = buildCronTranscriptMessages(cronPayloadText(msg.job), msg.runs, m.chatModel.renderer)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -306,6 +306,84 @@ func runCmd(t *testing.T, cmd tea.Cmd) {
 	}
 }
 
+// TestAppModel_EscFromCrons_RestoresOriginalChat: opening a cron run
+// transcript rebuilds chatModel in place, so esc out of the crons list
+// must restore the chat the user opened the list from rather than
+// stranding them on the transcript.
+func TestAppModel_EscFromCrons_RestoresOriginalChat(t *testing.T) {
+	fake := newFakeBackend()
+	m := AppModel{backend: fake, width: 120, height: 40}
+	m.chatModel = newChatModel(fake, "orig-session", "agent-1", "Scout", "", config.Preferences{}, false, "", "", false)
+	m.chatModel.setSize(120, 40)
+	m.state = viewCrons
+
+	// Open a run transcript: this clobbers the live chat in place.
+	updated, _ := m.Update(cronTranscriptMsg{job: sampleJobs()[0], agentName: "Scout"})
+	m = updated.(AppModel)
+	if !m.cronsReturnValid {
+		t.Fatal("expected the original chat to be preserved when a transcript opens")
+	}
+	if !m.chatModel.transcript {
+		t.Fatal("expected the live chat to be the transcript after cronTranscriptMsg")
+	}
+
+	// Esc out of the crons list must put the original chat back.
+	updated, _ = m.Update(goBackFromCronsMsg{})
+	m = updated.(AppModel)
+	if m.state != viewChat {
+		t.Errorf("expected viewChat after esc from crons, got %v", m.state)
+	}
+	if m.chatModel.transcript {
+		t.Error("expected the original (non-transcript) chat to be restored")
+	}
+	if m.chatModel.sessionKey != "orig-session" {
+		t.Errorf("expected original session restored, got %q", m.chatModel.sessionKey)
+	}
+	if m.cronsReturnValid {
+		t.Error("expected the preserved chat to be released after restore")
+	}
+}
+
+// TestAppModel_ShowCrons_ClearsStalePreservedChat: each fresh crons
+// excursion must forget any chat preserved by a previous one, so an esc
+// that never opened a transcript doesn't restore a stale chat.
+func TestAppModel_ShowCrons_ClearsStalePreservedChat(t *testing.T) {
+	fake := newFakeBackend()
+	m := AppModel{backend: fake, width: 120, height: 40}
+	m.chatModel = newChatModel(fake, "orig-session", "agent-1", "Scout", "", config.Preferences{}, false, "", "", false)
+	m.state = viewChat
+	// Leftover state from a prior excursion that ended abnormally.
+	m.cronsReturnValid = true
+
+	updated, _ := m.Update(showCronsMsg{filterAgentID: "agent-1", filterLabel: "Scout"})
+	m = updated.(AppModel)
+	if m.state != viewCrons {
+		t.Errorf("expected viewCrons after showCronsMsg, got %v", m.state)
+	}
+	if m.cronsReturnValid {
+		t.Error("expected a fresh crons excursion to clear any preserved chat")
+	}
+}
+
+// TestAppModel_EscFromCrons_NoTranscriptLeavesChatUntouched: when the
+// user never opened a transcript there is nothing to restore, so esc
+// just returns to the (untouched) chat.
+func TestAppModel_EscFromCrons_NoTranscriptLeavesChatUntouched(t *testing.T) {
+	fake := newFakeBackend()
+	m := AppModel{backend: fake, width: 120, height: 40}
+	m.chatModel = newChatModel(fake, "orig-session", "agent-1", "Scout", "", config.Preferences{}, false, "", "", false)
+	m.state = viewCrons
+
+	updated, _ := m.Update(goBackFromCronsMsg{})
+	m = updated.(AppModel)
+	if m.state != viewChat {
+		t.Errorf("expected viewChat after esc from crons, got %v", m.state)
+	}
+	if m.chatModel.sessionKey != "orig-session" {
+		t.Errorf("expected chat left untouched, got session %q", m.chatModel.sessionKey)
+	}
+}
+
 // TestAppModel_SessionCreatedError_ClearsSelectingLock: an error from
 // CreateSession bounces the user back to the agent picker; the picker's
 // `selecting` flag must be cleared in the same step so it doesn't stay


### PR DESCRIPTION
Escaping out of the crons list now returns the user to the screen they opened it from, instead of stranding them on a run transcript.

## Summary
- Preserve the chat the user was viewing when a cron run transcript replaces it in place, and restore it when leaving the crons browser
- Esc from the crons list now lands back on the originating chat session rather than the transcript
- Each fresh crons excursion clears any preserved chat from a previous one
- Add app-level tests covering the restore, no-transcript, and stale-state paths

## Implementation details
Opening a run transcript rebuilds `chatModel` in place (the transcript reuses the chat view), so the previous esc path returned to `viewChat` showing the transcript rather than the user's session. The original chat is now captured the first time a transcript replaces it — after recording is stopped, so the restored model carries no dangling recorder — and restored on `goBackFromCronsMsg`. Capturing at replace time (rather than snapshotting on open) avoids clobbering legitimate background updates to the chat that arrive while the crons browser is active.
