### PR TITLE
feat: add OnExit callback for host-driven quit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -170,6 +170,22 @@ type RunOptions struct {
 	// terminal that can't otherwise dismiss it, leaves this false.
 	DisableExitKeys bool
 
+	// OnExit, if non-nil, is invoked when the user requests a quit
+	// (/quit, the Quit action, q on a navigation screen, ctrl+c). It
+	// makes the host responsible for teardown instead of the program
+	// calling tea.Quit itself, which only stops the render loop — fine
+	// for a CLI returning to its shell, but on an embedder whose own
+	// surface (a window, a terminal view) outlives the loop it would
+	// leave a frozen final frame on screen. Such embedders set OnExit to
+	// a callback that closes that surface (and whose teardown path then
+	// calls Program.Quit); the program keeps rendering normally until
+	// that happens. When set it takes precedence over DisableExitKeys,
+	// re-enabling the quit affordances but routing them to the host.
+	// The CLI leaves it nil and relies on tea.Quit. Runs from a tea.Cmd
+	// goroutine — embedders that touch UI on a main thread should
+	// trampoline accordingly.
+	OnExit func()
+
 	// BrightCursor pins the chat composer's textarea cursor on-frame to
 	// ANSI 15 (bright white) instead of Bubbles' default ANSI 7 (light
 	// grey). Bubbles renders the on-frame as `Style.Reverse(true)` over
@@ -314,6 +330,7 @@ func New(opts RunOptions) (*Program, error) {
 		HideInputArea:         opts.HideInputArea,
 		HideActionHints:       opts.HideActionHints,
 		DisableExitKeys:       opts.DisableExitKeys,
+		OnExit:                opts.OnExit,
 		BrightCursor:          opts.BrightCursor,
 		OnInputFocusChanged:   opts.OnInputFocusChanged,
 		OnActionsChanged:      opts.OnActionsChanged,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -42,6 +42,17 @@ type AppOptions struct {
 	HideActionHints bool
 	DisableExitKeys bool
 
+	// OnExit, if non-nil, is invoked when the user requests a quit
+	// (/quit, the Quit action, q on a navigation screen, ctrl+c) and
+	// makes the host responsible for tearing the program down. It exists
+	// for embedders mounted inside a host whose own surface outlives the
+	// TUI loop: there, tea.Quit would stop rendering but leave the host
+	// view showing a frozen frame, so instead the program asks the host
+	// to terminate (and let its teardown path call Program.Quit). When
+	// set it takes precedence over DisableExitKeys. The CLI leaves it nil
+	// and relies on tea.Quit. See app.RunOptions for the full rationale.
+	OnExit func()
+
 	// BrightCursor pins the chat textarea cursor's on-frame to ANSI 15
 	// (bright white) instead of Bubbles' default ANSI 7. See
 	// app.RunOptions for the full rationale; this is the unexported
@@ -129,6 +140,7 @@ type AppModel struct {
 	hideInput        bool
 	hideActionHints  bool
 	disableExitKeys  bool
+	onExit           func()
 	brightCursor     bool
 	managed          bool
 
@@ -198,6 +210,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 		hideInput:             opts.HideInputArea,
 		hideActionHints:       opts.HideActionHints,
 		disableExitKeys:       opts.DisableExitKeys,
+		onExit:                opts.OnExit,
 		brightCursor:          opts.BrightCursor,
 		store:                 opts.Store,
 		backendFactory:        opts.BackendFactory,
@@ -277,6 +290,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // transition through OnActionsChanged so embedders can rebuild their
 // action UI without polling.
 func (m AppModel) Actions() []Action {
+	return m.withExitAction(m.viewActions())
+}
+
+// viewActions returns the active view's own action list, before the
+// app-level Quit action is mixed in.
+func (m AppModel) viewActions() []Action {
 	switch m.state {
 	case viewConnections:
 		return m.connectionsModel.Actions()
@@ -300,11 +319,29 @@ func (m AppModel) Actions() []Action {
 	return nil
 }
 
+// withExitAction appends a Quit action when the host delegates exit to
+// us, so an embedder rendering actions as native controls always offers
+// a way out. Suppressed on views with a focused text input (where q is
+// a literal character and the inline "q: quit" hint would mislead) so
+// it tracks the same screens the q shortcut quits on. The CLI leaves
+// hostDrivenExit false and keeps bubbles' own quit footer instead.
+func (m AppModel) withExitAction(actions []Action) []Action {
+	if !m.hostDrivenExit() || m.computeWantsInput() {
+		return actions
+	}
+	return append(actions, Action{ID: "quit", Label: "Quit", Key: "q"})
+}
+
 // TriggerAction routes an embedder-issued action invocation to the
 // active view. Both keystrokes (handled inside each view's KeyPressMsg
 // switch) and external triggers (Program.TriggerAction) go through the
 // view's TriggerAction so the work lives in one place.
 func (m AppModel) TriggerAction(id string) (AppModel, tea.Cmd) {
+	// The Quit action is owned by the AppModel, not any single view, so
+	// intercept it before delegating — the views don't know about it.
+	if id == "quit" {
+		return m, m.requestExit()
+	}
 	switch m.state {
 	case viewConnections:
 		var cmd tea.Cmd
@@ -395,6 +432,46 @@ func (m AppModel) computeWantsInput() bool {
 		return m.askConfigModel.wantsInput()
 	}
 	return false
+}
+
+// exitUnavailableNotice is shown when the user asks to quit on a host
+// that can't terminate itself. Phrased platform-neutrally: the core
+// has no concept of which host it's embedded in.
+const exitUnavailableNotice = "Quitting isn't available here — use your device's app switcher to leave."
+
+// requestExit resolves a user quit request into the command appropriate
+// for how the program is hosted. A non-nil cmd means the quit is being
+// honoured; nil means the host cannot terminate itself and the caller
+// should surface a notice instead of silently swallowing the request.
+//
+//   - onExit set (embedded in a host that owns teardown): hand off to
+//     the host and keep rendering until it tears us down. Never tea.Quit
+//     here — that would freeze the host view on the last frame.
+//   - disableExitKeys without onExit (host whose OS forbids self-exit):
+//     no command; the request can't be honoured.
+//   - neither (the CLI): tea.Quit returns the user to their shell.
+func (m AppModel) requestExit() tea.Cmd {
+	if m.onExit != nil {
+		cb := m.onExit
+		return func() tea.Msg {
+			cb()
+			return nil
+		}
+	}
+	if m.disableExitKeys {
+		return nil
+	}
+	return tea.Quit
+}
+
+// hostDrivenExit reports whether quitting is delegated to the host
+// (rather than tea.Quit or suppressed). It gates the affordances that
+// only make sense when the host can actually close the program in
+// response: the Quit action button and the q-to-quit shortcut on
+// navigation screens. The CLI surfaces quit through bubbles' own
+// bindings, so it leaves this false.
+func (m AppModel) hostDrivenExit() bool {
+	return m.onExit != nil
 }
 
 // maybeNotifyInputFocus invokes the OnInputFocusChanged callback whenever
@@ -503,6 +580,23 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 
 	case goBackMsg:
 		m.state = viewSelect
+		return m, nil
+
+	case requestExitMsg:
+		if cmd := m.requestExit(); cmd != nil {
+			return m, cmd
+		}
+		// The host can't terminate itself (a native platform whose OS
+		// forbids quitting). Don't leave the user wondering why /quit
+		// did nothing — surface a one-line notice in the chat, the only
+		// place a quit command is typed.
+		if m.state == viewChat {
+			m.chatModel.appendMessage(chatMessage{
+				role:    "system",
+				content: exitUnavailableNotice,
+			})
+			m.chatModel.updateViewport()
+		}
 		return m, nil
 
 	case showConfigMsg:
@@ -821,15 +915,22 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "ctrl+c":
-			if m.disableExitKeys {
-				// Embedded host disallows process termination — on a
-				// native-platform shell whose OS forbids quitting,
-				// tea.Quit would only stop the TUI loop while the
-				// host view stays mounted. Swallow the keypress so
-				// it doesn't accidentally tear down half the program.
-				return m, nil
+			// requestExit routes per host: the CLI gets tea.Quit, an
+			// exit-capable host gets its OnExit callback, and a host
+			// whose OS forbids self-termination gets nil — swallowing
+			// the keypress so it can't tear down the TUI loop behind a
+			// still-mounted host view.
+			return m, m.requestExit()
+		case "q":
+			// q quits on navigation screens, mirroring the CLI's bubbles
+			// list binding — but only on a host that delegates exit to us
+			// (the CLI keeps its own binding) and never while a text
+			// input has focus, so a literal 'q' still types into the chat
+			// composer or a form field. The navigation lists disable
+			// filtering, so there's no filter query to type a 'q' into.
+			if m.hostDrivenExit() && !m.computeWantsInput() {
+				return m, m.requestExit()
 			}
-			return m, tea.Quit
 		case "esc":
 			if m.state == viewConfig {
 				m.state = m.configReturn

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -209,6 +209,141 @@ func TestAppModel_DisableExitKeysSwallowsCtrlC(t *testing.T) {
 	}
 }
 
+// TestAppModel_OnExitRoutesQuitToHost: when the host supplies OnExit, the
+// program must hand quit requests to it rather than calling tea.Quit —
+// tea.Quit would freeze the host's view on the last frame. Exercises all
+// four quit paths: ctrl+c, q on a navigation screen, /quit, and the Quit
+// action.
+func TestAppModel_OnExitRoutesQuitToHost(t *testing.T) {
+	store := &config.Connections{}
+
+	newModel := func(exited *bool) AppModel {
+		return NewApp(nil, AppOptions{
+			Store:           store,
+			BackendFactory:  func(*config.Connection) (backend.Backend, error) { return nil, nil },
+			DisableExitKeys: true, // host can't be dismissed by tea.Quit...
+			OnExit:          func() { *exited = true },
+		})
+	}
+
+	// runExit asserts the cmd fires OnExit and emits no tea.QuitMsg.
+	runExit := func(t *testing.T, name string, cmd tea.Cmd, exited *bool) {
+		t.Helper()
+		if cmd == nil {
+			t.Fatalf("%s: expected a command", name)
+		}
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(tea.QuitMsg); ok {
+				t.Fatalf("%s: OnExit hosts must not emit tea.Quit", name)
+			}
+		}
+		if !*exited {
+			t.Fatalf("%s: expected OnExit to be invoked", name)
+		}
+	}
+
+	t.Run("ctrl+c", func(t *testing.T) {
+		var exited bool
+		m := newModel(&exited)
+		_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+		runExit(t, "ctrl+c", cmd, &exited)
+	})
+
+	t.Run("q on navigation screen", func(t *testing.T) {
+		var exited bool
+		m := newModel(&exited)
+		// The entry view is the agent/connections picker — a navigation
+		// screen with no focused text input, so q quits.
+		_, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+		runExit(t, "q", cmd, &exited)
+	})
+
+	t.Run("/quit via requestExitMsg", func(t *testing.T) {
+		var exited bool
+		m := newModel(&exited)
+		_, cmd := m.Update(requestExitMsg{})
+		runExit(t, "requestExitMsg", cmd, &exited)
+	})
+
+	t.Run("Quit action", func(t *testing.T) {
+		var exited bool
+		m := newModel(&exited)
+		_, cmd := m.Update(TriggerActionMsg{ID: "quit"})
+		runExit(t, "quit action", cmd, &exited)
+	})
+}
+
+// TestAppModel_RequestExitMsgRouting: the message /quit emits resolves
+// per host. The CLI quits via tea.Quit; a host that can't self-terminate
+// gets no command and a user-facing notice instead of a dead loop.
+func TestAppModel_RequestExitMsgRouting(t *testing.T) {
+	store := &config.Connections{}
+	factory := func(*config.Connection) (backend.Backend, error) { return nil, nil }
+
+	// CLI: requestExitMsg becomes tea.Quit.
+	cli := NewApp(nil, AppOptions{Store: store, BackendFactory: factory})
+	_, cmd := cli.Update(requestExitMsg{})
+	if cmd == nil {
+		t.Fatal("CLI: expected a quit command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("CLI: expected tea.QuitMsg, got %T", cmd())
+	}
+
+	// No-exit host in chat: no command, but a notice is appended so the
+	// user isn't left wondering why /quit did nothing.
+	noExit := NewApp(nil, AppOptions{Store: store, BackendFactory: factory, DisableExitKeys: true})
+	noExit.state = viewChat
+	before := len(noExit.chatModel.messages)
+	next, cmd := noExit.Update(requestExitMsg{})
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(tea.QuitMsg); ok {
+				t.Fatal("no-exit host must not emit tea.Quit")
+			}
+		}
+	}
+	got := next.(AppModel).chatModel.messages
+	if len(got) != before+1 {
+		t.Fatalf("expected a notice message appended, got %d (was %d)", len(got), before)
+	}
+	if last := got[len(got)-1]; last.role != "system" || last.content != exitUnavailableNotice {
+		t.Fatalf("unexpected notice message: %+v", last)
+	}
+}
+
+// TestAppModel_QuitActionExposedOnlyForHostDrivenExit: the Quit action is
+// an embedder affordance — it should appear when (and only when) the host
+// can act on it. The CLI (tea.Quit) and a no-exit host both leave it off.
+func TestAppModel_QuitActionExposedOnlyForHostDrivenExit(t *testing.T) {
+	store := &config.Connections{}
+	factory := func(*config.Connection) (backend.Backend, error) { return nil, nil }
+
+	hasQuit := func(actions []Action) bool {
+		for _, a := range actions {
+			if a.ID == "quit" {
+				return true
+			}
+		}
+		return false
+	}
+
+	cli := NewApp(nil, AppOptions{Store: store, BackendFactory: factory})
+	if hasQuit(cli.Actions()) {
+		t.Error("CLI should not expose a Quit action")
+	}
+
+	noExit := NewApp(nil, AppOptions{Store: store, BackendFactory: factory, DisableExitKeys: true})
+	if hasQuit(noExit.Actions()) {
+		t.Error("a host that can't terminate should not expose a Quit action")
+	}
+
+	hostExit := NewApp(nil, AppOptions{Store: store, BackendFactory: factory, DisableExitKeys: true, OnExit: func() {}})
+	if !hasQuit(hostExit.Actions()) {
+		t.Error("an OnExit host should expose a Quit action on the navigation screen")
+	}
+}
+
 // TestAppModel_TabAdvancesFocusInConnectionsForm: end-to-end check
 // that Tab in the connections form actually advances focus when
 // routed through AppModel.Update. This guards against the value-vs-

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -219,7 +219,10 @@ func (m *chatModel) handleSlashCommand(text string) (handled bool, cmd tea.Cmd) 
 	command := strings.ToLower(strings.TrimSpace(text))
 	switch command {
 	case "/quit", "/exit":
-		return true, tea.Quit
+		// Defer the exit policy to the AppModel: it knows whether to
+		// tea.Quit, hand off to an exit-capable host, or report that
+		// self-termination isn't possible. See requestExitMsg.
+		return true, func() tea.Msg { return requestExitMsg{} }
 	case "/agents":
 		return true, m.gateNavigation("Switching agents", func() tea.Msg { return goBackMsg{} })
 	case "/models":

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -53,6 +53,11 @@ func TestSlashCommand_Quit(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected a quit cmd")
 	}
+	// /quit defers the exit policy to the AppModel rather than calling
+	// tea.Quit itself, so the cmd carries a requestExitMsg.
+	if _, ok := cmd().(requestExitMsg); !ok {
+		t.Fatalf("expected requestExitMsg, got %T", cmd())
+	}
 }
 
 func TestSlashCommand_Exit(t *testing.T) {
@@ -63,6 +68,9 @@ func TestSlashCommand_Exit(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected a quit cmd")
+	}
+	if _, ok := cmd().(requestExitMsg); !ok {
+		t.Fatalf("expected requestExitMsg, got %T", cmd())
 	}
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -97,6 +97,14 @@ type GatewayEventMsg protocol.Event
 // goBackMsg signals the AppModel to return to agent selection.
 type goBackMsg struct{}
 
+// requestExitMsg asks the AppModel to honour a user quit request
+// (/quit, /exit, the Quit action). Views emit it instead of tea.Quit
+// so the AppModel can apply the host-appropriate exit policy in one
+// place: terminate via the host callback, fall back to tea.Quit, or —
+// on a host whose OS forbids self-termination — surface a notice
+// rather than tearing down the TUI loop behind a still-mounted view.
+type requestExitMsg struct{}
+
 // modelSwitchedMsg is returned after switching models.
 type modelSwitchedMsg struct {
 	modelID string


### PR DESCRIPTION
Adds an optional `OnExit` callback so an embedding host can own program teardown instead of the program calling `tea.Quit` itself.

## Summary
- Add `OnExit func()` to `app.RunOptions` (and the internal `tui.AppOptions`). When set, it takes precedence over `DisableExitKeys` and re-enables the quit affordances, but routes them to the host rather than `tea.Quit`.
- Centralise quit handling: `/quit`, `/exit`, the new **Quit** action, `q` on a navigation screen, and `ctrl+c` all flow through a single `requestExit` path via a `requestExitMsg`.
- When no host callback is supplied and exit keys are disabled, a quit request is declined with an in-TUI notice instead of silently stopping the loop behind a still-mounted host surface.
- The CLI is unchanged: with no `OnExit` it still quits via `tea.Quit`, and the Quit action / `q` shortcut stay off so bubbles' own bindings remain the surface.
- Tests cover all four quit paths, the CLI vs host-driven vs declined routing, and the Quit-action gating.

## Implementation details
A plain `tea.Quit` only stops the Bubble Tea render loop. For an embedder whose own surface (a window, a terminal view) outlives that loop, this leaves a frozen final frame on screen with a dead session behind it. `OnExit` hands such a host the teardown responsibility — the program keeps rendering normally until the host closes its surface (whose teardown path then calls `Program.Quit`). The presence of the callback is also what distinguishes a host that *can* terminate from one that can't, so the Quit affordances and the declined-quit notice key off it without the core needing to know anything platform-specific.