### PR TITLE
ci: pin v3 integration leg to 2026.5.7 for admin pairing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         gateway:
-          - "2026.4.29" # protocol v3
+          - "2026.5.7"  # protocol v3 (latest v3 release; earlier v3 builds can't grant operator.admin on pairing)
           - "2026.5.28" # protocol v4
     env:
       OPENCLAW_IMAGE: ghcr.io/openclaw/openclaw:${{ matrix.gateway }}


### PR DESCRIPTION
## Summary
The integration matrix's v3 leg was pinned to `2026.4.29`, which predates the gateway CLI fix that requests `operator.admin` during `openclaw devices approve`. The admin-scoped pairing flow introduced in 36400d1 therefore can't pair on that build (`missing scope: operator.admin` → `NOT_PAIRED`), failing CI on every PR.

## Change
Bump the v3 leg to `2026.5.7` — the **latest** release still speaking gateway protocol v3 (protocol bumps to v4 at 2026.5.12), and the first v3 line that supports admin-scoped device approval. Keeps genuine protocol-v3 coverage while letting the v3 leg pair with full admin like the v4 leg.

## Verification
Confirmed from the gateway source: `2026.5.7` has `PROTOCOL_VERSION = 3` and includes the `request operator.admin for device approvals` fix that `2026.4.29` lacks. This PR runs the integration matrix in CI to confirm both legs pair and pass end-to-end.