### PR TITLE
fix: re-anchor chat viewport when the completion menu opens or closes

### DIFF
--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -361,6 +361,13 @@ func (m chatModel) renderCompletionMenu() (string, int) {
 // of the "menu hidden" baseline; this method reapplies the menu's
 // footprint on top of that baseline whenever menu state changes.
 func (m *chatModel) applyLayout() {
+	// Preserve a bottom-anchored transcript across the height change. When the
+	// completion menu (or a notification / routine bar) opens the viewport
+	// shrinks and when it closes it grows again; without re-anchoring, a grown
+	// viewport keeps its old scroll offset and strands the transcript scrolled
+	// up with blank space beneath it. Only re-anchor when already at the bottom,
+	// so a deliberate scroll-up is left alone.
+	wasAtBottom := m.viewport.AtBottom()
 	h := m.baseViewportHeight - m.menuRowsToRender()
 	if m.activeRoutine != nil {
 		h--
@@ -370,6 +377,9 @@ func (m *chatModel) applyLayout() {
 		h = 1
 	}
 	m.viewport.SetHeight(h)
+	if wasAtBottom {
+		m.viewport.GotoBottom()
+	}
 }
 
 // refreshCompletionMenu recomputes the menu state from the current


### PR DESCRIPTION
Keep the chat transcript pinned to the bottom when the completion menu opens or closes.

## Summary
- Re-anchor the chat viewport to the bottom inside `applyLayout`, so the transcript stays bottom-anchored across a layout change — the completion menu opening *and* closing, plus notification and routine-status bars.
- Only re-anchors when the viewport is already at the bottom, so a deliberate scroll-up is left untouched.

## Implementation details
Opening the menu already re-anchored the viewport, but closing it did not: the grown-back viewport kept its old scroll offset and stranded the transcript scrolled up with blank space beneath it. Moving the re-anchor into `applyLayout` fixes every caller that resizes the viewport rather than just the menu-open path.

This is an independent, pre-existing bug — it does not depend on any other in-flight work.
