### PR TITLE
feat: add inline conversation rendering behind LUCINATE_INLINE

### DIFF
--- a/docs/inline-scrollback.md
+++ b/docs/inline-scrollback.md
@@ -1,0 +1,181 @@
+# Inline scrollback (conversation scrolling)
+
+**Status: prototype, off by default.** Enable with `LUCINATE_INLINE=1`.
+
+## The problem
+
+The chat view renders into the terminal's **alternate screen buffer**
+(`AppModel.View` sets `v.AltScreen = true`). The alt screen has no scrollback
+and no native text selection, so the terminal hands the whole screen to the
+app and every capability has to be re-implemented inside it. Three requirements
+then collide:
+
+- **Selection / copy** works only with mouse tracking **off** (issue #14) — but
+  then the app never receives wheel events.
+- With mouse off in the alt screen, terminals fall back to *alternate-scroll
+  mode*: they translate the wheel into **arrow keys**. The native platforms'
+  terminal does exactly this (it sends up/down key events when the display
+  buffer is alternate); their swipe-to-scroll emits arrows too.
+- Those arrows hit the chat key handler, where **Up/Down are reserved for
+  message recall / history walk** and are deliberately not forwarded to the
+  viewport. So a scroll gesture recalls a message instead of scrolling, and the
+  history never moves.
+
+In the *normal* buffer the native platforms' terminal already does the right
+thing — native scrollback **and** native selection (its non-alternate scroll
+path).
+
+## The approach
+
+Render the chat transcript **inline in the normal buffer** instead of the alt
+screen — the same split Claude Code / Ink `<Static>` use. Finished turns are
+pushed into the terminal's real scrollback with `tea.Printf`; only a small live
+region (the in-flight turn + input) is redrawn in place. The terminal then owns
+scrolling and selection, and Up/Down stay free for input history because the
+scroll gesture never reaches the app.
+
+Modal screens (pickers, config, connection list) stay on the alt screen;
+`AppModel.View` sets `AltScreen = false` only for `viewChat` when inline. On
+exit from a modal, Bubble Tea restores the normal buffer with the committed
+transcript intact.
+
+## The layout: a small live region, everything else in scrollback
+
+The inline chat keeps the live region **small** — usually just the input box,
+help line, and status bar (`inlineView`). Finished turns are spilled into the
+terminal's own scrollback, so the live region flows naturally at the bottom of
+the output and never fights the spill. The status bar is the **very last row**.
+
+This is the load-bearing decision. A *full-height* live region (padding the
+transcript up to fill the screen) was tried and abandoned: a large live region
+conflicts with `insertAbove`-based scrollback spills, producing ghost frames and
+blank gaps. A small region has room to spill above it and Just Works — this is
+the Ink `<Static>` / Claude Code model.
+
+`chatModel` splits its rows into **spilled** (already in scrollback, immutable)
+and **live** (`m.messages[committedCount:]`, redrawn each frame).
+
+- `historyLoadedMsg` → `commitLoadedHistory` spills the whole resumed history
+  plus a resume divider. When the history fills the screen the input lands at the
+  bottom with history above it; on a short session it floats where the content
+  ends.
+- **Finished turns stay live.** A completed turn is *not* spilled on its refresh
+  — see "Why finished turns stay live" below. `reflowInline` (run from
+  `AppModel.Update`) spills only the OLDEST turns, and only once the accumulated
+  live tail would overflow the space above the input. So turns pile up in the
+  live region and the oldest scroll off into scrollback as the screen fills.
+
+## Why finished turns stay live
+
+Committing a finished turn to scrollback *shrinks* the live region, and Bubble
+Tea's inline renderer is top-anchored: it keeps the frame's top fixed and clears
+the bottom, so the input jumps **up** by the turn's height and dead rows appear
+at the bottom. (Verified in a real terminal; a resize doesn't re-anchor it.)
+
+The fix is to never shrink the frame for a finished turn — keep it live. The
+input then holds its row across the whole turn (send → stream → done), because
+the live region only ever *grows*, and growing a bottom-seated inline frame just
+scrolls the scrollback up while the input stays put. `reflowInline` spills the
+oldest turns only when new content would overflow the screen; that spill happens
+*during growth*, so it's balanced and the input doesn't move. A single response
+taller than the screen is clipped to its newest rows for display (its top enters
+scrollback once a later turn pushes it out of the newest slot).
+
+Reconciliation still runs (`mergeHistoryRefresh`): finished turns are kept live
+from the server-canonical merge, and `reflowInline` only ever spills the oldest
+(already-canonical) rows, so the spilled prefix is append-only.
+
+## Keeping the input steady during a turn
+
+Because Bubble Tea's inline frame is **top-anchored**, the input (rendered below
+the live tail) moves whenever the tail changes height — and a streaming turn
+changes it constantly: the pre-response spinner appears then is dropped, tool
+cards appear, new assistant segments start. Left alone the input jumps up and
+down. (Ink/Claude Code avoids this by bottom-anchoring; Bubble Tea can't.)
+
+`turnTailFloor` damps it. `updateInlineFloor` (run after every chat update)
+records the high-water height of **everything above the input** —
+`aboveInputBlock`: the live tail *plus* the completion menu, notifications, and
+routine status. `inlineView` then holds that block at the floor via `fitAbove`
+(top-padding) so it **never shrinks**. This covers both jitter sources:
+
+- a streaming turn dropping a row (ephemeral tool card, dropped spinner), and
+- the completion menu filtering down as you type `/age` (fewer matches → shorter
+  menu → the input would otherwise rise).
+
+The block may still grow the floor (input drifts down smoothly as text streams,
+capped at the screen), but it never jitters upward. The floor resets to zero once
+the block empties — the turn committed, the menu closed, we're idle — so the next
+burst starts clean. Net: the input holds position during a turn or while
+filtering, moving only when activity first appears and once when it clears.
+
+A zero-size first frame (before the first `WindowSizeMsg`) is guarded in
+`inlineView` — rendering at zero width would otherwise produce negative-width
+styles and a corrupt frame.
+
+## Clean first frame after the alt-screen transition
+
+Entering inline chat from the agent picker (an alt-screen view) leaves Bubble
+Tea's inline renderer with stale frame state: the first frame renders corrupt
+(missing input border, ghosted status bar, split header) until the next resize.
+The fix is in the `historyLoadedMsg` handler — it returns
+`tea.Sequence(commitCmd, tea.RequestWindowSize)` so that, once the history has
+been spilled to scrollback, a window-size round-trip fires. The renderer erases
+and repaints on the resulting `WindowSizeMsg` (its `resize` always erases),
+giving a clean first frame. The sequence matters: requesting the size in `Init`
+instead races the history commit and doesn't stick.
+
+## Frame-height safety
+
+Every inline frame must be no taller than its line count implies, or the inline
+renderer's cursor-up can't clear the previous frame (ghosting). Two rules:
+
+- **No line may exceed the terminal width** — a wide line wraps to two rows.
+  `clampToWidth` truncates every line, and the header/status and routine-status
+  bars are truncated to `width − GetHorizontalFrameSize()` *before* lipgloss's
+  `Width()` (which would otherwise wrap over-long content, padding included).
+- **An over-tall in-flight turn is clipped** to its newest rows (`clipTail`) so
+  the frame never exceeds the terminal height.
+
+## Known limitations (prototype)
+
+- **Input floats on short sessions** (empty space below). See below.
+
+## Why not pin the input to the bottom
+
+Tried twice, reverted twice — both failures trace to the same cause, so it's
+worth stating plainly. The live region **must be free to change height**: the
+completion menu, a multi-line composer, notifications, and the streaming turn all
+grow and shrink it every keystroke. An inline live region grows *downward*, so it
+needs empty rows below it to grow into. The float provides exactly that room.
+
+Pin it to the bottom — either by padding the live region to full height, or by
+padding scrollback to push it down — and that room is gone. The next time the
+frame grows (typing `/` opens the menu), the terminal has to scroll, and Bubble
+Tea's inline renderer can't clear the scrolled-away rows, ghosting the input and
+status bar. A pinned, growable bottom prompt genuinely needs the alternate
+screen — the thing we left to get native scroll and selection. On sessions with a
+screenful of history the input sits at the bottom anyway; only fresh/short
+sessions float, which matches ordinary terminal behaviour.
+- **Scrolling fights active streaming.** Scrolling back while a turn streams gets
+  interrupted (each delta redraws and terminals snap to the bottom). Scroll
+  freely when idle.
+- **Spill is asynchronous.** `tea.Printf` runs one loop tick after the watermark
+  advances, so a just-finished turn can briefly flicker as it moves to scrollback.
+- **Client-only rows don't reach scrollback.** `/help`, `/stats`, etc. render in
+  the live region and vanish on the next refresh (the server never returns them).
+- **Resize does not reflow** rows already in scrollback (expected; Claude Code
+  has the same limitation).
+- `/mouse` is unnecessary in inline mode (selection and scroll are native).
+
+## Trying it
+
+```
+LUCINATE_INLINE=1 lucinate chat
+```
+
+Then check, in a real terminal (iTerm2, Terminal.app, or a native-platform
+terminal): wheel/trackpad
+scrolls the history; click-drag selects and copies; Up/Down still recall
+previous input; slash-command pickers still open full-screen and return
+cleanly.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1007,7 +1007,13 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 	case viewChat:
 		var cmd tea.Cmd
 		m.chatModel, cmd = m.chatModel.Update(msg)
-		return m, cmd
+		// Inline scrollback: spill the oldest finished turns to native
+		// scrollback once the live tail overflows the screen, and track the
+		// above-input high-water height so the input holds steady when content
+		// shrinks. Both no-op unless inline mode is on.
+		spill := m.chatModel.reflowInline()
+		m.chatModel.updateInlineFloor()
+		return m, tea.Batch(cmd, spill)
 
 	case viewSessions:
 		var cmd tea.Cmd
@@ -1242,6 +1248,14 @@ func (m AppModel) View() tea.View {
 		v = tea.NewView("")
 	}
 	v.AltScreen = true
+	// Inline scrollback prototype: the chat view renders into the normal
+	// screen buffer so the terminal owns scrolling and text selection.
+	// Other views (pickers, config, connection list) stay full-screen. On
+	// exit from a modal, Bubble Tea restores the normal buffer with the
+	// committed transcript intact.
+	if m.state == viewChat && m.chatModel.inline {
+		v.AltScreen = false
+	}
 	if m.mouseCapture {
 		v.MouseMode = tea.MouseModeCellMotion
 	}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -15,6 +15,7 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/a3tai/openclaw-go/protocol"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lucinate-ai/lucinate/internal/backend"
 	"github.com/lucinate-ai/lucinate/internal/client"
@@ -152,6 +153,9 @@ type chatModel struct {
 	viewport           viewport.Model
 	textarea           textarea.Model
 	messages           []chatMessage
+	inline             bool // PROTOTYPE (LUCINATE_INLINE=1): render finalised turns into the terminal's native scrollback instead of an alt-screen viewport, so the terminal owns scrolling and selection; see docs/inline-scrollback.md
+	committedCount     int  // inline mode: number of leading m.messages rows already emitted to scrollback; also the start index of the still-live tail rendered in View
+	turnTailFloor      int  // inline mode: the max live-tail height seen during the current turn; the tail is padded up to this so it never SHRINKS mid-turn (ephemeral rows, dropped placeholders), which would jump the input up. Reset to 0 when the tail empties (turn committed / idle)
 	backend            backend.Backend
 	connName           string // active connection name, rendered in the header bar
 	sessionKey         string
@@ -462,6 +466,7 @@ func newChatModel(b backend.Backend, sessionKey, agentID, agentName, modelID str
 
 	return chatModel{
 		viewport:        vp,
+		inline:          inlineScrollbackEnabled(),
 		textarea:        ta,
 		backend:         b,
 		connName:        connName,
@@ -634,6 +639,7 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case historyLoadedMsg:
 		m.historyLoading = false
+		var commitCmd tea.Cmd
 		switch {
 		case msg.err != nil:
 			m.appendMessage(chatMessage{
@@ -642,23 +648,54 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			})
 		case len(msg.messages) > 0:
 			lastTs := lastTimestampMs(msg.messages)
-			// Server-imported rows keep gen=0 (the chatMessage zero
-			// value) so any subsequent refresh treats them as
-			// history-side and replaces them cleanly.
-			hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
-			m.messages = append(hist, m.messages...)
-			m.recordCanonical(msg.messages)
+			if m.inline {
+				// Inline mode keeps m.messages aligned with the
+				// server-canonical set (no client-only separator row, which a
+				// later refresh drops and would misalign the spill watermark),
+				// and spills the whole loaded history to scrollback so the
+				// input sits at the bottom of the flow with history above it.
+				m.messages = append(msg.messages, m.messages...)
+				m.recordCanonical(msg.messages)
+				commitCmd = m.commitLoadedHistory(msg.messages, lastTs)
+			} else {
+				// Server-imported rows keep gen=0 (the chatMessage zero
+				// value) so any subsequent refresh treats them as
+				// history-side and replaces them cleanly.
+				hist := append(msg.messages, chatMessage{role: "separator", timestampMs: lastTs})
+				m.messages = append(hist, m.messages...)
+				m.recordCanonical(msg.messages)
+			}
 		}
 		m.updateViewport()
+		// Inline mode: after spilling history to scrollback, force a clean
+		// repaint. Entering inline chat from the alt-screen picker leaves the
+		// inline renderer with stale frame state, so the first frame is corrupt
+		// (missing input border, ghosted status bar) until the next resize.
+		// Sequencing the window-size round-trip *after* the history commit means
+		// the renderer erases and repaints once the scrollback is in place.
+		var seq []tea.Cmd
+		if commitCmd != nil {
+			seq = append(seq, commitCmd)
+		}
+		if m.inline {
+			seq = append(seq, tea.RequestWindowSize)
+		}
 		// If a caller pre-seeded pendingMessages (e.g. `lucinate chat`
 		// passing an auto-submit message), drain it now so the user
 		// turn is appended *after* the history scrollback — matching
 		// what they'd see typing it themselves.
 		if len(m.pendingMessages) > 0 && !m.sending {
 			m.sending = true
-			return m, m.drainQueue()
+			seq = append(seq, m.drainQueue())
 		}
-		return m, nil
+		switch len(seq) {
+		case 0:
+			return m, nil
+		case 1:
+			return m, seq[0]
+		default:
+			return m, tea.Sequence(seq...)
+		}
 
 	case agentSwitchFailedMsg:
 		m.appendMessage(chatMessage{role: "system", errMsg: msg.err.Error()})
@@ -738,6 +775,10 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		} else {
 			m.sessionKey = msg.newSessionKey
 			m.messages = nil
+			// Inline mode: the wiped rows are already in scrollback and
+			// can't be unscrolled; reset the watermark so the fresh row
+			// indexes from zero rather than underflowing the live tail.
+			m.committedCount = 0
 			m.appendMessage(chatMessage{role: "system", content: "Session cleared. Starting fresh."})
 		}
 		m.updateViewport()
@@ -784,6 +825,12 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 			m.mergeHistoryRefresh(msg.messages, msg.boundary)
 			m.recordCanonical(msg.messages)
 			m.updateViewport()
+			// Inline mode keeps the finished turn LIVE (not spilled here).
+			// Spilling it would shrink the live region, and Bubble Tea's
+			// top-anchored inline renderer pulls the input up by the turn's
+			// height and leaves dead rows at the bottom. reflowInline (run from
+			// AppModel.Update) spills the OLDEST turns only once the accumulated
+			// tail would overflow the screen.
 		}
 		// History refresh fires after each completed turn — pull a
 		// fresh prompt-token snapshot so the % keeps up with the
@@ -1337,7 +1384,21 @@ func (m *chatModel) setSize(w, h int) {
 	m.updateViewport()
 }
 
-func (m chatModel) View() string {
+// chatChrome holds the rendered non-transcript UI pieces shared by the
+// alt-screen and inline layouts: the header/status bar, completion menu, help
+// line, routine status, notifications, and the input box.
+type chatChrome struct {
+	header        string
+	menu          string
+	help          string
+	routineStatus string
+	notifications string
+	input         string
+}
+
+// buildChrome renders the chrome once so View and the inline budget math agree
+// on both content and height.
+func (m chatModel) buildChrome() chatChrome {
 	left := " lucinate"
 	if m.connName != "" {
 		left += " · " + m.connName
@@ -1395,6 +1456,14 @@ func (m chatModel) View() string {
 	if headerColor != "" {
 		hdrStyle = hdrStyle.Background(lipgloss.Color(headerColor))
 	}
+	// Truncate to the content width (terminal width minus the style's own
+	// padding) first: lipgloss's Width() *wraps* over-long content — including
+	// content pushed over by padding — to a second row, which in inline mode
+	// inflates the frame height past the terminal and ghosts the previous
+	// frame. The status bar must stay exactly one row.
+	if avail := m.width - hdrStyle.GetHorizontalFrameSize(); ansi.StringWidth(title) > avail {
+		title = ansi.Truncate(title, avail, "")
+	}
 	header := hdrStyle.
 		Width(m.width).
 		Render(title)
@@ -1445,36 +1514,148 @@ func (m chatModel) View() string {
 
 	routineStatus := ""
 	if line := m.routineStatusLine(); line != "" {
-		routineStatus = m.routineStatusStyle().Width(m.width).Render(line)
+		rs := m.routineStatusStyle()
+		if avail := m.width - rs.GetHorizontalFrameSize(); ansi.StringWidth(line) > avail {
+			line = ansi.Truncate(line, avail, "")
+		}
+		routineStatus = rs.Width(m.width).Render(line)
 	}
-	notifications := m.renderNotifications()
+
+	// Only render the composer when it's shown — hideInput hosts (native
+	// input surfaces) leave the textarea zero-valued, and its View() panics
+	// on a zero value.
+	var input string
+	if !m.hideInput {
+		input = borderStyle.
+			Width(m.width - 4).
+			Render(m.textarea.View())
+	}
+
+	return chatChrome{
+		header:        header,
+		menu:          menu,
+		help:          help,
+		routineStatus: routineStatus,
+		notifications: m.renderNotifications(),
+		input:         input,
+	}
+}
+
+func (m chatModel) View() string {
+	if m.inline {
+		return m.inlineView()
+	}
+
+	c := m.buildChrome()
 
 	if m.hideInput {
-		parts := []string{header, m.viewport.View()}
-		if notifications != "" {
-			parts = append(parts, notifications)
+		parts := []string{c.header, m.viewport.View()}
+		if c.notifications != "" {
+			parts = append(parts, c.notifications)
 		}
-		if routineStatus != "" {
-			parts = append(parts, routineStatus)
+		if c.routineStatus != "" {
+			parts = append(parts, c.routineStatus)
 		}
-		parts = append(parts, help)
+		parts = append(parts, c.help)
 		return lipgloss.JoinVertical(lipgloss.Left, parts...)
 	}
 
-	input := borderStyle.
-		Width(m.width - 4).
-		Render(m.textarea.View())
-
-	parts := []string{header, m.viewport.View()}
-	if menu != "" {
-		parts = append(parts, menu)
+	parts := []string{c.header, m.viewport.View()}
+	if c.menu != "" {
+		parts = append(parts, c.menu)
 	}
-	if notifications != "" {
-		parts = append(parts, notifications)
+	if c.notifications != "" {
+		parts = append(parts, c.notifications)
 	}
-	if routineStatus != "" {
-		parts = append(parts, routineStatus)
+	if c.routineStatus != "" {
+		parts = append(parts, c.routineStatus)
 	}
-	parts = append(parts, input, help)
+	parts = append(parts, c.input, c.help)
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// aboveInputBlock returns the content rendered above the input in inline mode —
+// the live transcript tail, then the completion menu, notifications, and routine
+// status — joined top to bottom. The menu/notifications/routine bits sit at the
+// bottom of the block (just above the input); the tail is above them.
+func (m chatModel) aboveInputBlock(c chatChrome) string {
+	var parts []string
+	if tail := m.renderLiveTail(); tail != "" {
+		parts = append(parts, tail)
+	}
+	if c.menu != "" {
+		parts = append(parts, c.menu)
+	}
+	if c.notifications != "" {
+		parts = append(parts, c.notifications)
+	}
+	if c.routineStatus != "" {
+		parts = append(parts, c.routineStatus)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// aboveInputHeight is the current rendered height of aboveInputBlock. Powers the
+// input-stability floor (see updateInlineFloor).
+func (m chatModel) aboveInputHeight() int {
+	if s := m.aboveInputBlock(m.buildChrome()); s != "" {
+		return lipgloss.Height(s)
+	}
+	return 0
+}
+
+// inlineView renders the inline layout: the content above the input (tail +
+// menu + notifications), then the input, help, and the status bar as the last
+// row. The live region stays small — finished turns are spilled to the
+// terminal's own scrollback, where native scroll and selection apply — so it
+// flows at the bottom of the output without fighting the spill.
+//
+// The above-input block is held at its activity high-water height (turnTailFloor)
+// so the input doesn't jump up when the tail or completion menu shrinks, and
+// clipped if it would exceed the screen. Every line is clamped to the terminal
+// width so a wrapped line can't inflate the frame height and ghost the previous
+// frame.
+// inlineMaxAbove is the number of screen rows available above the input for the
+// live tail and menu — the terminal height minus the fixed lower chrome (input,
+// help, status bar) and one spare row to avoid a bottom-edge scroll.
+func (m chatModel) inlineMaxAbove() int {
+	c := m.buildChrome()
+	lowerH := lipgloss.Height(c.header)
+	if !m.hideInput {
+		lowerH += lipgloss.Height(c.input) + lipgloss.Height(c.help)
+	}
+	if h := m.height - lowerH - 1; h > 0 {
+		return h
+	}
+	return 1
+}
+
+func (m chatModel) inlineView() string {
+	// Guard the pre-size first frame (WindowSizeMsg not yet delivered): rendering
+	// at zero width/height produces negative-width styles and garbage.
+	if m.width < 10 || m.height < 3 {
+		return ""
+	}
+
+	c := m.buildChrome()
+
+	var lower []string
+	if !m.hideInput {
+		lower = append(lower, c.input, c.help)
+	}
+	lower = append(lower, c.header) // status bar: the very last row
+	lowerStr := lipgloss.JoinVertical(lipgloss.Left, lower...)
+
+	maxAbove := m.inlineMaxAbove()
+	floor := m.turnTailFloor
+	if floor > maxAbove {
+		floor = maxAbove
+	}
+	above := fitAbove(m.aboveInputBlock(c), floor, maxAbove)
+
+	frame := lowerStr
+	if above != "" {
+		frame = above + "\n" + lowerStr
+	}
+	return clampToWidth(frame, m.width)
 }

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -1,0 +1,221 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// newInlineChat builds a chat model with the inline scrollback prototype forced
+// on (bypassing the env gate) and a usable size.
+func newInlineChat(t *testing.T) chatModel {
+	t.Helper()
+	m := newChatModel(newFakeBackend(), "session-key", "agent-id", "agent", "", config.DefaultPreferences(), false, "", "", false)
+	m.inline = true
+	m.setSize(80, 24)
+	return m
+}
+
+func TestFitAbove_PadsToFloorAndClipsToMax(t *testing.T) {
+	// Pads the top up to the floor, seating content at the bottom.
+	got := fitAbove("a\nb", 5, 100)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 5 || lines[3] != "a" || lines[4] != "b" {
+		t.Fatalf("floor pad wrong: %q", got)
+	}
+	// Clips the oldest rows past maxRows, keeping the newest.
+	if got := fitAbove("a\nb\nc\nd", 0, 2); got != "c\nd" {
+		t.Fatalf("clip kept %q, want %q", got, "c\nd")
+	}
+	// Empty with a floor produces that many blank rows (holds the input down).
+	if got := fitAbove("", 3, 10); got != "\n\n" {
+		t.Fatalf("empty+floor produced %q, want two newlines (3 rows)", got)
+	}
+	// Empty with no floor stays empty (idle: no reserved space).
+	if got := fitAbove("", 0, 10); got != "" {
+		t.Fatalf("empty+no-floor produced %q, want empty", got)
+	}
+}
+
+func TestInline_LoadSpillsHistoryLeavingSmallLiveRegion(t *testing.T) {
+	m := newInlineChat(t)
+	m, cmd := m.Update(historyLoadedMsg{messages: []chatMessage{
+		{role: "user", content: "hello"},
+		{role: "assistant", content: "hi there"},
+	}})
+
+	// The loaded history is spilled straight to scrollback, so the live region
+	// is empty — the input sits at the bottom of the flow with history above.
+	if m.committedCount != 2 {
+		t.Fatalf("committedCount = %d, want 2 (history spilled)", m.committedCount)
+	}
+	if tail := m.renderLiveTail(); tail != "" {
+		t.Fatalf("renderLiveTail = %q, want empty after load", tail)
+	}
+	if cmd == nil {
+		t.Fatal("expected a scrollback print command from history load")
+	}
+}
+
+func TestInline_FinishedTurnsStayLive(t *testing.T) {
+	m := newInlineChat(t)
+	m, _ = m.Update(historyLoadedMsg{messages: []chatMessage{
+		{role: "user", content: "u0"},
+		{role: "assistant", content: "a0"},
+	}})
+	if m.committedCount != 2 {
+		t.Fatalf("after load committedCount = %d, want 2", m.committedCount)
+	}
+
+	// A fresh turn stays in the live region.
+	m.appendMessage(chatMessage{role: "user", content: "u1"})
+	m.appendMessage(chatMessage{role: "assistant", content: "a1"})
+
+	// After the post-turn refresh, the finished turn must NOT be spilled to
+	// scrollback — it stays live so the frame doesn't shrink and jump the input.
+	server := []chatMessage{
+		{role: "user", content: "u0"},
+		{role: "assistant", content: "a0"},
+		{role: "user", content: "u1"},
+		{role: "assistant", content: "a1"},
+	}
+	m, _ = m.Update(historyRefreshMsg{messages: server, boundary: 1})
+	if m.committedCount != 2 {
+		t.Fatalf("after refresh committedCount = %d, want 2 (finished turn stays live, not spilled)", m.committedCount)
+	}
+	if tail := m.renderLiveTail(); !strings.Contains(tail, "u1") || !strings.Contains(tail, "a1") {
+		t.Fatalf("finished turn left the live region: %q", tail)
+	}
+
+	// reflowInline only spills once the tail overflows the screen. On a tall
+	// terminal these few rows fit, so nothing spills.
+	if cmd := m.reflowInline(); cmd != nil {
+		t.Fatal("reflowInline spilled a tail that fits the screen")
+	}
+
+	// Shrink the screen so the tail overflows: now the oldest spills, newest stays.
+	m.setSize(80, 6)
+	if cmd := m.reflowInline(); cmd == nil {
+		t.Fatal("reflowInline did not spill an overflowing tail")
+	}
+	if m.committedCount <= 2 {
+		t.Fatalf("reflowInline advanced committedCount to %d, want > 2 (oldest spilled)", m.committedCount)
+	}
+	if tail := m.renderLiveTail(); !strings.Contains(tail, "a1") {
+		t.Fatal("reflowInline spilled the newest message (should always keep it live)")
+	}
+}
+
+// TestInline_ViewNeverExceedsTerminalBounds is the regression for the ghosting
+// bug: in a narrow terminal the full-width status bar (and other chrome) would
+// wrap, making the real frame taller than the terminal so the inline renderer
+// couldn't clear the previous frame. The view must be at most `height` rows and
+// no line wider than `width`, regardless of header length or menu state.
+func TestInline_ViewNeverExceedsTerminalBounds(t *testing.T) {
+	m := newChatModel(newFakeBackend(), "s", "agent-id",
+		"a-really-long-agent-name", "provider/some-long-model-id-v4-flash",
+		config.DefaultPreferences(), false, "a-long-connection-name", "", false)
+	m.inline = true
+	m.setSize(60, 20)
+	m.stats = &sessionStats{totalCost: 12.34, inputTokens: 1000, outputTokens: 2000}
+
+	// An over-tall in-flight turn plus an open completion menu — the worst case.
+	m.appendMessage(chatMessage{role: "assistant", content: strings.Repeat("a long streaming line of tokens\n", 60)})
+	m.textarea.SetValue("/age")
+	m.refreshCompletionMenu()
+
+	view := m.inlineView()
+	lines := strings.Split(view, "\n")
+	if len(lines) > 20 {
+		t.Fatalf("inline view is %d rows, exceeds terminal height 20", len(lines))
+	}
+	for i, ln := range lines {
+		if w := ansi.StringWidth(ln); w > 60 {
+			t.Fatalf("line %d width %d exceeds terminal width 60 (would wrap and ghost): %q", i, w, ln)
+		}
+	}
+	// The status bar is the very last row.
+	if last := lines[len(lines)-1]; !strings.Contains(last, "lucinate") {
+		t.Fatalf("status bar is not the last row: %q", last)
+	}
+}
+
+// TestInline_AboveInputFloorHoldsOnShrink verifies the input doesn't jump up
+// when the content above it shrinks (a dropped placeholder, an ephemeral tool
+// card, or the completion menu filtering down): the frame height is held at its
+// high-water mark, and resets only once the block empties.
+func TestInline_AboveInputFloorHoldsOnShrink(t *testing.T) {
+	m := newInlineChat(t)
+	m.historyLoading = false // load has completed by the time a turn streams
+	m.committedCount = 0
+
+	m.messages = []chatMessage{
+		{role: "user", content: "do a thing"},
+		{role: "assistant", content: "working"},
+		{role: "tool", toolName: "read", toolState: "running"},
+		{role: "tool", toolName: "write", toolState: "running"},
+	}
+	m.updateInlineFloor()
+	grown := lipgloss.Height(m.inlineView())
+
+	// A row vanishes — the frame must not get shorter.
+	m.messages = m.messages[:2]
+	m.updateInlineFloor()
+	if held := lipgloss.Height(m.inlineView()); held != grown {
+		t.Fatalf("frame shrank %d→%d on row removal; input would jump up", grown, held)
+	}
+
+	// The floor resets once the block empties.
+	m.messages = nil
+	m.updateInlineFloor()
+	if m.turnTailFloor != 0 {
+		t.Fatalf("turnTailFloor = %d after block emptied, want 0", m.turnTailFloor)
+	}
+}
+
+func TestInline_ChatViewLeavesAltScreen(t *testing.T) {
+	fake := newFakeBackend()
+
+	m := AppModel{backend: fake, width: 120, height: 40}
+	m.chatModel = newChatModel(fake, "s", "a", "agent", "", config.DefaultPreferences(), false, "", "", false)
+	m.chatModel.inline = true
+	m.chatModel.setSize(120, 40)
+	m.state = viewChat
+	if v := m.View(); v.AltScreen {
+		t.Error("inline chat view must not use the alternate screen")
+	}
+
+	m.state = viewConnections
+	if v := m.View(); !v.AltScreen {
+		t.Error("modal views must keep the alternate screen")
+	}
+
+	m.chatModel.inline = false
+	m.state = viewChat
+	if v := m.View(); !v.AltScreen {
+		t.Error("non-inline chat must keep the alternate screen")
+	}
+}
+
+func TestInline_Disabled_NoScrollbackAndKeepsSeparator(t *testing.T) {
+	m := newChatModel(newFakeBackend(), "session-key", "agent-id", "agent", "", config.DefaultPreferences(), false, "", "", false)
+	m.setSize(80, 24)
+	m, cmd := m.Update(historyLoadedMsg{messages: []chatMessage{
+		{role: "user", content: "u0"},
+		{role: "assistant", content: "a0"},
+	}})
+	// Non-inline keeps the client separator row in the transcript.
+	if got := len(m.messages); got != 3 {
+		t.Fatalf("non-inline messages = %d, want 3 (2 rows + separator)", got)
+	}
+	if cmd != nil {
+		t.Fatal("non-inline mode must not print to scrollback")
+	}
+	if m.committedCount != 0 {
+		t.Fatalf("non-inline committedCount = %d, want 0", m.committedCount)
+	}
+}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -2,10 +2,13 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -23,62 +26,7 @@ func (m *chatModel) updateViewport() {
 		if i > 0 {
 			b.WriteString("\n")
 		}
-		switch msg.role {
-		case "separator":
-			b.WriteString(statusStyle.Render(buildSeparator(contentWidth, formatSeparatorLabel(msg.timestampMs, time.Now()))))
-
-		case "user":
-			prefixIndent, wrapWidth := m.writePrefix(&b, userPrefixStyle, "You")
-			body := wordWrap(msg.content, wrapWidth)
-			b.WriteString(indentMultiline(body, prefixIndent))
-
-		case "assistant":
-			prefixIndent, wrapWidth := m.writePrefix(&b, assistantPrefixStyle, m.agentName)
-			if msg.errMsg != "" {
-				body := wordWrap(msg.errMsg, wrapWidth)
-				b.WriteString(errorStyle.Render(indentMultiline(body, prefixIndent)))
-			} else {
-				if msg.thinking != "" {
-					b.WriteString(statusStyle.Render("◦ thinking"))
-					b.WriteString("\n")
-					thinkingBody := wordWrap(msg.thinking, wrapWidth)
-					b.WriteString(thinkingBodyStyle.Render(indentMultiline(thinkingBody, prefixIndent)))
-					b.WriteString("\n\n")
-					b.WriteString(prefixIndent)
-				}
-				if msg.streaming {
-					body := wordWrap(msg.content, wrapWidth)
-					b.WriteString(indentMultiline(body, prefixIndent))
-					b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
-				} else if msg.rendered {
-					// Glamour-rendered content is already wrapped and contains ANSI codes.
-					content := msg.content
-					if m.narrowLayout() {
-						// In stacked layout, strip glamour's left margin from each
-						// line so the body sits flush under the prefix.
-						content = stripLeadingSpacesPerLine(content)
-					}
-					b.WriteString(indentMultiline(content, prefixIndent))
-				} else {
-					body := wordWrap(msg.content, wrapWidth)
-					b.WriteString(indentMultiline(body, prefixIndent))
-				}
-			}
-
-		case "system":
-			if msg.errMsg != "" {
-				b.WriteString(errorStyle.Render(wordWrap(msg.errMsg, contentWidth)))
-			} else {
-				b.WriteString(statusStyle.Render(wordWrap(msg.content, contentWidth)))
-				if msg.pending {
-					b.WriteString(" ")
-					b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
-				}
-			}
-
-		case "tool":
-			b.WriteString(m.renderToolCard(msg, contentWidth))
-		}
+		b.WriteString(m.renderMessage(msg))
 	}
 
 	// Render queued messages that haven't been sent yet — shown as dim/italic
@@ -107,6 +55,329 @@ func (m *chatModel) updateViewport() {
 	if wasAtBottom {
 		m.viewport.GotoBottom()
 	}
+}
+
+// renderMessage renders a single transcript row to a styled string, without
+// the leading separator newline that joins consecutive rows. Shared by the
+// alt-screen viewport path (updateViewport) and the inline scrollback path
+// (renderLiveTail / commitToScrollback) so a row looks identical whether it
+// is still live or has been committed to the terminal's native scrollback.
+func (m *chatModel) renderMessage(msg chatMessage) string {
+	contentWidth := m.width - 4
+	var b strings.Builder
+	switch msg.role {
+	case "separator":
+		b.WriteString(statusStyle.Render(buildSeparator(contentWidth, formatSeparatorLabel(msg.timestampMs, time.Now()))))
+
+	case "user":
+		prefixIndent, wrapWidth := m.writePrefix(&b, userPrefixStyle, "You")
+		body := wordWrap(msg.content, wrapWidth)
+		b.WriteString(indentMultiline(body, prefixIndent))
+
+	case "assistant":
+		prefixIndent, wrapWidth := m.writePrefix(&b, assistantPrefixStyle, m.agentName)
+		if msg.errMsg != "" {
+			body := wordWrap(msg.errMsg, wrapWidth)
+			b.WriteString(errorStyle.Render(indentMultiline(body, prefixIndent)))
+		} else {
+			if msg.thinking != "" {
+				b.WriteString(statusStyle.Render("◦ thinking"))
+				b.WriteString("\n")
+				thinkingBody := wordWrap(msg.thinking, wrapWidth)
+				b.WriteString(thinkingBodyStyle.Render(indentMultiline(thinkingBody, prefixIndent)))
+				b.WriteString("\n\n")
+				b.WriteString(prefixIndent)
+			}
+			if msg.streaming {
+				body := wordWrap(msg.content, wrapWidth)
+				b.WriteString(indentMultiline(body, prefixIndent))
+				b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
+			} else if msg.rendered {
+				// Glamour-rendered content is already wrapped and contains ANSI codes.
+				content := msg.content
+				if m.narrowLayout() {
+					// In stacked layout, strip glamour's left margin from each
+					// line so the body sits flush under the prefix.
+					content = stripLeadingSpacesPerLine(content)
+				}
+				b.WriteString(indentMultiline(content, prefixIndent))
+			} else {
+				body := wordWrap(msg.content, wrapWidth)
+				b.WriteString(indentMultiline(body, prefixIndent))
+			}
+		}
+
+	case "system":
+		if msg.errMsg != "" {
+			b.WriteString(errorStyle.Render(wordWrap(msg.errMsg, contentWidth)))
+		} else {
+			b.WriteString(statusStyle.Render(wordWrap(msg.content, contentWidth)))
+			if msg.pending {
+				b.WriteString(" ")
+				b.WriteString(cursorStyle.Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]))
+			}
+		}
+
+	case "tool":
+		b.WriteString(m.renderToolCard(msg, contentWidth))
+	}
+	return b.String()
+}
+
+// inlineScrollbackEnabled reports whether the inline scrollback prototype is
+// active. Gated on an env var so the shipping alt-screen path is untouched by
+// default and the two can be A/B'd in the same build. See the plan in
+// docs/inline-scrollback.md.
+func inlineScrollbackEnabled() bool {
+	return os.Getenv("LUCINATE_INLINE") == "1"
+}
+
+// renderLiveTail renders the inline live region's transcript portion: the tail
+// of m.messages not yet spilled to scrollback (committedCount onward), followed
+// by any queued-but-unsent messages. inlineView bottom-anchors this within the
+// tail budget; reflowInline spills whatever overflows the budget's top into the
+// terminal's native scrollback.
+func (m *chatModel) renderLiveTail() string {
+	contentWidth := m.width - 4
+	if m.historyLoading && len(m.messages) == 0 && len(m.pendingMessages) == 0 {
+		return statusStyle.Render(wordWrap("Loading conversation history…", contentWidth))
+	}
+
+	start := m.committedCount
+	if start < 0 {
+		start = 0
+	}
+	var b strings.Builder
+	first := true
+	for i := start; i < len(m.messages); i++ {
+		if !first {
+			b.WriteString("\n")
+		}
+		first = false
+		b.WriteString(m.renderMessage(m.messages[i]))
+	}
+	if pending := m.renderPendingTail(); pending != "" {
+		if !first {
+			b.WriteString("\n")
+		}
+		b.WriteString(pending)
+	}
+	return b.String()
+}
+
+// renderPendingTail renders the queued-but-unsent messages shown as dim
+// shadows above the input. Always live (never spilled), so reflowInline counts
+// its height as fixed overhead when deciding what to spill.
+func (m *chatModel) renderPendingTail() string {
+	if len(m.pendingMessages) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, text := range m.pendingMessages {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		prefixIndent, wrapWidth := m.writePrefix(&b, pendingPrefixStyle, "You")
+		body := wordWrap(text, wrapWidth)
+		b.WriteString(pendingBodyStyle.Render(indentMultiline(body, prefixIndent)))
+	}
+	return b.String()
+}
+
+// buildCommitBlock renders m.messages[from:to] joined the same way the viewport
+// joins rows (a single newline between blocks, none leading). Pure: no mutation,
+// so tests can assert exactly what a spill would push to scrollback.
+func (m *chatModel) buildCommitBlock(from, to int) string {
+	if from < 0 {
+		from = 0
+	}
+	if to > len(m.messages) {
+		to = len(m.messages)
+	}
+	var b strings.Builder
+	for i := from; i < to; i++ {
+		if i > from {
+			b.WriteString("\n")
+		}
+		b.WriteString(m.renderMessage(m.messages[i]))
+	}
+	return b.String()
+}
+
+// clampToWidth truncates every line of s to at most width display cells. The
+// inline renderer positions frames by moving the cursor up by the frame's line
+// count; a line wider than the terminal wraps to two rows, so the real frame is
+// taller than the line count and the cursor-up math corrupts (ghost frames).
+// Truncating guarantees one screen row per line so the accounting holds. It is
+// ANSI-aware, so styled runs (the status bar's background, etc.) stay intact.
+func clampToWidth(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if ansi.StringWidth(line) > width {
+			lines[i] = ansi.Truncate(line, width, "")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// fitAbove sizes the "above the input" block (live tail + completion menu +
+// notifications + routine status) for the inline layout. It pads the TOP with
+// blank rows up to floor — so the block never renders shorter than its
+// high-water height and the input below it can't jump up when the tail or menu
+// shrinks — and clips the OLDEST rows if it would exceed maxRows, keeping the
+// newest content (and the menu, which sits at the bottom of the block) visible.
+func fitAbove(s string, floor, maxRows int) string {
+	var lines []string
+	if s != "" {
+		lines = strings.Split(s, "\n")
+	}
+	if len(lines) < floor {
+		lines = append(make([]string, floor-len(lines)), lines...)
+	}
+	if maxRows >= 0 && len(lines) > maxRows {
+		lines = lines[len(lines)-maxRows:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// reflowInline spills the OLDEST finished messages into the terminal's native
+// scrollback, but only once the accumulated live tail would overflow the space
+// above the input — so finished turns stay live (no frame shrink, no input
+// jump) until the screen is full, then the oldest scroll off into scrollback.
+// The newest message is always kept live (it may still be streaming, and an
+// over-tall streaming turn is clipped for display rather than spilled). Returns
+// the print command, or nil when nothing needs spilling.
+func (m *chatModel) reflowInline() tea.Cmd {
+	if !m.inline {
+		return nil
+	}
+	if m.committedCount > len(m.messages) {
+		m.committedCount = len(m.messages)
+	}
+	if len(m.messages) == 0 {
+		return nil
+	}
+
+	// Budget for the live message tail: the rows above the input, minus the
+	// non-message chrome that also sits there (menu, notifications, routine
+	// status, queued messages).
+	c := m.buildChrome()
+	budget := m.inlineMaxAbove()
+	if c.menu != "" {
+		budget -= lipgloss.Height(c.menu)
+	}
+	if c.notifications != "" {
+		budget -= lipgloss.Height(c.notifications)
+	}
+	if c.routineStatus != "" {
+		budget -= lipgloss.Height(c.routineStatus)
+	}
+	if p := m.renderPendingTail(); p != "" {
+		budget -= lipgloss.Height(p)
+	}
+	if budget < 1 {
+		budget = 1
+	}
+
+	// Keep the newest run of messages that fits; spill everything older.
+	used := 0
+	newCommitted := len(m.messages)
+	for i := len(m.messages) - 1; i >= m.committedCount; i-- {
+		h := lipgloss.Height(m.renderMessage(m.messages[i]))
+		if newCommitted < len(m.messages) && used+h > budget {
+			break
+		}
+		used += h
+		newCommitted = i
+	}
+	if newCommitted <= m.committedCount {
+		return nil
+	}
+	block := m.buildCommitBlock(m.committedCount, newCommitted)
+	m.committedCount = newCommitted
+	if block == "" {
+		return nil
+	}
+	return tea.Printf("%s", block)
+}
+
+// updateInlineFloor tracks the high-water height of everything above the input
+// (tail + menu + notifications + routine status). Called after every chat
+// update. The block may grow the floor but the view never renders it shorter,
+// so the input holds position instead of jumping when a row is dropped or the
+// menu filters down. Resets once the block empties (idle).
+//
+// Note: the floor is deliberately NOT released when the completion menu closes.
+// Releasing it shrinks the frame, and Bubble Tea's top-anchored inline renderer
+// then strands the status bar mid-screen with blank rows beneath it (worse than
+// the small gap a held floor leaves). The menu opening scrolls native scrollback
+// up to make room, and that can't be scrolled back down programmatically — an
+// inherent limit of rendering into the terminal's own scrollback.
+func (m *chatModel) updateInlineFloor() {
+	if !m.inline {
+		return
+	}
+	if h := m.aboveInputHeight(); h == 0 {
+		m.turnTailFloor = 0
+	} else if h > m.turnTailFloor {
+		m.turnTailFloor = h
+	}
+}
+
+// commitLoadedHistory spills the resumed conversation history — the canonical
+// rows plus a trailing resume divider — into the terminal's native scrollback
+// as one ordered block, and sets committedCount to len(canonical). Keeping the
+// live region empty right after load is what makes the input sit at the bottom
+// of the natural flow whenever the history fills the screen; on a short session
+// the input floats where the content ends (normal terminal behaviour).
+//
+// Note: an earlier version also prepended blank-line padding to seat the input
+// at the bottom on short sessions. That pins the small live region to the
+// bottom of the screen, which leaves it no room to grow — opening the
+// completion menu then forces a scroll that Bubble Tea's inline renderer can't
+// clear, ghosting the input and status bar. The float is the robust choice.
+//
+// The divider is scrollback-only decoration (never stored in m.messages) so it
+// can't shift the watermark when a later refresh, which never returns it,
+// re-anchors the canonical prefix.
+func (m *chatModel) commitLoadedHistory(canonical []chatMessage, lastTs int64) tea.Cmd {
+	if !m.inline || len(canonical) == 0 {
+		return nil
+	}
+	block := m.buildCommitBlock(0, len(canonical))
+	block += "\n" + m.renderMessage(chatMessage{role: "separator", timestampMs: lastTs})
+	m.committedCount = len(canonical)
+	return tea.Printf("%s", block)
+}
+
+// commitToScrollback spills the newly-canonical leading rows of m.messages into
+// scrollback and advances committedCount past them, keeping the live region
+// small (a large live region fights insertAbove-based spills). canonicalLen is
+// the number of leading rows now known to be server-canonical — len(server)
+// right after a history refresh. Only canonical rows are ever committed, so the
+// committed prefix is append-only and never needs rewriting (which scrollback
+// can't do); the count is re-anchored each call, so a client-only row the
+// server later drops self-corrects without a gap or a duplicate.
+func (m *chatModel) commitToScrollback(canonicalLen int) tea.Cmd {
+	if !m.inline {
+		return nil
+	}
+	if canonicalLen > len(m.messages) {
+		canonicalLen = len(m.messages)
+	}
+	if m.committedCount >= canonicalLen {
+		m.committedCount = canonicalLen
+		return nil
+	}
+	block := m.buildCommitBlock(m.committedCount, canonicalLen)
+	m.committedCount = canonicalLen
+	if block == "" {
+		return nil
+	}
+	return tea.Printf("%s", block)
 }
 
 // narrowBodyMinWidth is the minimum body column width below which the inline


### PR DESCRIPTION
Add an opt-in inline rendering mode that draws the chat into the terminal's native scrollback, so the terminal owns scrolling and text selection.

## Summary
- New inline mode, gated on `LUCINATE_INLINE=1`, renders the conversation into the terminal's normal-buffer scrollback instead of the alt-screen viewport.
- The terminal owns wheel/trackpad scrolling and native click-drag selection/copy; up/down still recall previously typed input.
- Finished turns stay live and spill into scrollback only on overflow, so the input holds its position during and after a turn.
- Off by default — the alt-screen path is unchanged and behaviour-preserving.
- Adds `docs/inline-scrollback.md` covering the design, frame-height safety, and known limitations.

## Implementation details
The mode exists because the alt-screen has no native scrollback or selection, forcing both to be re-implemented in-app; rendering inline hands them back to the terminal.

Key decisions, all driven by Bubble Tea's inline renderer being **top-anchored**:
- **Finished turns are not committed on completion.** Committing shrinks the live region, and a top-anchored shrink pulls the input up and strands the status bar. Turns stay live; `reflowInline` spills only the oldest once the tail overflows the screen, during growth, so the input never jumps.
- **Frame-height safety.** Every line is clamped to the terminal width (a wrapped line would inflate the frame and ghost the previous frame), and the header is truncated before lipgloss's `Width()` so it can't wrap to two rows.
- **Clean first frame.** Entering inline chat from the alt-screen picker leaves the renderer with stale state; the history-load handler sequences a `RequestWindowSize` after the scrollback commit to force a clean repaint.

Shared rendering (`renderMessage`, `buildChrome`) is extracted so the alt-screen and inline paths render identically; the extraction is behaviour-preserving for the default path.
