### PR TITLE
feat: default mouse capture on with in-app transcript selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No file browsers, no task boards, no dashboards. Just chat.
 - **Tool call cards** — when the agent invokes a tool, an inline card shows what's running, what arguments it got, and whether it succeeded or failed (OpenClaw)
 - **Shell commands** — run locally with `!` or remotely on the gateway with `!!`
 - **Message queueing** so you can keep typing while the agent is responding
+- **Scroll and copy like a native** — the wheel scrolls history, click-drag selects and copies on release, and `↑`/`↓` recall what you typed. All three, no fighting.
 - **Local agent skills** loaded from `~/.agents/skills/` — invoke as a slash command (`/review`) or drop one mid-message (`use /review on the diff`)
 - **Routines** — author multi-step prompt sequences once, replay them with `/routine <name>`. Auto-advance after each reply, or step through manually. Manage them in-TUI with `/routines`.
 - **Live token/cost stats** in the header bar (OpenClaw)
@@ -55,7 +56,7 @@ On Windows, in PowerShell:
 irm https://raw.githubusercontent.com/lucinate-ai/lucinate/main/install/lucinate.ps1 | iex
 ```
 
-Or, if you have Go 1.24+:
+Or, if you have Go 1.25+:
 
 ```sh
 go install github.com/lucinate-ai/lucinate@latest
@@ -125,11 +126,16 @@ Select an agent from the list to start chatting.
 | `Enter` | Send message |
 | `Alt+Enter` | Insert newline |
 | `Ctrl+W` | Delete word |
+| `↑` / `↓` | Recall previously sent messages (bash-style) |
 | `PgUp` / `PgDn` | Scroll chat history |
 | `Tab` | Show slash-command menu, extend to common prefix, then cycle |
 | `Shift+Tab` | Cycle backward through matches |
 | `Esc` | Back to agent list |
 | `Ctrl+C` | Quit |
+
+The mouse works too: **wheel scrolls the history**, and **click-drag selects
+text** — it lands on your clipboard the moment you let go. Prefer your
+terminal's native selection? `/mouse off` hands the mouse back.
 
 ### Preferences
 
@@ -163,6 +169,7 @@ Type these in the chat input. As soon as you type `/`, a menu shows every matchi
 | `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`); the override sticks to that agent and persists across runs. Bare `/header` reports the current agent's value, `/header reset` restores the default. |
 | `/models` | Open the model picker (filter as you type) |
 | `/model <name>` | Switch model (fuzzy match) |
+| `/mouse on\|off` | Mouse capture (on by default: wheel scrolls, drag copies; off: your terminal's native selection) |
 | `/reset` | Delete session and start fresh (with confirmation) |
 | `/routine <name>` | Activate a stored multi-step routine in the current session |
 | `/routines` | List, view, edit, or delete routines |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ This directory contains maintainer-level documentation for lucinate. It covers h
 | [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
 | [export-and-recording.md](export-and-recording.md) | `/record` and `/export` transcripts: canonical-history tap, dedup, file layout, lifecycle |
 | [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
-| [chat-ux.md](chat-ux.md) | Input key bindings, streaming animation, thinking levels, header bar, history depth |
+| [chat-ux.md](chat-ux.md) | Input key bindings, mouse scrolling and in-app selection, streaming animation, thinking levels, header bar, history depth |
 | [message-rendering.md](message-rendering.md) | Message roles, `System:` prefix convention, history cleanup, markdown rendering |
 | [key-conventions.md](key-conventions.md) | Cross-view keyboard conventions: action keys, confirms, navigation, form keys, reserved keys |
 | [logging.md](logging.md) | `internal/logging` design: `LUCINATE_LOG_*` env vars, destination rule, TUI-safety constraints |

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -126,6 +126,30 @@ Tests pin the contract: `TestMergeHistoryRefresh_PreservesLiveTail`, `TestMergeH
 
 Each (re)connect attempt has a per-attempt deadline applied to the WebSocket / HTTP handshake. The default is 15 seconds; the range is 5–300 seconds via `/config` ("Connect timeout"). The configured value is loaded by `app.DefaultBackendFactory` (`app/factory.go`) for every backend dispatch, so the same setting governs the initial connect and the supervisor's reconnect attempts. Bump it when targeting a slow local LLM that cold-starts on first request.
 
-## Scrolling
+## Scrolling, selection, and the mouse
 
-The message history is a Bubble Tea viewport. Mouse wheel events are forwarded to the viewport directly. Page Up/Down and arrow keys scroll when the input is not the active focus. New messages are anchored to the bottom via `GotoBottom()` after each update.
+The message history is a Bubble Tea viewport. Mouse capture (SGR cell-motion
+tracking) is **on by default**, which makes the three core interactions
+coexist cleanly:
+
+- **Wheel / trackpad scrolls the history.** Wheel events are forwarded to the
+  viewport directly. Because tracking is on, the terminal never translates the
+  wheel into arrow keys, so scrolling can't collide with input recall. If
+  you've scrolled up, new streaming output does not yank you back down; new
+  messages re-anchor to the bottom only when you're already there
+  (`GotoBottom()` after each update).
+- **Click-drag selects and copies.** Dragging over the transcript draws a
+  reverse-video highlight; on release the selected text is copied to the
+  clipboard (both OSC 52 through the terminal and the OS clipboard directly),
+  with a "Copied …" confirmation row. Implemented in
+  `internal/tui/selection.go`. Selections are char-precise, span multiple
+  lines, auto-scroll when dragged past the viewport edge, and strip styling
+  from the copied text.
+- **Up/Down remain input recall.** The bash-style walk through previously
+  submitted messages (and queued-message editing) owns the arrow keys
+  exclusively; scrolling never reaches them.
+
+Page Up/Down still scroll a page at a time. `/mouse off` opts out of capture,
+handing click-drag back to the terminal's native selection at the cost of
+wheel scrolling (the previous default behaviour); `/mouse on` restores the
+default.

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -7,10 +7,13 @@
 | Enter | Send message — or, on empty input with an active routine, advance the routine ([routines.md](routines.md)) |
 | Alt+Enter | Insert newline |
 | Ctrl+W | Delete word backward |
-| Up arrow (empty input) | Recall last sent message for editing |
+| Up arrow (empty input) | Recall the last queued message for editing, or start a bash-style walk back through previously sent messages |
+| Down arrow (while walking) | Walk forward again; at the newest entry, clear the input |
 | Tab | Open slash menu, extend to longest common prefix, then cycle |
 | Shift+Tab | While slash-menu is cycling: cycle backward through candidates. Otherwise, with an active routine: cycle the routine's mode (auto ↔ manual) |
 | Page Up / Page Down | Scroll message history |
+| Mouse wheel | Scroll message history — see [Scrolling, selection, and the mouse](#scrolling-selection-and-the-mouse) |
+| Mouse click-drag | Select transcript text; copies to the clipboard on release |
 | Esc | Cancel in-progress response — or, with an active routine, end the routine and (if streaming) cancel the turn |
 
 Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter is not supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
@@ -18,6 +21,8 @@ Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `c
 ## Message recall
 
 When the textarea is empty and the user presses Up arrow, the last entry in `m.pendingMessages` is popped and inserted into the textarea with the cursor at the end. This allows editing and resending a recently queued message without retyping it.
+
+With no queued messages, Up starts a bash-style walk back through previously submitted user messages (`historyBrowseIndex` / `historyBrowseValue` in `chat.go`): repeated Up steps older, Down steps newer, and reaching the newest entry clears the input. The walk ends as soon as the recalled text is edited — Up/Down then revert to ordinary cursor movement within multi-line content. Because mouse capture is on by default, the terminal never synthesises arrow keys from the wheel, so scrolling can't accidentally trigger a walk (see [Scrolling, selection, and the mouse](#scrolling-selection-and-the-mouse)).
 
 ## Streaming animation
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,6 +32,10 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
+| `/mouse` | Report the current mouse-capture state |
+| `/mouse on` | Enable mouse capture (the default): wheel scrolls history, click-drag selects and copies — see [chat-ux.md](chat-ux.md#scrolling-selection-and-the-mouse) |
+| `/mouse off` | Disable capture, handing click-drag back to the terminal's native selection (wheel scrolling stops) |
+| `/mouse toggle` | Flip the capture state |
 | `/record` | Show whether transcript capture is on, and where it's writing |
 | `/record on` | Begin streaming canonical conversation messages to a transcript file — see below |
 | `/record off` | Stop the active recording and report the file path |

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/a3tai/openclaw-go v1.20260325.1-0.20260417064242-ec5cddc23822
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260419004333-9332b2225b80
@@ -21,7 +22,6 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-udiff v0.4.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -150,12 +150,14 @@ type AppModel struct {
 	// and the agent list, none of which share a fixed parent.
 	configReturn viewState
 
-	// mouseCapture toggles SGR mouse tracking. Off by default so a plain
-	// click-drag runs the terminal's native text selection (the fix for
-	// lucinate-ai/lucinate#14); the user opts in via /mouse on to get
-	// mouse-wheel scrolling of the chat history, accepting that native
-	// selection then needs a Shift/Option modifier. Owned here because the
-	// View() that emits the mode lives on AppModel.
+	// mouseCapture toggles SGR mouse tracking. On by default: the wheel
+	// scrolls the chat history (and is never translated to arrow keys, so
+	// Up/Down stay reserved for input recall), and click-drag runs the
+	// in-app transcript selection with copy-on-release (selection.go) —
+	// which restores the copy capability that issue #14 previously required
+	// native selection for. /mouse off opts out, handing click-drag back to
+	// the terminal's native selection at the cost of wheel scrolling. Owned
+	// here because the View() that emits the mode lives on AppModel.
 	mouseCapture bool
 
 	// cronsReturnChat preserves the chat the user was viewing when they
@@ -207,6 +209,7 @@ func NewApp(b backend.Backend, opts AppOptions) AppModel {
 	m := AppModel{
 		backend:               b,
 		prefs:                 config.LoadPreferences(),
+		mouseCapture:          true,
 		hideInput:             opts.HideInputArea,
 		hideActionHints:       opts.HideActionHints,
 		disableExitKeys:       opts.DisableExitKeys,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -528,8 +528,9 @@ func TestAppModel_EscFromCrons_NoTranscriptLeavesChatUntouched(t *testing.T) {
 // TestAppModel_MouseMode_TogglesCaptureAndView verifies the /mouse
 // command path: a mouseModeMsg flips the authoritative mouseCapture flag,
 // View() emits MouseModeCellMotion only when capture is on, and the chat
-// model gets a feedback row. Capture must default off so click-drag runs
-// the terminal's native selection (lucinate-ai/lucinate#14).
+// model gets a feedback row. NewApp defaults capture ON (wheel scrolls,
+// in-app selection copies — see selection.go); /mouse off remains the
+// opt-out that hands click-drag back to the terminal's native selection.
 func TestAppModel_MouseMode_TogglesCaptureAndView(t *testing.T) {
 	m := AppModel{state: viewChat}
 	// hideInput skips the textarea render so View() doesn't touch the
@@ -537,8 +538,10 @@ func TestAppModel_MouseMode_TogglesCaptureAndView(t *testing.T) {
 	// after the per-view switch and is independent of the chat body.
 	m.chatModel = chatModel{viewport: viewport.New(), hideInput: true}
 
+	// Zero-value model starts with capture off; the NewApp default (on) is
+	// covered by TestNewApp_MouseCaptureDefaultsOn.
 	if got := m.View(); got.MouseMode != tea.MouseModeNone {
-		t.Fatalf("default MouseMode = %v, want MouseModeNone (selection must work out of the box)", got.MouseMode)
+		t.Fatalf("zero-value MouseMode = %v, want MouseModeNone", got.MouseMode)
 	}
 
 	on, _ := m.update(mouseModeMsg{action: "on"})

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -152,6 +152,9 @@ type chatModel struct {
 	viewport           viewport.Model
 	textarea           textarea.Model
 	messages           []chatMessage
+	sel                selectionState // in-app mouse drag selection over the transcript; see selection.go
+	selLines           []string       // rendered content lines (styled, unpadded, pre-highlight); rebuilt by updateViewport; the hit-test and copy source for the selection
+	viewportTopPad     int            // blank rows updateViewport prepends to bottom-anchor short content; hit-testing subtracts it
 	backend            backend.Backend
 	connName           string // active connection name, rendered in the header bar
 	sessionKey         string
@@ -1115,6 +1118,22 @@ func (m chatModel) Update(msg tea.Msg) (chatModel, tea.Cmd) {
 		m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
 		m.updateViewport()
 		return m, spinnerTickCmd()
+
+	// In-app mouse selection over the transcript (see selection.go). These
+	// return early so the events never reach the textarea or the viewport;
+	// wheel events are a distinct message type and keep their existing path
+	// through the passToViewport gate below.
+	case tea.MouseClickMsg:
+		m.handleMouseClick(msg)
+		return m, nil
+
+	case tea.MouseMotionMsg:
+		m.handleMouseMotion(msg)
+		return m, nil
+
+	case tea.MouseReleaseMsg:
+		cmd := m.handleMouseRelease(msg)
+		return m, cmd
 	}
 
 	// Update sub-components.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -76,7 +76,7 @@ const helpBody = `/quit, /exit — quit lucinate
 /header reset — restore the default header colour
 /models — open model picker (filter as you type)
 /model <name> — switch model directly
-/mouse on|off — toggle mouse capture (on = wheel scrolls history; off = native click-drag text selection)
+/mouse on|off — mouse capture (on, the default: wheel scrolls history, drag selects & copies; off: native terminal selection)
 /record on|off — toggle live transcript capture for this session (bare /record shows state)
 /reset — delete session and start fresh
 /sessions — browse and restore previous sessions
@@ -1096,9 +1096,9 @@ func (m *chatModel) handleMouseCommand(text string) (bool, tea.Cmd) {
 func (m *chatModel) reportMouseMode(on bool) {
 	var content string
 	if on {
-		content = "Mouse capture is ON — the wheel scrolls chat history. Native click-drag selection is disabled; hold Shift (or Option on macOS) to select & copy. Use /mouse off to restore native selection."
+		content = "Mouse capture is ON (default) — the wheel scrolls chat history, and click-drag selects text and copies it to the clipboard on release. Use /mouse off for your terminal's native selection."
 	} else {
-		content = "Mouse capture is OFF — click-drag selects & copies text natively. Use /mouse on to enable mouse-wheel scrolling of the chat history."
+		content = "Mouse capture is OFF — click-drag selects & copies text natively via your terminal. Use /mouse on to restore wheel scrolling and in-app selection."
 	}
 	m.appendMessage(chatMessage{role: "system", content: content})
 	m.updateViewport()

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -92,11 +92,31 @@ func (m *chatModel) updateViewport() {
 
 	content := b.String()
 
+	// Cache the rendered lines for mouse selection (hit-testing + copy) and
+	// bake in the highlight while a drag is active. Coordinates are line
+	// indexes into these lines, so they survive pure restyles (a spinner
+	// frame swap keeps the count) but not row shifts — if the rendered line
+	// count changes mid-drag (streaming growth, history refresh), drop the
+	// selection rather than highlight the wrong text.
+	lines := strings.Split(content, "\n")
+	if m.sel.dragging && len(lines) != len(m.selLines) {
+		m.sel = selectionState{}
+	}
+	m.selLines = lines
+	if m.sel.dragging {
+		display := make([]string, len(lines))
+		copy(display, lines)
+		applySelectionHighlight(display, m.sel.anchor, m.sel.head)
+		content = strings.Join(display, "\n")
+	}
+
 	// Pad the top so messages are anchored to the bottom of the viewport.
+	// Record the pad so selection hit-testing can subtract the blank rows.
+	m.viewportTopPad = 0
 	contentLines := strings.Count(content, "\n")
 	if contentLines < m.viewport.Height() {
-		padding := strings.Repeat("\n", m.viewport.Height()-contentLines)
-		content = padding + content
+		m.viewportTopPad = m.viewport.Height() - contentLines
+		content = strings.Repeat("\n", m.viewportTopPad) + content
 	}
 
 	// Only auto-follow when the user is already pinned at the bottom. If they've

--- a/internal/tui/selection.go
+++ b/internal/tui/selection.go
@@ -1,0 +1,232 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// In-app mouse text selection for the chat transcript.
+//
+// Mouse capture (SGR cell-motion tracking) is on by default, which means the
+// terminal no longer performs native click-drag selection over the chat —
+// instead the wheel scrolls the viewport and these handlers implement
+// selection: press anchors, drag extends (with a reverse-video highlight),
+// release copies the selected text to the clipboard. /mouse off restores the
+// terminal's native selection for anyone who prefers it.
+//
+// Positions are stored in content coordinates (line index into the rendered
+// transcript, display-cell column), not screen coordinates, so an in-progress
+// selection survives viewport scrolling — including wheel scrolling mid-drag.
+
+// selPoint is a position in the rendered transcript: line indexes
+// chatModel.selLines (the unpadded rendered content lines); col is a
+// display-cell column within that line.
+type selPoint struct {
+	line int
+	col  int
+}
+
+// selectionState tracks an in-progress drag selection.
+type selectionState struct {
+	dragging bool     // left button held; the highlight renders while true
+	anchor   selPoint // where the press landed
+	head     selPoint // latest drag position
+}
+
+// hitTest maps a 0-based screen cell (x, y) to a content position. Screen row
+// 0 is the header; the viewport occupies rows 1..Height() at column 0, and
+// updateViewport top-pads short content with viewportTopPad blank rows, so:
+//
+//	contentLine = viewport.YOffset() + (y − 1) − viewportTopPad
+//
+// strict=true returns ok=false outside the transcript (header, pad rows,
+// chrome below the viewport) — used for the initial click so presses on the
+// input area don't start a selection; strict=false clamps into content bounds
+// — used for the drag head so dragging past an edge selects to that edge.
+func (m *chatModel) hitTest(x, y int, strict bool) (selPoint, bool) {
+	if len(m.selLines) == 0 {
+		return selPoint{}, false
+	}
+	row := y - 1 // row 0 is the header
+	if strict && (row < 0 || row >= m.viewport.Height()) {
+		return selPoint{}, false
+	}
+	line := m.viewport.YOffset() + row - m.viewportTopPad
+	if strict && (line < 0 || line >= len(m.selLines)) {
+		return selPoint{}, false
+	}
+	line = clampInt(line, 0, len(m.selLines)-1)
+	w := ansi.StringWidth(m.selLines[line])
+	col := clampInt(x, 0, max(0, w-1)) // empty line → col 0
+	return selPoint{line: line, col: col}, true
+}
+
+// handleMouseClick starts a drag selection on a left press inside the
+// transcript, and clears any previous selection on every left press.
+func (m *chatModel) handleMouseClick(msg tea.MouseClickMsg) {
+	mo := msg.Mouse()
+	if mo.Button != tea.MouseLeft {
+		return
+	}
+	had := m.sel.dragging
+	m.sel = selectionState{}
+	if p, ok := m.hitTest(mo.X, mo.Y, true); ok {
+		m.sel = selectionState{dragging: true, anchor: p, head: p}
+	}
+	if had || m.sel.dragging {
+		m.updateViewport()
+	}
+}
+
+// handleMouseMotion extends the drag selection. Dragging onto the header row
+// or below the transcript auto-scrolls the viewport one line per motion event
+// so a drag can reach content beyond the visible region.
+func (m *chatModel) handleMouseMotion(msg tea.MouseMotionMsg) {
+	if !m.sel.dragging {
+		return
+	}
+	mo := msg.Mouse()
+	if mo.Button != tea.MouseLeft {
+		return
+	}
+	if mo.Y <= 0 {
+		m.viewport.SetYOffset(m.viewport.YOffset() - 1)
+	} else if mo.Y >= 1+m.viewport.Height() {
+		m.viewport.SetYOffset(m.viewport.YOffset() + 1)
+	}
+	if p, ok := m.hitTest(mo.X, mo.Y, false); ok {
+		m.sel.head = p
+	}
+	m.updateViewport()
+}
+
+// handleMouseRelease finalises the drag: a non-empty selection is extracted
+// as plain text and copied to the clipboard, then the highlight clears.
+// MouseNone is accepted because some terminals report SGR release without
+// echoing the pressed button.
+func (m *chatModel) handleMouseRelease(msg tea.MouseReleaseMsg) tea.Cmd {
+	if !m.sel.dragging {
+		return nil
+	}
+	mo := msg.Mouse()
+	if mo.Button != tea.MouseLeft && mo.Button != tea.MouseNone {
+		return nil
+	}
+	a, b := m.sel.anchor, m.sel.head
+	m.sel = selectionState{}
+	var cmd tea.Cmd
+	if a != b {
+		if text := extractSelection(m.selLines, a, b); text != "" {
+			cmd = copySelectionCmd(text)
+			m.notify(copyNotice(text))
+		}
+	}
+	m.updateViewport()
+	return cmd
+}
+
+// normalizeSel orders a before b (by line, then col).
+func normalizeSel(a, b selPoint) (selPoint, selPoint) {
+	if a.line > b.line || (a.line == b.line && a.col > b.col) {
+		return b, a
+	}
+	return a, b
+}
+
+// extractSelection returns the plain text between a and b, inclusive of the
+// cell under b (ansi.Cut is half-open, hence the +1 on the end column).
+// Trailing spaces are trimmed per line so padded layout gaps don't end up on
+// the clipboard.
+func extractSelection(lines []string, a, b selPoint) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	a, b = normalizeSel(a, b)
+	a.line = clampInt(a.line, 0, len(lines)-1)
+	b.line = clampInt(b.line, 0, len(lines)-1)
+
+	cut := func(line string, from, to int) string {
+		w := ansi.StringWidth(line)
+		from = clampInt(from, 0, w)
+		to = clampInt(to, from, w)
+		return strings.TrimRight(ansi.Strip(ansi.Cut(line, from, to)), " ")
+	}
+
+	if a.line == b.line {
+		return cut(lines[a.line], a.col, b.col+1)
+	}
+	out := make([]string, 0, b.line-a.line+1)
+	out = append(out, cut(lines[a.line], a.col, ansi.StringWidth(lines[a.line])))
+	for i := a.line + 1; i < b.line; i++ {
+		out = append(out, strings.TrimRight(ansi.Strip(lines[i]), " "))
+	}
+	out = append(out, cut(lines[b.line], 0, b.col+1))
+	return strings.Join(out, "\n")
+}
+
+// applySelectionHighlight rewrites the lines intersecting the selection,
+// restyling the selected span with selectionStyle over ANSI-stripped text —
+// the selection overrides inner styling, like native terminal selection.
+// Width-invariant: stripping removes only zero-width escape sequences and the
+// restyle adds only SGR sequences, so row alignment is unaffected.
+func applySelectionHighlight(lines []string, a, b selPoint) {
+	a, b = normalizeSel(a, b)
+	for i := max(a.line, 0); i <= b.line && i < len(lines); i++ {
+		w := ansi.StringWidth(lines[i])
+		x0, x1 := 0, w
+		if i == a.line {
+			x0 = clampInt(a.col, 0, w)
+		}
+		if i == b.line {
+			x1 = clampInt(b.col+1, 0, w)
+		}
+		if x0 >= x1 {
+			// A zero-width span on an empty (or fully-left) line: still mark
+			// whole middle lines of a multi-line selection visibly? No — an
+			// empty line has nothing to invert; skip it.
+			continue
+		}
+		pre := ansi.Cut(lines[i], 0, x0)
+		mid := selectionStyle.Render(ansi.Strip(ansi.Cut(lines[i], x0, x1)))
+		post := ansi.Cut(lines[i], x1, w)
+		lines[i] = pre + mid + post
+	}
+}
+
+// copySelectionCmd writes text to the clipboard two ways: OSC 52 through the
+// renderer (reaches the hosting terminal — a native platform's terminal view,
+// tmux with set-clipboard, iTerm2) and the local OS clipboard (covers
+// terminals that ignore OSC 52, e.g. Terminal.app for local sessions). OS
+// clipboard errors are ignored — OSC 52 is the fallback.
+func copySelectionCmd(text string) tea.Cmd {
+	return tea.Batch(
+		tea.SetClipboard(text),
+		func() tea.Msg {
+			_ = clipboard.WriteAll(text)
+			return nil
+		},
+	)
+}
+
+// copyNotice renders the ephemeral confirmation row for a completed copy.
+func copyNotice(text string) string {
+	chars := len([]rune(text))
+	if n := strings.Count(text, "\n") + 1; n > 1 {
+		return fmt.Sprintf("Copied %d lines (%d chars) to clipboard.", n, chars)
+	}
+	return fmt.Sprintf("Copied %d chars to clipboard.", chars)
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -1,0 +1,248 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// newSelectionChat builds a chat model with rendered content ready for
+// hit-testing: real setSize, messages rendered through updateViewport.
+func newSelectionChat(t *testing.T, contents ...string) chatModel {
+	t.Helper()
+	m := newChatModel(newFakeBackend(), "session-key", "agent-id", "agent", "", config.DefaultPreferences(), false, "", "", false)
+	m.setSize(80, 24)
+	m.historyLoading = false
+	for _, c := range contents {
+		m.appendMessage(chatMessage{role: "system", content: c})
+	}
+	m.updateViewport()
+	return m
+}
+
+// screenRowOf returns the 0-based screen row (as a mouse event Y) where the
+// given content line is currently displayed: the inverse of hitTest.
+func screenRowOf(m *chatModel, line int) int {
+	return line + m.viewportTopPad - m.viewport.YOffset() + 1
+}
+
+func TestSelection_HitTest(t *testing.T) {
+	m := newSelectionChat(t, "alpha", "bravo", "charlie")
+
+	// A known content line maps back to itself through the formula.
+	for want := 0; want < 3; want++ {
+		y := screenRowOf(&m, want)
+		p, ok := m.hitTest(0, y, true)
+		if !ok || p.line != want {
+			t.Fatalf("hitTest(0, %d, strict) = %+v ok=%v, want line %d", y, p, ok, want)
+		}
+	}
+
+	// The header row (y=0) is rejected in strict mode.
+	if _, ok := m.hitTest(0, 0, true); ok {
+		t.Fatal("strict hitTest accepted the header row")
+	}
+
+	// A padding row above the content is rejected in strict mode (short
+	// content is bottom-anchored, so early viewport rows are blank pad).
+	if m.viewportTopPad < 2 {
+		t.Fatalf("test setup expects blank pad rows, got pad=%d", m.viewportTopPad)
+	}
+	if _, ok := m.hitTest(0, 2, true); ok {
+		t.Fatal("strict hitTest accepted a blank padding row")
+	}
+
+	// Non-strict clamps out-of-range rows into content bounds.
+	if p, ok := m.hitTest(0, 0, false); !ok || p.line != 0 {
+		t.Fatalf("non-strict top clamp = %+v ok=%v, want line 0", p, ok)
+	}
+	if p, ok := m.hitTest(0, 1+m.viewport.Height()+5, false); !ok || p.line != 2 {
+		t.Fatalf("non-strict bottom clamp = %+v ok=%v, want line 2", p, ok)
+	}
+
+	// X clamps to the line's width.
+	y := screenRowOf(&m, 0)
+	w := ansi.StringWidth(m.selLines[0])
+	if p, _ := m.hitTest(500, y, true); p.col != w-1 {
+		t.Fatalf("x clamp = col %d, want %d", p.col, w-1)
+	}
+
+	// Empty content: no crash, no hit.
+	var empty chatModel
+	if _, ok := empty.hitTest(0, 1, true); ok {
+		t.Fatal("hitTest on empty model reported a hit")
+	}
+}
+
+func TestSelection_HitTest_ScrolledViewport(t *testing.T) {
+	// Enough content to overflow the viewport so YOffset participates.
+	var contents []string
+	for i := 0; i < 40; i++ {
+		contents = append(contents, strings.Repeat("x", 10))
+	}
+	m := newSelectionChat(t, contents...)
+	if m.viewportTopPad != 0 {
+		t.Fatalf("expected no top pad with overflowing content, got %d", m.viewportTopPad)
+	}
+	if m.viewport.YOffset() == 0 {
+		t.Fatal("expected a scrolled viewport (auto-follow to bottom)")
+	}
+	// The first visible row (y=1) maps to the line at YOffset.
+	p, ok := m.hitTest(0, 1, true)
+	if !ok || p.line != m.viewport.YOffset() {
+		t.Fatalf("hitTest(0,1) = %+v ok=%v, want line %d", p, ok, m.viewport.YOffset())
+	}
+}
+
+func TestSelection_Extract(t *testing.T) {
+	styled := userPrefixStyle.Render("You: ") + "hello world"
+	lines := []string{styled, "second line here", "third"}
+
+	// Single-line span, inclusive of the end cell, styling stripped.
+	got := extractSelection(lines, selPoint{0, 5}, selPoint{0, 9})
+	if got != "hello" {
+		t.Fatalf("single-line extract = %q, want %q", got, "hello")
+	}
+
+	// Reversed anchor/head normalises.
+	if got := extractSelection(lines, selPoint{0, 9}, selPoint{0, 5}); got != "hello" {
+		t.Fatalf("reversed extract = %q, want %q", got, "hello")
+	}
+
+	// Multi-line: first-partial, whole middle, last-partial.
+	got = extractSelection(lines, selPoint{0, 5}, selPoint{2, 2})
+	want := "hello world\nsecond line here\nthi"
+	if got != want {
+		t.Fatalf("multi-line extract = %q, want %q", got, want)
+	}
+
+	// Trailing spaces are trimmed per line.
+	padded := []string{"abc   ", "def"}
+	if got := extractSelection(padded, selPoint{0, 0}, selPoint{1, 2}); got != "abc\ndef" {
+		t.Fatalf("padded extract = %q, want %q", got, "abc\ndef")
+	}
+
+	// Wide runes at the boundary: selecting through an emoji keeps output
+	// printable (ansi.Cut may substitute a space when splitting a wide cell;
+	// the exact behaviour is documented by this assertion not crashing and
+	// producing the full glyph when the span covers both its cells).
+	wide := []string{"a🙂b"}
+	if got := extractSelection(wide, selPoint{0, 0}, selPoint{0, 3}); got != "a🙂b" {
+		t.Fatalf("wide-rune extract = %q, want %q", got, "a🙂b")
+	}
+}
+
+func TestSelection_HighlightWidthInvariant(t *testing.T) {
+	lines := []string{
+		userPrefixStyle.Render("You: ") + "hello world",
+		assistantPrefixStyle.Render("agent: ") + statusStyle.Render("styled body"),
+		"plain",
+	}
+	widths := make([]int, len(lines))
+	for i, l := range lines {
+		widths[i] = ansi.StringWidth(l)
+	}
+
+	applySelectionHighlight(lines, selPoint{0, 2}, selPoint{2, 3})
+
+	for i, l := range lines {
+		if got := ansi.StringWidth(l); got != widths[i] {
+			t.Errorf("line %d width changed %d → %d after highlight", i, widths[i], got)
+		}
+	}
+	// The reverse-video SGR must be present on every intersecting line.
+	for i, l := range lines {
+		if !strings.Contains(l, "\x1b[7m") {
+			t.Errorf("line %d missing reverse-video SGR: %q", i, l)
+		}
+	}
+}
+
+func TestSelection_InvalidatedOnLineCountChange(t *testing.T) {
+	m := newSelectionChat(t, "alpha", "bravo")
+	m.sel = selectionState{dragging: true, anchor: selPoint{0, 0}, head: selPoint{1, 2}}
+
+	// A re-render with the same line count preserves the selection (spinner
+	// restyles do exactly this every frame).
+	m.updateViewport()
+	if !m.sel.dragging {
+		t.Fatal("selection dropped by a same-count re-render")
+	}
+
+	// Appending a message changes the rendered line count → selection drops.
+	m.appendMessage(chatMessage{role: "system", content: "charlie"})
+	m.updateViewport()
+	if m.sel.dragging {
+		t.Fatal("selection survived a line-count change; would highlight the wrong rows")
+	}
+}
+
+func TestSelection_DragSelectCopyFlow(t *testing.T) {
+	m := newSelectionChat(t, "alpha", "bravo", "charlie")
+
+	y0 := screenRowOf(&m, 0)
+	y2 := screenRowOf(&m, 2)
+
+	// Press on line 0 starts a drag.
+	m, _ = m.Update(tea.MouseClickMsg{X: 0, Y: y0, Button: tea.MouseLeft})
+	if !m.sel.dragging {
+		t.Fatal("left press on the transcript did not start a drag")
+	}
+
+	// Drag to line 2: the transcript viewport shows the reverse-video
+	// highlight. (Scoped to the viewport — the composer cursor also uses
+	// reverse video, so the full frame always contains the SGR.)
+	m, _ = m.Update(tea.MouseMotionMsg{X: 4, Y: y2, Button: tea.MouseLeft})
+	if m.sel.head.line != 2 {
+		t.Fatalf("drag head line = %d, want 2", m.sel.head.line)
+	}
+	if !strings.Contains(m.viewport.View(), "\x1b[7m") {
+		t.Fatal("no selection highlight in the viewport during drag")
+	}
+
+	// Release copies and clears.
+	m, cmd := m.Update(tea.MouseReleaseMsg{X: 4, Y: y2, Button: tea.MouseLeft})
+	if cmd == nil {
+		t.Fatal("release of a non-empty selection returned no copy command")
+	}
+	if m.sel.dragging {
+		t.Fatal("selection still active after release")
+	}
+	if strings.Contains(m.viewport.View(), "\x1b[7m") {
+		t.Fatal("highlight still present in the viewport after release")
+	}
+	if len(m.notifications) == 0 {
+		t.Fatal("no copy notification after release")
+	}
+
+	// A plain click (press+release, no movement) copies nothing.
+	m, _ = m.Update(tea.MouseClickMsg{X: 0, Y: y0, Button: tea.MouseLeft})
+	m, cmd = m.Update(tea.MouseReleaseMsg{X: 0, Y: y0, Button: tea.MouseLeft})
+	if cmd != nil {
+		t.Fatal("plain click produced a copy command")
+	}
+
+	// A press outside the transcript (header row) does not start a drag.
+	m, _ = m.Update(tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if m.sel.dragging {
+		t.Fatal("press on the header started a drag")
+	}
+}
+
+func TestNewApp_MouseCaptureDefaultsOn(t *testing.T) {
+	m := NewApp(newFakeBackend(), AppOptions{})
+	if !m.mouseCapture {
+		t.Fatal("NewApp must default mouseCapture on (wheel scroll + in-app selection)")
+	}
+	// And the view advertises cell-motion tracking.
+	m.state = viewChat
+	m.chatModel = chatModel{viewport: viewport.New(), hideInput: true}
+	if got := m.View(); got.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("default MouseMode = %v, want MouseModeCellMotion", got.MouseMode)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -33,6 +33,11 @@ var (
 			Foreground(accent).
 			Bold(true)
 
+	// In-app mouse selection highlight. Reverse video, like a terminal's
+	// native selection; applied over ANSI-stripped text so the highlight
+	// overrides inner styling (see applySelectionHighlight).
+	selectionStyle = lipgloss.NewStyle().Reverse(true)
+
 	// Input area border.
 	inputBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).


### PR DESCRIPTION
Make history scrolling, mouse text selection, and arrow-key input recall coexist in the chat view.

## Summary
- Mouse capture (SGR cell-motion tracking) is now **on by default**: the wheel scrolls the conversation history, and — because the terminal no longer translates wheel movement into arrow keys — Up/Down stay reserved for bash-style input recall.
- Click-drag now selects transcript text **in-app** with a reverse-video highlight, and copies it to the clipboard on release (both OSC 52 through the terminal and the OS clipboard directly), with a "Copied…" confirmation row. This restores the copy capability that previously forced tracking off (#14).
- `/mouse off` remains the opt-out, handing click-drag back to the terminal's native selection at the cost of wheel scrolling; `/mouse on` restores the default.
- Selection is char-precise, spans multiple lines, auto-scrolls when dragged past the viewport edge, and strips styling from the copied text.
- Docs updated: README highlights/keys/commands, `docs/chat-ux.md` (new "Scrolling, selection, and the mouse" section, bash-style walk documented), `docs/commands.md` gains the `/mouse` entry.

## Implementation details
- Selection state lives on `chatModel` in content coordinates (rendered-line index + display-cell column), so an in-progress selection survives scrolling — including wheel scrolling mid-drag. `updateViewport` caches the rendered lines, records the top-padding used to bottom-anchor short transcripts (hit-testing subtracts it), and bakes the highlight into the display copy only.
- Span extraction and highlighting use `ansi.Cut`/`ansi.Strip`, so they are ANSI- and grapheme-aware without hand-rolled escape parsing; the highlight is width-invariant (SGR-only rewrites), keeping row alignment intact.
- If the rendered line count changes mid-drag (streaming growth, history refresh), the selection is dropped rather than left highlighting the wrong rows; pure restyles such as spinner ticks preserve it.
- Copy goes through both `tea.SetClipboard` (OSC 52 — reaches the native platforms' terminal host, tmux, iTerm2) and `atotto/clipboard` (terminals that ignore OSC 52), promoting the latter from an indirect to a direct dependency.
- Verified end-to-end in tmux by injecting raw SGR mouse sequences: wheel scrolling, drag highlight lifecycle, both clipboard routes, recall, the `/mouse` toggle, and scroll-position hold during streaming.
