### PR TITLE
fix: freeze form inputs while create/auth mutations are in flight

### DIFF
--- a/internal/tui/connecting.go
+++ b/internal/tui/connecting.go
@@ -41,6 +41,13 @@ type connectingModel struct {
 	tokenInput textinput.Model
 	authErr    error
 
+	// resolving is set once the user commits a recovery choice (submit
+	// token, clear/reset identity, retry pairing) and the store+connect
+	// round-trip is dispatched. While set, the modal ignores further
+	// input so a double-tap can't dispatch the mutation twice. Reset on
+	// re-entry (enterAuthModal) when a retry lands back on this modal.
+	resolving bool
+
 	width  int
 	height int
 
@@ -68,6 +75,9 @@ func (m *connectingModel) enterAuthModal(conn *config.Connection, b backend.Back
 	m.backend = b
 	m.authErr = err
 	m.authNeed = need
+	// A retry that failed again re-enters this same model instance;
+	// clear the in-flight guard so the reopened modal is interactive.
+	m.resolving = false
 	switch need {
 	case authRecoveryTokenMismatch:
 		m.subState = subStateAuthMismatchPrompt
@@ -100,6 +110,10 @@ func (m connectingModel) Update(msg tea.Msg) (connectingModel, tea.Cmd) {
 		return m.handleKey(key)
 	}
 	if m.subState == subStateAuthTokenPrompt {
+		if m.resolving {
+			// Submit is in flight; freeze the field.
+			return m, nil
+		}
 		var cmd tea.Cmd
 		m.tokenInput, cmd = m.tokenInput.Update(msg)
 		return m, cmd
@@ -108,12 +122,20 @@ func (m connectingModel) Update(msg tea.Msg) (connectingModel, tea.Cmd) {
 }
 
 func (m connectingModel) handleKey(msg tea.KeyPressMsg) (connectingModel, tea.Cmd) {
+	if m.resolving {
+		// A recovery choice is already committed and its store+connect
+		// round-trip is in flight; ignore further input until the
+		// result lands (success transitions away, a repeat failure
+		// re-enters via enterAuthModal which clears the flag).
+		return m, nil
+	}
 	switch m.subState {
 	case subStatePairingRequired:
 		switch msg.String() {
 		case "enter", "r":
 			b := m.backend
 			conn := m.connection
+			m.resolving = true
 			return m, func() tea.Msg {
 				return authResolvedMsg{connection: conn, backend: b}
 			}
@@ -131,6 +153,7 @@ func (m connectingModel) handleKey(msg tea.KeyPressMsg) (connectingModel, tea.Cm
 		case "1", "enter":
 			b := m.backend
 			conn := m.connection
+			m.resolving = true
 			return m, func() tea.Msg {
 				if auth, ok := b.(backend.DeviceTokenAuth); ok {
 					if err := auth.ClearToken(); err != nil {
@@ -142,6 +165,7 @@ func (m connectingModel) handleKey(msg tea.KeyPressMsg) (connectingModel, tea.Cm
 		case "2":
 			b := m.backend
 			conn := m.connection
+			m.resolving = true
 			return m, func() tea.Msg {
 				if auth, ok := b.(backend.DeviceTokenAuth); ok {
 					if err := auth.ResetIdentity(); err != nil {
@@ -169,6 +193,7 @@ func (m connectingModel) handleKey(msg tea.KeyPressMsg) (connectingModel, tea.Cm
 			b := m.backend
 			conn := m.connection
 			need := m.authNeed
+			m.resolving = true
 			return m, func() tea.Msg {
 				// Dispatch on the modal's recovery type rather than
 				// on backend interface assertion: a single backend
@@ -376,6 +401,9 @@ func (m connectingModel) viewPairingRequired() string {
 	writeLine("  approve command. Run that command, then press Enter to retry.")
 
 	footer := helpStyle.Render("  Enter: retry | Esc: cancel")
+	if m.resolving {
+		footer = statusStyle.Render("  Retrying...")
+	}
 
 	if m.height <= 0 {
 		return titleLine + body.String() + "\n" + footer
@@ -407,6 +435,9 @@ func (m connectingModel) viewAuthToken() string {
 	tokenEnd := lineCount - 1
 
 	footer := helpStyle.Render("  Enter: submit | Esc: cancel")
+	if m.resolving {
+		footer = statusStyle.Render("  Submitting...")
+	}
 
 	if m.height <= 0 {
 		return titleLine + body.String() + "\n" + footer

--- a/internal/tui/connecting_test.go
+++ b/internal/tui/connecting_test.go
@@ -152,6 +152,54 @@ func TestConnectingModel_TokenPromptIgnoresEmpty(t *testing.T) {
 	}
 }
 
+func TestConnectingModel_ResolvingBlocksDoubleSubmit(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	fake := newFakeBackend()
+	m := newConnectingModel(conn, false)
+	m.enterAuthModal(conn, fake, authRecoveryTokenMissing, errors.New("gateway token missing"))
+
+	m.tokenInput.SetValue("pre-shared-token")
+	m, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected cmd from first Enter")
+	}
+	if !m.resolving {
+		t.Fatal("expected resolving=true after committing the submit")
+	}
+
+	// A second Enter while the store+connect round-trip is in flight must
+	// be ignored so the mutation can't be dispatched twice.
+	m, cmd2 := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd2 != nil {
+		t.Error("second Enter should be ignored while resolving")
+	}
+	// The field is frozen too: a printable key doesn't mutate it.
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	if got := m.tokenInput.Value(); got != "pre-shared-token" {
+		t.Errorf("token field mutated while resolving: got %q", got)
+	}
+}
+
+func TestConnectingModel_EnterAuthModalClearsResolving(t *testing.T) {
+	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
+	fake := newFakeBackend()
+	m := newConnectingModel(conn, false)
+	m.enterAuthModal(conn, fake, authRecoveryTokenMissing, errors.New("gateway token missing"))
+
+	m.tokenInput.SetValue("tok")
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !m.resolving {
+		t.Fatal("expected resolving=true after submit")
+	}
+
+	// A retry that failed again re-enters the same model instance; the
+	// reopened modal must be interactive.
+	m.enterAuthModal(conn, fake, authRecoveryTokenMissing, errors.New("still missing"))
+	if m.resolving {
+		t.Error("expected resolving cleared on re-entry via enterAuthModal")
+	}
+}
+
 func TestConnectingModel_PairingRequiredShowsInstructions(t *testing.T) {
 	conn := &config.Connection{Name: "home", URL: "https://home.example.com"}
 	m := newConnectingModel(conn, false)

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -640,6 +640,12 @@ func (m selectModel) TriggerAction(id string) (selectModel, tea.Cmd) {
 }
 
 func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
+	if m.creating {
+		// Create RPC in flight; ignore all input. The call has
+		// already left, so there's nothing to cancel — mirror
+		// handleConfirmDeleteKey's freeze while m.deleting.
+		return m, nil
+	}
 	switch msg.String() {
 	case "esc":
 		m.subState = subStateList
@@ -649,9 +655,6 @@ func (m selectModel) handleCreateKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd)
 		return m, m.switchFocus()
 
 	case "enter":
-		if m.creating {
-			return m, nil
-		}
 		name := m.nameInput.Value()
 		m.nameValidMsg = validateName(name)
 		if m.nameValidMsg != "" {
@@ -717,6 +720,12 @@ func (m selectModel) updateConfirmDelete(msg tea.Msg) (selectModel, tea.Cmd) {
 }
 
 func (m selectModel) updateCreateForm(msg tea.Msg) (selectModel, tea.Cmd) {
+	if m.creating {
+		// Freeze the inputs while the create RPC is in flight so
+		// cursor blink / paste / etc. can't mutate the form mid-commit
+		// — matches updateConfirmDelete's guard on m.deleting.
+		return m, nil
+	}
 	prevName := m.nameInput.Value()
 
 	var cmd tea.Cmd

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -265,6 +265,37 @@ func TestSelectModel_AgentCreatedError(t *testing.T) {
 	}
 }
 
+func TestSelectModel_CreatingBlocksKeystrokes(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m.subState = subStateCreate
+	m.nameInput.SetValue("my-agent")
+	m.focusedField = 0
+	m.creating = true
+
+	// A printable key, Tab, and Esc must all be inert while the create
+	// RPC is in flight — the form is frozen until agentCreatedMsg lands.
+	for _, key := range []tea.KeyPressMsg{
+		{Code: 'x', Text: "x"},
+		{Code: tea.KeyTab},
+		{Code: tea.KeyEsc},
+	} {
+		m, _ = m.handleKey(key)
+	}
+
+	if got := m.nameInput.Value(); got != "my-agent" {
+		t.Errorf("name input mutated while creating: got %q, want %q", got, "my-agent")
+	}
+	if m.focusedField != 0 {
+		t.Errorf("focus changed while creating: got %d, want 0", m.focusedField)
+	}
+	if m.subState != subStateCreate {
+		t.Errorf("esc backed out of the form while creating: subState = %v, want subStateCreate", m.subState)
+	}
+	if !m.creating {
+		t.Error("creating flag should remain set until the result arrives")
+	}
+}
+
 func TestSelectModel_AutoSelectNewAgent(t *testing.T) {
 	m := newSelectModel(nil, false, false, nil, false, "")
 	m.newAgentID = "new-agent"


### PR DESCRIPTION
Freeze a form's inputs while its create/auth network call is in flight, so the fields can't be edited mid-commit while the request is outstanding.

## Summary
- **Create-agent form:** while the `CreateAgent` RPC is in flight, the name/workspace inputs, Tab, and Esc are now inert. Previously only the Enter key was guarded, so the fields stayed editable mid-commit and the UX felt brittle.
- **Auth-token / API-key recovery modal:** the same freeze now applies, closing a gap where the modal had no in-flight guard at all — a double-Enter could dispatch the store-token + reconnect round-trip twice.
- **Failure handling is preserved:** on error the form/modal re-enables with the entered values intact and the existing retry hint, so the user can edit and resubmit.
- A `Creating agent…` / `Submitting…` / `Retrying…` status is shown while the call is outstanding.

## Implementation details
This reuses the freeze convention already established in the TUI rather than inventing a new one: the confirm-delete substate guards on `m.deleting` and the cron form guards on `m.form.saving`, each short-circuiting its key handler while the mutation is outstanding and clearing the flag when the result lands.

- `internal/tui/select.go`: `handleCreateKey` and `updateCreateForm` now short-circuit on `m.creating`, so every keystroke, Tab (`switchFocus`), and Esc is dropped until `agentCreatedMsg` arrives. The existing `agentCreatedMsg` handler and error footer are untouched, so edit/retry-after-failure still works. The freeze is deliberately hard (Esc included): letting Esc back out mid-flight would return to the list, where a later error can't render and would be silently swallowed — matching the confirm-delete precedent.
- `internal/tui/connecting.go`: adds a `resolving` flag, set when a recovery choice is committed (token/API-key submit, clear/reset identity, pairing retry). `handleKey` and the token-input update path short-circuit while it's set; `enterAuthModal` clears it so a repeat failure reopens an interactive modal. The token and pairing views render a `Submitting…` / `Retrying…` status while resolving.

Tests: added `TestSelectModel_CreatingBlocksKeystrokes`, `TestConnectingModel_ResolvingBlocksDoubleSubmit`, and `TestConnectingModel_EnterAuthModalClearsResolving` (the last confirming a retry stays interactive). `go build ./...`, `go vet ./internal/tui/...`, and the full `go test ./...` suite pass.