### PR TITLE
feat(tui): bare `/model` now reports current model instead of error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### Changed
-- feat(tui): bare `/model` now reports the model in use for the current session instead of an error
-
 ## [1.21.0] - 2026-07-13
 ### Added
 - feat: default mouse capture on with in-app transcript selection (#171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- feat(tui): bare `/model` now reports the model in use for the current session instead of an error
+
 ## [1.21.0] - 2026-07-13
 ### Added
 - feat: default mouse capture on with in-app transcript selection (#171)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,6 +30,7 @@ Slash input that isn't a built-in is checked against the loaded skill names: if 
 | `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted per agent across runs — see below |
 | `/header reset` | Restore the default header colour for the current agent (also accepts `default` or `off`) |
 | `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
+| `/model` | Report the model in use for the current session |
 | `/model <name>` | Switch model — see below |
 | `/models` | Open the model picker (filter as you type) |
 | `/mouse` | Report the current mouse-capture state |
@@ -57,7 +58,7 @@ Backend-only commands render a "not available on this connection" system message
 
 ### /model
 
-`handleModelCommand()` requires a name argument; bare `/model` emits an inline hint pointing at `/models`. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
+`handleModelCommand()` reports the current model for the active session when called with no argument (falling back to `gateway default` when `m.modelID` is empty), pointing the user at `/models` and `/model <name>` to change it. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
 
 ### /stats
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -75,6 +75,7 @@ const helpBody = `/quit, /exit — quit lucinate
 /header <hex> — set chat header background to a hex colour (e.g. #112233 or #F0C)
 /header reset — restore the default header colour
 /models — open model picker (filter as you type)
+/model — show the model in use for this session
 /model <name> — switch model directly
 /mouse on|off — mouse capture (on, the default: wheel scrolls history, drag selects & copies; off: native terminal selection)
 /record on|off — toggle live transcript capture for this session (bare /record shows state)
@@ -515,14 +516,19 @@ func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 	return true, m.gateNavigation("Switching agents", switchCmd)
 }
 
-// handleModelCommand handles `/model <name>`. Bare `/model` is an error —
-// `/models` opens the picker.
+// handleModelCommand handles `/model` and `/model <name>`. Bare `/model`
+// reports the model in use for the active session; `/models` opens the
+// picker to change it.
 func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
 	parts := strings.SplitN(strings.TrimSpace(text), " ", 2)
 	if len(parts) == 1 || strings.TrimSpace(parts[1]) == "" {
+		model := m.modelID
+		if model == "" {
+			model = "gateway default"
+		}
 		m.appendMessage(chatMessage{
-			role:   "system",
-			errMsg: "/model requires a name — use /models to open the picker",
+			role:    "system",
+			content: fmt.Sprintf("Model: %s\nUse /models to open the picker, or /model <name> to switch.", model),
 		})
 		m.updateViewport()
 		return true, nil

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -307,18 +307,37 @@ func TestSlashCommand_Skills_Populated(t *testing.T) {
 	}
 }
 
-func TestSlashCommand_Model_BareEmitsHint(t *testing.T) {
+func TestSlashCommand_Model_BareReportsCurrentModel(t *testing.T) {
 	m := newSlashTestModel()
+	m.modelID = "claude-opus-4-8"
 	handled, cmd := m.handleSlashCommand("/model")
 	if !handled {
 		t.Fatal("expected /model to be handled")
 	}
 	if cmd != nil {
-		t.Error("expected bare /model to return no cmd (inline error only)")
+		t.Error("expected bare /model to return no cmd (inline report only)")
 	}
 	last := m.messages[len(m.messages)-1]
-	if last.role != "system" || !strings.Contains(last.errMsg, "/models") {
-		t.Errorf("expected hint pointing at /models, got: %+v", last)
+	if last.role != "system" || last.errMsg != "" {
+		t.Errorf("expected a system content row, got: %+v", last)
+	}
+	if !strings.Contains(last.content, "claude-opus-4-8") {
+		t.Errorf("expected current model in report, got: %q", last.content)
+	}
+}
+
+func TestSlashCommand_Model_BareWithoutModelReportsDefault(t *testing.T) {
+	m := newSlashTestModel()
+	handled, _ := m.handleSlashCommand("/model")
+	if !handled {
+		t.Fatal("expected /model to be handled")
+	}
+	last := m.messages[len(m.messages)-1]
+	if last.role != "system" || last.errMsg != "" {
+		t.Errorf("expected a system content row, got: %+v", last)
+	}
+	if !strings.Contains(last.content, "gateway default") {
+		t.Errorf("expected gateway-default fallback, got: %q", last.content)
 	}
 }
 


### PR DESCRIPTION
## Summary
Changed the `/model` command behavior when called without arguments to report the model currently in use for the session, rather than displaying an error message. This improves the user experience by making it easier to check the active model.

## Key Changes
- **Command behavior**: Bare `/model` now displays the current model ID (or "gateway default" if not set) instead of an error hint
- **User guidance**: Updated the inline message to guide users toward `/models` (picker) or `/model <name>` (direct switch) options
- **Documentation**: Updated help text and command documentation to reflect the new behavior
- **Tests**: Refactored existing test to verify the new reporting behavior and added a new test case for the default model fallback scenario

## Implementation Details
- When `/model` is called without arguments, the command checks `m.modelID` and displays it; if empty, it falls back to "gateway default"
- The message is now appended as a system message with `content` (instead of `errMsg`), making it a regular informational message rather than an error
- Updated help documentation in both the inline help (`helpBody`) and the external `docs/commands.md` file