### PR TITLE
fix(tui): qualify model reference with provider prefix on switch

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,7 +58,9 @@ Backend-only commands render a "not available on this connection" system message
 
 ### /model
 
-`handleModelCommand()` reports the current model for the active session when called with no argument (falling back to `gateway default` when `m.modelID` is empty), pointing the user at `/models` and `/model <name>` to change it. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelID)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
+`handleModelCommand()` reports the current model for the active session when called with no argument (falling back to `gateway default` when `m.modelID` is empty), pointing the user at `/models` and `/model <name>` to change it. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelRef)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
+
+Both switch paths — the `/model <name>` command and the `/models` picker — patch with the **qualified `<provider>/<id>` reference** produced by `qualifiedModelRef()` (`internal/tui/models.go`), not the bare id. `models.list` reports a provider-local id (e.g. `deepseek/deepseek-v4-pro`) alongside a separate `provider` field (e.g. `openrouter`), but `sessions.patch` — like the agent's configured `model.primary` — validates against the fully-qualified form (`openrouter/deepseek/deepseek-v4-pro`). Sending the bare id makes the gateway reject the switch with `INVALID_REQUEST: model not allowed: <id>`. Backends that leave `provider` empty (openai, hermes) keep the bare id unchanged.
 
 ### /stats
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -556,10 +556,14 @@ func (m *chatModel) handleModelCommand(text string) (bool, tea.Cmd) {
 		if match == nil {
 			return modelSwitchedMsg{err: fmt.Errorf("no model matching %q", query)}
 		}
-		if err := b.SessionPatchModel(context.Background(), sessionKey, match.ID); err != nil {
+		// Patch with the qualified "<provider>/<id>" reference the
+		// gateway expects — match.ID alone is provider-local and gets
+		// rejected as "model not allowed" (see qualifiedModelRef).
+		modelRef := qualifiedModelRef(*match)
+		if err := b.SessionPatchModel(context.Background(), sessionKey, modelRef); err != nil {
 			return modelSwitchedMsg{err: err}
 		}
-		return modelSwitchedMsg{modelID: match.ID}
+		return modelSwitchedMsg{modelID: modelRef}
 	}
 }
 

--- a/internal/tui/models.go
+++ b/internal/tui/models.go
@@ -30,6 +30,24 @@ func (i modelItem) FilterValue() string {
 	return strings.Join(parts, " ")
 }
 
+// qualifiedModelRef returns the fully-qualified "<provider>/<id>" model
+// reference the gateway expects for sessions.patch. models.list reports
+// a provider-local id (e.g. "deepseek/deepseek-v4-pro") alongside a
+// separate provider (e.g. "openrouter"), but the session model and the
+// agent's configured model.primary are the qualified form
+// ("openrouter/deepseek/deepseek-v4-pro"). Sending the bare id makes the
+// gateway reject the switch with "model not allowed: <id>".
+//
+// Backends that don't populate Provider (openai, hermes) keep the bare
+// id unchanged. The prefix guard is idempotent, so an already-qualified
+// id from a future gateway isn't double-prefixed.
+func qualifiedModelRef(mc protocol.ModelChoice) string {
+	if mc.Provider == "" || strings.HasPrefix(mc.ID, mc.Provider+"/") {
+		return mc.ID
+	}
+	return mc.Provider + "/" + mc.ID
+}
+
 // modelDelegate renders each model row in the picker.
 type modelDelegate struct{}
 
@@ -165,10 +183,13 @@ func (m modelPickerModel) Update(msg tea.Msg) (modelPickerModel, tea.Cmd) {
 		m.list.SetItems(items)
 		// Pre-select the active model so Enter on an empty filter
 		// picks "the one you already have" rather than a surprising
-		// jump to the top of the list.
+		// jump to the top of the list. currentModelID is the qualified
+		// "<provider>/<id>" reference (from agent.Model.Primary), so
+		// match it against the qualified ref; the bare-id fallback keeps
+		// backends without a provider (openai, hermes) working.
 		if m.currentModelID != "" {
 			for idx, mc := range msg.models {
-				if mc.ID == m.currentModelID {
+				if qualifiedModelRef(mc) == m.currentModelID || mc.ID == m.currentModelID {
 					m.list.Select(idx)
 					break
 				}
@@ -196,7 +217,7 @@ func (m modelPickerModel) handleKey(msg tea.KeyPressMsg) (modelPickerModel, tea.
 	// when the whole point of the view is type-then-pick.
 	if msg.String() == "enter" && !m.loading && m.err == nil {
 		if item, ok := m.list.SelectedItem().(modelItem); ok {
-			modelID := item.model.ID
+			modelID := qualifiedModelRef(item.model)
 			b := m.backend
 			sessionKey := m.sessionKey
 			switchCmd := func() tea.Msg {

--- a/internal/tui/models_test.go
+++ b/internal/tui/models_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+// TestQualifiedModelRef covers the provider-prefix normalisation the
+// model picker and /model command apply before sessions.patch. The
+// gateway reports a provider-local id + separate provider from
+// models.list, but sessions.patch validates against the fully-qualified
+// "<provider>/<id>" reference — so the bare id must be joined with its
+// provider or the switch is rejected with "model not allowed".
+func TestQualifiedModelRef(t *testing.T) {
+	tests := []struct {
+		name string
+		in   protocol.ModelChoice
+		want string
+	}{
+		{
+			name: "openrouter provider-local slug gets prefixed",
+			in:   protocol.ModelChoice{ID: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+			want: "openrouter/deepseek/deepseek-v4-pro",
+		},
+		{
+			name: "simple provider and id",
+			in:   protocol.ModelChoice{ID: "claude-sonnet-4", Provider: "anthropic"},
+			want: "anthropic/claude-sonnet-4",
+		},
+		{
+			name: "empty provider keeps bare id (openai/hermes)",
+			in:   protocol.ModelChoice{ID: "gpt-4o", Provider: ""},
+			want: "gpt-4o",
+		},
+		{
+			name: "already-qualified id is not double-prefixed",
+			in:   protocol.ModelChoice{ID: "openrouter/deepseek/deepseek-v4-pro", Provider: "openrouter"},
+			want: "openrouter/deepseek/deepseek-v4-pro",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qualifiedModelRef(tt.in); got != tt.want {
+				t.Errorf("qualifiedModelRef(%+v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Switching models against an OpenClaw gateway now sends the fully-qualified `<provider>/<id>` reference, so `/models` and `/model` no longer fail with `INVALID_REQUEST: model not allowed`.

## Summary

- Add `qualifiedModelRef()`, which joins a `ModelChoice`'s `provider` and `id` into the `<provider>/<id>` reference the gateway validates `sessions.patch` against (e.g. `openrouter/deepseek/deepseek-v4-pro`), rather than sending the bare provider-local id.
- Apply it in both switch paths — the `/models` picker and the `/model <name>` command — resolving the `model not allowed` rejection when the picked model belongs to a provider such as OpenRouter.
- Fix the picker's active-model pre-selection, which compared the bare id against the qualified `currentModelID` (sourced from the agent's `model.primary`) and so never highlighted the current model.
- Leave bare ids untouched for backends that don't populate `provider` (openai, hermes); the prefix guard is idempotent, so an already-qualified id is not double-prefixed.
- Add `TestQualifiedModelRef` and document the behaviour in `docs/commands.md`.

## Implementation details

The gateway exposes model identity in two different shapes. `models.list` returns a provider-local `id` (e.g. `deepseek/deepseek-v4-pro`) alongside a separate `provider` field (e.g. `openrouter`), whereas `sessions.patch` and the agent's configured `model.primary` use the fully-qualified `<provider>/<id>` form (e.g. `openrouter/deepseek/deepseek-v4-pro`). The picker previously passed the bare id straight through, which the gateway rejected against its allowed set.

`qualifiedModelRef` centralises the join so both switch paths and the pre-selection comparison agree on the qualified form. The header display is unaffected because it already trims a model reference to its last path segment.
