### PR TITLE
feat(tui): add filtering to the agent picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- feat(tui): filter the agent picker by name or ID — press `/` to fuzzy-filter the list, `esc` to clear
+
 ### Changed
 - fix(tui): render queued messages in a footer below the tool-activity strip (directly above the input) instead of at the bottom of the scrollable transcript
 - fix(tui): pin informational notifications (e.g. "copied … to clipboard") to the top below the header and drop error notifications to the bottommost row below the queued messages

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -17,6 +17,7 @@ Unlike the model picker, the agent picker starts in plain list mode rather than 
 - **Keystroke routing.** While the filter input is focused (`list.FilterState() == list.Filtering`), `handleKey` forwards every key except `enter` to the list so characters that collide with action shortcuts (e.g. `n`) type into the query instead of firing the action. Outside filtering, the normal action dispatch applies.
 - **Enter selects from the filter.** `enter` picks the highlighted agent from any filter state, so the user can type-to-narrow and pick in one keystroke rather than first applying the filter (the bubbles default while typing). When the filter matches nothing, `enter` falls through to the list.
 - **Input focus.** `selectModel.filtering()` reports whether the filter is focused; `app.go`'s `computeWantsInput()` consults it (alongside the create-agent form) so the app-level `q`-to-quit shortcut and the embedder input-focus signal treat a typed `q` as filter text rather than a quit request.
+- **Reset on re-entry.** The picker reuses one `selectModel` across navigation, so leaving for another screen (config, connections, chat) and coming back would otherwise restore a stale narrowed view. `AppModel.Update` calls `selectModel.resetFilter()` on every transition *into* `viewSelect`, clearing the query so the list reopens showing every agent. It's a no-op when no filter was active.
 
 ## Auto-selection
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -8,6 +8,16 @@ Agents come from the active backend (`backend.Backend.ListAgents`). For OpenClaw
 
 `loadAgents()` calls `client.ListAgents()` and returns an `agentsLoadedMsg`. Each agent is an `agentItem` wrapping a `protocol.AgentSummary`. The list is displayed using a Bubble Tea list component with a custom delegate that shows the agent name (falling back to ID if no name is set).
 
+## Filtering
+
+The picker enables the Bubble Tea list's built-in filtering with the same fuzzy matcher (`fuzzyFilter`) as the model picker (`internal/tui/models.go`). Press `/` to open the filter, type to narrow, and `esc` to clear it. `agentItem.FilterValue()` concatenates the agent's name and ID, so a query matches either — typing part of a display name or part of the raw agent ID both hit the same agent.
+
+Unlike the model picker, the agent picker starts in plain list mode rather than dropping straight into filtering: the single-letter action shortcuts (`n` new, `d` delete, `c` connections) must stay reachable, so filtering is opt-in via `/`.
+
+- **Keystroke routing.** While the filter input is focused (`list.FilterState() == list.Filtering`), `handleKey` forwards every key except `enter` to the list so characters that collide with action shortcuts (e.g. `n`) type into the query instead of firing the action. Outside filtering, the normal action dispatch applies.
+- **Enter selects from the filter.** `enter` picks the highlighted agent from any filter state, so the user can type-to-narrow and pick in one keystroke rather than first applying the filter (the bubbles default while typing). When the filter matches nothing, `enter` falls through to the list.
+- **Input focus.** `selectModel.filtering()` reports whether the filter is focused; `app.go`'s `computeWantsInput()` consults it (alongside the create-agent form) so the app-level `q`-to-quit shortcut and the embedder input-focus signal treat a typed `q` as filter text rather than a quit request.
+
 ## Auto-selection
 
 If exactly one agent is returned, it is selected automatically without user interaction and a session is created immediately. The same auto-select fires after creating a new agent — the picker bypasses the list and proceeds straight to chat.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -426,7 +426,10 @@ func (m AppModel) computeWantsInput() bool {
 	case viewChat:
 		return true
 	case viewSelect:
-		return m.selectModel.subState == subStateCreate
+		// subStateCreate focuses the new-agent form inputs; filtering
+		// focuses the list's fuzzy-filter query. Either means a typed
+		// key (including `q`) is text, not a navigation shortcut.
+		return m.selectModel.subState == subStateCreate || m.selectModel.filtering()
 	case viewConnections:
 		return m.connectionsModel.wantsInput()
 	case viewConnecting:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -268,6 +268,13 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	prevState := m.state
 	next, cmd := m.update(msg)
 	if next.state != prevState {
+		// Re-entering the agent picker from another screen (config,
+		// connections, chat) reuses the existing selectModel, so clear
+		// any active fuzzy filter — the list should reopen showing every
+		// agent, not a stale narrowed view from before we left.
+		if next.state == viewSelect {
+			next.selectModel.resetFilter()
+		}
 		// View transitions in an embedded terminal can leave stale cells
 		// from the previous view when an on-screen keyboard
 		// simultaneously toggles and resizes the embedder's grid

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -752,3 +752,50 @@ func TestAppModel_AskConfigSubScreenRoundTrip(t *testing.T) {
 		t.Errorf("expected esc from config to return to viewSelect origin, got %v", back.state)
 	}
 }
+
+// TestAppModel_FilterResetsWhenReenteringAgentList checks that returning
+// to the agent picker from another screen clears any active fuzzy filter
+// so the list reopens showing every agent, not a stale narrowed view.
+// Both re-entry messages (Back-from-config and the connections goBackMsg)
+// route through the same Update view-transition hook.
+func TestAppModel_FilterResetsWhenReenteringAgentList(t *testing.T) {
+	cases := []struct {
+		name string
+		from viewState
+		msg  tea.Msg
+		prep func(AppModel) AppModel
+	}{
+		{"from config", viewConfig, goBackFromConfigMsg{}, func(m AppModel) AppModel { m.configReturn = viewSelect; return m }},
+		{"from connections", viewConnections, goBackMsg{}, func(m AppModel) AppModel { return m }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := newSelectModel(nil, false, false, nil, false, "")
+			sm = loadAgents(sm,
+				protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+				protocol.AgentSummary{ID: "beta", Name: "Beta"},
+			)
+			sm.list.SetFilterText("beta")
+			if len(sm.list.VisibleItems()) != 1 {
+				t.Fatalf("setup: expected 1 filtered agent, got %d", len(sm.list.VisibleItems()))
+			}
+
+			m := AppModel{state: tc.from}
+			m.selectModel = sm
+			m = tc.prep(m)
+
+			back, _ := m.Update(tc.msg)
+			app := back.(AppModel)
+
+			if app.state != viewSelect {
+				t.Fatalf("expected viewSelect after re-entry, got %v", app.state)
+			}
+			if app.selectModel.list.FilterState() != list.Unfiltered {
+				t.Errorf("expected filter reset to Unfiltered, got %v", app.selectModel.list.FilterState())
+			}
+			if got := len(app.selectModel.list.VisibleItems()); got != 2 {
+				t.Errorf("expected full list (2 agents) after reset, got %d", got)
+			}
+		})
+	}
+}

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -1040,6 +1040,15 @@ func (m selectModel) filtering() bool {
 	return m.list.FilterState() == list.Filtering
 }
 
+// resetFilter clears any active fuzzy filter, restoring the full agent
+// list and unfocusing the filter input. The app calls it when the
+// picker is re-entered from another screen (config, connections, chat)
+// so a stale narrowed view doesn't persist across navigation. It's a
+// no-op when no filter is active.
+func (m *selectModel) resetFilter() {
+	m.list.ResetFilter()
+}
+
 func (m *selectModel) setSize(w, h int) {
 	m.width = w
 	m.height = h

--- a/internal/tui/select.go
+++ b/internal/tui/select.go
@@ -24,9 +24,13 @@ type agentItem struct {
 	sessionKey string
 }
 
+// FilterValue is the haystack the bubbles list filter (here: fuzzy
+// match) runs against. Concatenating Name and ID lets the user narrow
+// the list by either — typing part of a display name or part of the
+// raw agent ID both hit the same agent.
 func (i agentItem) FilterValue() string {
-	if i.agent.Name != "" {
-		return i.agent.Name
+	if i.agent.Name != "" && i.agent.Name != i.agent.ID {
+		return i.agent.Name + " " + i.agent.ID
 	}
 	return i.agent.ID
 }
@@ -205,7 +209,14 @@ func newSelectModel(b backend.Backend, hideHints, showConnections bool, activeCo
 	// anyway.
 	l.SetShowHelp(!hideHints)
 	l.Styles.Title = headerStyle
-	l.SetFilteringEnabled(false)
+	// Live filtering lets the user narrow a long agent list by pressing
+	// `/` and typing a query, reusing the same fuzzy matcher as the
+	// model picker (see models.go). Unlike that view, the agent picker
+	// starts in plain list mode — filtering is opt-in via `/` so the
+	// single-letter action shortcuts (n/d/c) stay reachable until the
+	// user chooses to filter.
+	l.SetFilteringEnabled(true)
+	l.Filter = fuzzyFilter
 	if disableExitKeys {
 		l.KeyMap.Quit.Unbind()
 		l.KeyMap.ForceQuit.Unbind()
@@ -507,6 +518,11 @@ func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 
 	// Enter is intrinsic list navigation (select the highlighted item)
 	// rather than a discoverable view-level command, so it stays inline.
+	// It selects from a live filter too, so the user can type to narrow
+	// then pick in one keystroke instead of first applying the filter
+	// (the bubbles default while typing). Falls through when nothing is
+	// selectable — e.g. a filter matching zero agents — so the list
+	// still gets the keystroke.
 	if msg.String() == "enter" {
 		if !m.loading && m.err == nil {
 			if item, ok := m.list.SelectedItem().(agentItem); ok {
@@ -519,6 +535,16 @@ func (m selectModel) handleKey(msg tea.KeyPressMsg) (selectModel, tea.Cmd) {
 				return m, nil
 			}
 		}
+	}
+
+	// While the filter input is focused, every other key (printable
+	// chars, backspace, esc-to-clear, cursor nav) belongs to the list
+	// so typing narrows the results instead of firing action shortcuts
+	// like `n`/`d`/`c` that collide with characters in agent names.
+	if m.list.FilterState() == list.Filtering {
+		var cmd tea.Cmd
+		m.list, cmd = m.list.Update(msg)
+		return m, cmd
 	}
 
 	// Discoverable shortcuts route through TriggerAction so the help
@@ -547,6 +573,15 @@ func (m selectModel) Actions() []Action {
 		// Mirror the loading view: no actionable surface while the
 		// gateway round-trip is in flight, so embedders that render
 		// Actions as buttons can't smuggle a re-entry past the gate.
+		return nil
+	}
+	if m.filtering() {
+		// While the fuzzy filter is focused the only interactions are
+		// intrinsic (type to narrow, enter to pick, esc to clear) — the
+		// list's own help footer surfaces those. The action shortcuts
+		// (n/d/c) have their keys captured as filter text here, so
+		// advertising them in the hint line or as embedder buttons
+		// would mislead.
 		return nil
 	}
 	if m.subState == subStateConfirmDelete {
@@ -995,6 +1030,14 @@ func (m selectModel) backupHint() string {
 func (m selectModel) selectedAgent() (agentItem, bool) {
 	item, ok := m.list.SelectedItem().(agentItem)
 	return item, ok
+}
+
+// filtering reports whether the agent list's fuzzy filter input is
+// focused — i.e. the user pressed `/` and is typing a query. The app
+// consults this so the q-to-quit shortcut and the embedder input-focus
+// signal treat a typed `q` as filter text rather than a quit request.
+func (m selectModel) filtering() bool {
+	return m.list.FilterState() == list.Filtering
 }
 
 func (m *selectModel) setSize(w, h int) {

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"github.com/a3tai/openclaw-go/protocol"
 	"github.com/charmbracelet/x/ansi"
@@ -949,6 +950,164 @@ func TestSelectModel_SelectingViewRendersLoading(t *testing.T) {
 	// navigating.
 	if strings.Contains(view, "Beta") {
 		t.Errorf("expected list to be hidden while selecting, got:\n%s", view)
+	}
+}
+
+func TestSelectModel_FilterKeyEntersFilteringState(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+	)
+	if m.filtering() {
+		t.Fatal("filter should be inactive before pressing /")
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	if !m.filtering() {
+		t.Error("expected `/` to open the list filter (filtering state)")
+	}
+}
+
+// TestSelectModel_FilterCapturesActionKeys guards the regression the
+// handleKey filter-state branch exists to prevent: while the filter is
+// focused, a letter that doubles as an action shortcut (`n` = new-agent)
+// must type into the filter rather than trigger the action.
+func TestSelectModel_FilterCapturesActionKeys(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m.allowAgentManagement = true
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "nova", Name: "Nova"},
+	)
+	m, _ = m.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+	if !m.filtering() {
+		t.Fatal("setup: expected filtering state after /")
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+
+	if m.subState == subStateCreate {
+		t.Error("`n` while filtering must not open the create form")
+	}
+	if !m.filtering() {
+		t.Error("expected to remain in filtering state after typing")
+	}
+	if got := m.list.FilterInput.Value(); got != "n" {
+		t.Errorf("filter input = %q, want %q (keystroke should reach the filter)", got, "n")
+	}
+}
+
+// TestSelectModel_FilterHidesActionHints verifies the action shortcuts
+// (n/d/c) are withdrawn while the filter is focused, since their keys
+// are captured as filter text and advertising them would mislead.
+func TestSelectModel_FilterHidesActionHints(t *testing.T) {
+	m := newSelectModel(nil, false, true, nil, false, "")
+	m.allowAgentManagement = true
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+	)
+	if len(m.Actions()) == 0 {
+		t.Fatal("setup: expected actions before filtering")
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	if got := m.Actions(); len(got) != 0 {
+		t.Errorf("expected no actions while filtering, got %+v", got)
+	}
+}
+
+func TestSelectModel_FilterNarrowsList(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+		protocol.AgentSummary{ID: "gamma", Name: "Gamma"},
+	)
+	if len(m.list.VisibleItems()) != 3 {
+		t.Fatalf("setup: expected 3 visible agents, got %d", len(m.list.VisibleItems()))
+	}
+
+	m.list.SetFilterText("beta")
+
+	vis := m.list.VisibleItems()
+	if len(vis) != 1 {
+		t.Fatalf("expected filter to narrow to 1 agent, got %d", len(vis))
+	}
+	if item, ok := vis[0].(agentItem); !ok || item.agent.ID != "beta" {
+		t.Errorf("visible agent = %+v, want beta", vis[0])
+	}
+}
+
+// TestSelectModel_FilterMatchesByID exercises the FilterValue haystack:
+// concatenating name and ID lets a query hit the raw agent ID even when
+// the display name shares no characters with it.
+func TestSelectModel_FilterMatchesByID(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "id-scout", Name: "Reconnaissance"},
+		protocol.AgentSummary{ID: "id-pilot", Name: "Navigator"},
+	)
+
+	m.list.SetFilterText("scout")
+
+	vis := m.list.VisibleItems()
+	if len(vis) != 1 {
+		t.Fatalf("expected 1 match filtering by ID substring, got %d", len(vis))
+	}
+	if item, _ := vis[0].(agentItem); item.agent.ID != "id-scout" {
+		t.Errorf("matched %+v, want id-scout", vis[0])
+	}
+}
+
+// TestSelectModel_EnterSelectsFilteredAgent verifies the type-to-narrow
+// then Enter-picks-in-one-keystroke flow: Enter selects the highlighted
+// match instead of the bubbles default (apply-filter) while typing.
+func TestSelectModel_EnterSelectsFilteredAgent(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+		protocol.AgentSummary{ID: "gamma", Name: "Gamma"},
+	)
+	m.list.SetFilterText("beta")
+	// SetFilterText lands in FilterApplied; return to Filtering to mirror
+	// pressing Enter while still typing the query.
+	m.list.SetFilterState(list.Filtering)
+
+	m, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if !m.selecting {
+		t.Fatal("expected Enter to select the filtered agent")
+	}
+	if m.selectingName != "Beta" {
+		t.Errorf("selectingName = %q, want Beta", m.selectingName)
+	}
+}
+
+// TestComputeWantsInput_FilteringAgentList ensures a focused agent-list
+// filter counts as wanting input, so the app-level q-to-quit shortcut
+// and the embedder keyboard signal yield to filter typing.
+func TestComputeWantsInput_FilteringAgentList(t *testing.T) {
+	sm := newSelectModel(nil, false, false, nil, false, "")
+	sm = loadAgents(sm,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+	)
+
+	m := AppModel{state: viewSelect}
+	m.selectModel = sm
+	if m.computeWantsInput() {
+		t.Fatal("plain list navigation should not want input")
+	}
+
+	sm.list.SetFilterState(list.Filtering)
+	m.selectModel = sm
+	if !m.computeWantsInput() {
+		t.Error("expected computeWantsInput=true while the agent filter is focused")
 	}
 }
 

--- a/internal/tui/select_test.go
+++ b/internal/tui/select_test.go
@@ -1088,6 +1088,33 @@ func TestSelectModel_EnterSelectsFilteredAgent(t *testing.T) {
 	}
 }
 
+// TestSelectModel_ResetFilterClearsQuery verifies resetFilter drops the
+// active query and restores the full agent list.
+func TestSelectModel_ResetFilterClearsQuery(t *testing.T) {
+	m := newSelectModel(nil, false, false, nil, false, "")
+	m = loadAgents(m,
+		protocol.AgentSummary{ID: "alpha", Name: "Alpha"},
+		protocol.AgentSummary{ID: "beta", Name: "Beta"},
+		protocol.AgentSummary{ID: "gamma", Name: "Gamma"},
+	)
+	m.list.SetFilterText("beta")
+	if len(m.list.VisibleItems()) != 1 {
+		t.Fatalf("setup: expected 1 filtered agent, got %d", len(m.list.VisibleItems()))
+	}
+
+	m.resetFilter()
+
+	if m.list.FilterState() != list.Unfiltered {
+		t.Errorf("FilterState = %v, want Unfiltered", m.list.FilterState())
+	}
+	if got := len(m.list.VisibleItems()); got != 3 {
+		t.Errorf("expected all 3 agents visible after reset, got %d", got)
+	}
+	if m.filtering() {
+		t.Error("filtering() should be false after reset")
+	}
+}
+
 // TestComputeWantsInput_FilteringAgentList ensures a focused agent-list
 // filter counts as wanting input, so the app-level q-to-quit shortcut
 // and the embedder keyboard signal yield to filter typing.


### PR DESCRIPTION
Add a fuzzy filter to the agent picker so users can narrow a long agent list by name or ID.

## Summary
- Enable the Bubble Tea list's built-in filtering on the agent picker, reusing the model picker's `fuzzyFilter`; press `/` to open the filter, type to narrow, and `esc` to clear.
- Match against both the agent name and ID — `FilterValue` concatenates them, so a query hits either.
- Keep filtering opt-in via `/` so the single-letter action shortcuts (`n` new, `d` delete, `c` connections) stay reachable in plain list mode.
- Route keystrokes to the query while the filter is focused, so letters that collide with action keys type into the filter instead of firing the action; withdraw the action hints during filtering.
- Select the highlighted match on `enter` from any filter state, so type-to-narrow then pick works in a single keystroke.
- Treat an active filter as wanting input (`computeWantsInput`) so the app-level `q`-to-quit shortcut and the embedder keyboard signal yield to filter typing.

## Implementation details
The agent picker deliberately diverges from the model picker, which drops straight into filtering on load. The agent picker starts in plain list mode because its view is primarily a launchpad with single-key actions, so filtering is opt-in to avoid stealing those keys. The `q`-to-quit integration was the non-obvious part: the global shortcut is gated on `computeWantsInput()`, whose comment previously assumed the navigation lists had filtering disabled, so enabling it here required teaching that predicate about the new filter-focused state.
