### PR TITLE
docs: adopt OpenSpec for spec-driven development

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,156 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,161 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,175 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,110 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,144 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/commands/opsx/update.md
+++ b/.claude/commands/opsx/update.md
@@ -1,0 +1,82 @@
+---
+name: "OPSX: Update"
+description: Update a change - revise existing planning artifacts and keep them coherent (Experimental)
+allowed-tools: Bash(openspec:*)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:update` (e.g., `/opsx:update add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to update.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic).

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-update-change/SKILL.md
+++ b/.claude/skills/openspec-update-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: openspec-update-change
+description: Update an OpenSpec change by revising its existing planning artifacts and keeping them coherent with one another. Use when the user wants to revise a change's plan, fold new decisions into it, or reconcile its artifacts after an edit. Never edits code.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to update.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,26 +34,49 @@ lucinate is a TUI chat client for backend agent runtimes, built with bubbletea. 
 
 `main.go` runs `ResolveEntryConnection()` → constructs `app.RunOptions` with a `BackendFactory` that dispatches by `Connection.Type` → launches bubbletea. The TUI owns the connection lifecycle in managed mode (Connect, auth modals, switch via `/connections`); the app driver in `app/app.go` rewires the events pump and supervisor whenever a new backend is published via `OnBackendChanged`.
 
-See [docs/connections.md](docs/connections.md) for the full picture (capability negotiation, auth recovery, secrets storage, OpenAI agent storage layout).
+See [`openspec/specs/connections/spec.md`](openspec/specs/connections/spec.md) for the full picture (capability negotiation, auth recovery, secrets storage, OpenAI agent storage layout), and [docs/connections.md](docs/connections.md) for the rationale behind it.
 
 ### Key dependency
 
 `github.com/a3tai/openclaw-go` is a **local replace** (`../openclaw-go`) — the OpenClaw Go SDK must be checked out as a sibling directory.
 
-## Developer docs
+## Specs and developer docs
 
-The `docs/` directory contains maintainer-level documentation for the main subsystems:
+This project uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) for spec-driven
+development. Three places hold the project's knowledge and each has its own lane — keep them
+there:
 
-- [connections.md](docs/connections.md) — connection types, picker, startup decision tree, capability negotiation, OpenAI agent storage, secrets
-- [authentication.md](docs/authentication.md) — device pairing flow, identity storage, gateway connection
-- [agents.md](docs/agents.md) — agent picker, auto-selection, agent creation
-- [sessions.md](docs/sessions.md) — session lifecycle, session browser, compact/reset, message queueing
-- [commands.md](docs/commands.md) — slash command dispatch, all built-in commands, tab completion, confirmation pattern
-- [one-shot.md](docs/one-shot.md) — `lucinate send` lifecycle, default session rule, detach semantics, embedding `app.Send`
-- [shell-execution.md](docs/shell-execution.md) — `!` local and `!!` remote exec, two-phase approval
-- [skills.md](docs/skills.md) — skill file format, discovery, catalog injection, activation
-- [chat-ux.md](docs/chat-ux.md) — input bindings, streaming animation, thinking levels, header bar, history depth
-- [message-rendering.md](docs/message-rendering.md) — message roles, `System:` prefix convention, history cleanup, markdown rendering
+- **`openspec/specs/<domain>/spec.md`** — the behavioural contract (requirements + scenarios):
+  the source of truth for *what* each subsystem does. `openspec list --specs` lists them.
+- **`docs/<domain>.md`** — the lessons, pitfalls, and design rationale (the *why*), each pointing
+  at its sibling spec. See [docs/README.md](docs/README.md) for the doc↔spec index.
+- **`openspec/config.yaml`** `context` — project-wide conventions (tech stack, the keyboard-key
+  vocabulary, the native-platform naming rule). This is the **canonical** home for conventions
+  and is injected into every OpenSpec proposal; update it here rather than restating rules
+  elsewhere, so they can't drift.
+
+Reach for the spec for "what should happen"; the doc for "why, and what to watch out for".
+
+### Making a change
+
+For any non-trivial change to behaviour, work through OpenSpec rather than editing a spec by
+hand — the delta gets reviewed before it lands in the spec:
+
+1. `/opsx:propose <kebab-id>` (optionally `/opsx:explore` first to think it through) scaffolds
+   `openspec/changes/<id>/` with `proposal.md`, `design.md`, `tasks.md`, and delta specs under
+   `specs/<domain>/spec.md` using `## ADDED` / `## MODIFIED` / `## REMOVED Requirements`.
+2. Implement against `tasks.md` (`/opsx:apply`), keeping code, tests, and the delta in step.
+3. `/opsx:archive` merges the delta into `openspec/specs/` and moves the change to
+   `openspec/changes/archive/`.
+
+The `/opsx:*` slash commands and `openspec-*` skills are installed under `.claude/`. Useful CLI:
+`openspec list [--specs]`, `openspec show <item>`, `openspec validate --specs`,
+`openspec archive <id>`. OpenSpec is brownfield-first: write specs for what you are changing —
+don't back-fill specs for untouched code.
+
+Small, self-contained fixes (a typo, a one-line behaviour tweak with its test) may update the
+spec directly — and the doc if the reasoning changed — without the full change ceremony where it
+adds no value.
 
 ## Testing requirements
 
@@ -76,9 +99,17 @@ Add or update tests whenever you change behaviour. Focus on core functionality �
 - Rendered output → use `teatest/v2` against a model adapter (see `rendering_test.go`). Assert on ANSI-stripped bytes via a single `teatest.WaitFor` — repeated `WaitFor` calls drain `tm.Output()`.
 - Anything requiring a real backend → guard with a build tag so `go test ./...` stays hermetic. The OpenClaw suite uses `//go:build integration` (`queue_integration_test.go`); the OpenAI suite uses `//go:build integration_openai` (`internal/backend/openai/integration_test.go`). Both have matching `make test-integration-{openclaw,openai}-{setup,,teardown}` targets (the OpenClaw setup splits further into `-ollama-setup` / `-bedrock-setup`) — see `test/integration/README.md`.
 
-Run `make test` before committing. Pushes trigger CI; a failing test blocks review.
+Run `make test` before committing (and `openspec validate --specs` if you touched any spec).
+Pushes trigger CI; a failing test blocks review.
 
-## Documentation
+## Keeping docs in sync
 
-When you add or change commands, key bindings, event handlers, or user-visible behaviour, update the relevant file(s) in the `docs/` directory. The docs listed in [Developer docs](#developer-docs) are the canonical reference for each subsystem — keep them in sync with the code.
+When you add or change commands, key bindings, event handlers, or user-visible behaviour:
+
+- **Behaviour changed?** Update the affected `openspec/specs/<domain>/spec.md` — through an
+  OpenSpec change for anything non-trivial (see [Making a change](#making-a-change)).
+- **Reasoning changed?** Update the matching `docs/<domain>.md` — a new pitfall, gotcha, or
+  design trade-off worth recording. Leave it untouched for pure behaviour changes.
+- **A convention changed?** Update `openspec/config.yaml`'s `context` (the canonical home), not a
+  copy of the rule scattered elsewhere.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,39 @@
-# Developer docs
+# Developer docs — lessons and rationale
 
-This directory contains maintainer-level documentation for lucinate. It covers how the major subsystems are implemented — intended as a starting point when working on a feature area, not as a user guide.
+This directory holds maintainer-level **lessons, pitfalls, and design rationale** for lucinate's
+subsystems: the "why it works this odd way" that doesn't have a first-class home in a spec.
+
+The **behavioural contract** for each subsystem — what it does, as requirements and scenarios —
+lives in [`openspec/specs/<domain>/spec.md`](../openspec/specs). Start there for "what should
+happen"; come here for "why it's built this way, and what to watch out for". When you change
+behaviour, the spec is the source of truth to keep in sync; a doc here is updated only when the
+*reasoning* changes.
 
 ## Index
 
-| Document | Covers |
+| Lessons doc | Behavioural contract |
 |---|---|
-| [connections.md](connections.md) | Connection types overview, picker, startup decision tree, capability negotiation, secrets |
-| [backend_openclaw.md](backend_openclaw.md) | OpenClaw backend: capability surface, skill catalog injection, device-token auth |
-| [backend_openai.md](backend_openai.md) | OpenAI-compat backend: SSE streaming, on-disk agent storage, IDENTITY.md/SOUL.md composition, local-pass compaction |
-| [backend_hermes.md](backend_hermes.md) | Hermes backend: `/v1/responses` chaining, synthetic single agent, server-side state |
-| [authentication.md](authentication.md) | Device pairing, Ed25519 identity, gateway connection and token lifecycle |
-| [agents.md](agents.md) | Agent picker, auto-selection, agent creation |
-| [sessions.md](sessions.md) | Session lifecycle, session browser, compact/reset, message queueing |
-| [crons.md](crons.md) | Gateway cron browser: list/detail/form substates, capability gating, raw-patch edit semantics |
-| [routines.md](routines.md) | Local prompt routines: STEPS.md format, controller lifecycle, auto-advance hook, directives, manager view |
-| [commands.md](commands.md) | Slash command dispatch, all built-in commands, tab completion, confirmation pattern |
-| [one-shot.md](one-shot.md) | One-shot CLI mode: `lucinate send` lifecycle, default session rule, detach semantics, embedding, the `ask` alias |
-| [chat-launch.md](chat-launch.md) | Pre-navigated TUI launch: `lucinate chat` override plumbing, consumption points, stale-clearing rules |
-| [shell-execution.md](shell-execution.md) | `!` local exec and `!!` remote exec with two-phase approval |
-| [export-and-recording.md](export-and-recording.md) | `/record` and `/export` transcripts: canonical-history tap, dedup, file layout, lifecycle |
-| [skills.md](skills.md) | Skill file format, discovery, catalog injection, activation |
-| [chat-ux.md](chat-ux.md) | Input key bindings, mouse scrolling and in-app selection, streaming animation, thinking levels, header bar, history depth |
-| [message-rendering.md](message-rendering.md) | Message roles, `System:` prefix convention, history cleanup, markdown rendering |
-| [key-conventions.md](key-conventions.md) | Cross-view keyboard conventions: action keys, confirms, navigation, form keys, reserved keys |
-| [logging.md](logging.md) | `internal/logging` design: `LUCINATE_LOG_*` env vars, destination rule, TUI-safety constraints |
+| [authentication.md](authentication.md) | [`specs/authentication`](../openspec/specs/authentication/spec.md) |
+| [connections.md](connections.md) | [`specs/connections`](../openspec/specs/connections/spec.md) |
+| [backend_openclaw.md](backend_openclaw.md) | [`specs/backend-openclaw`](../openspec/specs/backend-openclaw/spec.md) |
+| [backend_openai.md](backend_openai.md) | [`specs/backend-openai`](../openspec/specs/backend-openai/spec.md) |
+| [backend_hermes.md](backend_hermes.md) | [`specs/backend-hermes`](../openspec/specs/backend-hermes/spec.md) |
+| [agents.md](agents.md) | [`specs/agents`](../openspec/specs/agents/spec.md) |
+| [sessions.md](sessions.md) | [`specs/sessions`](../openspec/specs/sessions/spec.md) |
+| [crons.md](crons.md) | [`specs/crons`](../openspec/specs/crons/spec.md) |
+| [routines.md](routines.md) | [`specs/routines`](../openspec/specs/routines/spec.md) |
+| [commands.md](commands.md) | [`specs/commands`](../openspec/specs/commands/spec.md) |
+| [one-shot.md](one-shot.md) | [`specs/one-shot`](../openspec/specs/one-shot/spec.md) |
+| [chat-launch.md](chat-launch.md) | [`specs/chat-launch`](../openspec/specs/chat-launch/spec.md) |
+| [shell-execution.md](shell-execution.md) | [`specs/shell-execution`](../openspec/specs/shell-execution/spec.md) |
+| [export-and-recording.md](export-and-recording.md) | [`specs/export-and-recording`](../openspec/specs/export-and-recording/spec.md) |
+| [skills.md](skills.md) | [`specs/skills`](../openspec/specs/skills/spec.md) |
+| [chat-ux.md](chat-ux.md) | [`specs/chat-ux`](../openspec/specs/chat-ux/spec.md) |
+| [message-rendering.md](message-rendering.md) | [`specs/message-rendering`](../openspec/specs/message-rendering/spec.md) |
+| [logging.md](logging.md) | [`specs/logging`](../openspec/specs/logging/spec.md) |
+| [openclaw-go-fork.md](openclaw-go-fork.md) | [`specs/openclaw-go-fork`](../openspec/specs/openclaw-go-fork/spec.md) |
+
+[key-conventions.md](key-conventions.md) has no spec of its own — the cross-view keyboard
+vocabulary it describes is cross-cutting, so it lives in
+[`openspec/config.yaml`](../openspec/config.yaml)'s `context` (injected into every OpenSpec
+proposal). The doc remains here as the human-readable reference.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,70 +1,76 @@
-# Agent picker
+# Agent picker — lessons and rationale
 
-The agent picker (`selectModel` in `internal/tui/select.go`) is shown after a connection is established — either directly on startup when the connection is unambiguous, or after the user picks one from the connections picker (see [connections.md](connections.md)). It loads the list of configured agents and either presents a selection UI or auto-selects when only one agent exists. In managed mode the picker also surfaces a **Connections** action (key `c`) so the user can switch connection without first entering chat, and a **Settings** action (key `s`, gated on the same managed-mode flag) that emits `showConfigMsg{}` to open the settings screen. On OpenClaw connections it surfaces a **View crons** action (key `k`, gated on `backend.CronBackend`) that emits `showCronsMsg{filterAgentID: ""}` to open the cron browser across all agents — the one place to reach crons before entering a chat. `k` is dropped from the list's up-navigation to make room (`↑` still scrolls up); see [key-conventions.md](key-conventions.md).
+The behavioural contract for the agent picker lives in
+[`openspec/specs/agents/spec.md`](../openspec/specs/agents/spec.md) — where agents come from,
+loading, filtering, navigation, auto-selection, and the create/select/delete flows are all
+captured there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls,
+and design rationale behind that flow: the "why it works this odd way" that the spec's
+requirements don't dwell on.
 
-Agents come from the active backend (`backend.Backend.ListAgents`). For OpenClaw, that's the gateway's agent list. For OpenAI-compatible connections, agents are local — see [connections.md](connections.md#openai-agent-storage). For Hermes connections the list is one synthetic entry (the connected profile is the agent — see [backend_hermes.md](backend_hermes.md#one-profile-one-agent)) and the create-agent affordance is hidden via `Capabilities.AgentManagement`.
+## Filtering is opt-in, unlike the model picker
 
-## Loading agents
+The model picker drops straight into filtering, but the agent picker deliberately starts in
+plain list mode. The single-letter action shortcuts (`n` new, `d` delete, `c` connections) must
+stay reachable, so filtering is opt-in via `/`. Two consequences fall out of that decision:
 
-`loadAgents()` calls `client.ListAgents()` and returns an `agentsLoadedMsg`. Each agent is an `agentItem` wrapping a `protocol.AgentSummary`. The list is displayed using a Bubble Tea list component with a custom delegate that shows the agent name (falling back to ID if no name is set).
+- **Keystroke routing while filtering.** While the filter input is focused
+  (`list.FilterState() == list.Filtering`), `handleKey` forwards every key except `enter` to the
+  list so characters that collide with action shortcuts (e.g. `n`) type into the query instead of
+  firing the action. Outside filtering, the normal action dispatch applies.
+- **A typed `q` must not quit.** `selectModel.filtering()` reports whether the filter is focused;
+  `app.go`'s `computeWantsInput()` consults it (alongside the create-agent form) so the app-level
+  `q`-to-quit shortcut and the embedder input-focus signal treat a typed `q` as filter text rather
+  than a quit request.
 
-## Filtering
+## Pitfall: a stale narrowed filter on re-entry
 
-The picker enables the Bubble Tea list's built-in filtering with the same fuzzy matcher (`fuzzyFilter`) as the model picker (`internal/tui/models.go`). Press `/` to open the filter, type to narrow, and `esc` to clear it. `agentItem.FilterValue()` concatenates the agent's name and ID, so a query matches either — typing part of a display name or part of the raw agent ID both hit the same agent.
+The picker reuses one `selectModel` across navigation, so leaving for another screen (config,
+connections, chat) and coming back would otherwise restore a stale narrowed view. `AppModel.Update`
+calls `selectModel.resetFilter()` on every transition *into* `viewSelect`, clearing the query so the
+list reopens showing every agent. It's a no-op when no filter was active.
 
-Unlike the model picker, the agent picker starts in plain list mode rather than dropping straight into filtering: the single-letter action shortcuts (`n` new, `d` delete, `c` connections) must stay reachable, so filtering is opt-in via `/`.
+## `--agent` auto-pick runs before the single-agent branch, on purpose
 
-- **Keystroke routing.** While the filter input is focused (`list.FilterState() == list.Filtering`), `handleKey` forwards every key except `enter` to the list so characters that collide with action shortcuts (e.g. `n`) type into the query instead of firing the action. Outside filtering, the normal action dispatch applies.
-- **Enter selects from the filter.** `enter` picks the highlighted agent from any filter state, so the user can type-to-narrow and pick in one keystroke rather than first applying the filter (the bubbles default while typing). When the filter matches nothing, `enter` falls through to the list.
-- **Input focus.** `selectModel.filtering()` reports whether the filter is focused; `app.go`'s `computeWantsInput()` consults it (alongside the create-agent form) so the app-level `q`-to-quit shortcut and the embedder input-focus signal treat a typed `q` as filter text rather than a quit request.
-- **Reset on re-entry.** The picker reuses one `selectModel` across navigation, so leaving for another screen (config, connections, chat) and coming back would otherwise restore a stale narrowed view. `AppModel.Update` calls `selectModel.resetFilter()` on every transition *into* `viewSelect`, clearing the query so the list reopens showing every agent. It's a no-op when no filter was active.
+`selectModel.autoPickName` runs its ID-then-case-insensitive-name match **before** the
+single-agent and post-create branches. The reason is deliberate: a `--agent` mismatch in a
+single-agent connection should surface as an error banner on the picker rather than silently
+picking the only available agent. The override is one-shot — cleared on consume so a later
+`agentsLoadedMsg` (e.g. after a user-driven create) doesn't re-fire it. See the `chat-launch`
+spec for the full override-consumption story.
 
-## Auto-selection
+## Deleting an agent: the safety design
 
-If exactly one agent is returned, it is selected automatically without user interaction and a session is created immediately. The same auto-select fires after creating a new agent — the picker bypasses the list and proceeds straight to chat.
+The confirm-delete view is deliberately loud, and several of its choices exist to make a
+destructive action hard to fire by accident:
 
-`lucinate chat --agent <name>` is a third auto-pick driver: `selectModel.autoPickName` runs an ID-then-case-insensitive-name match on the first `agentsLoadedMsg` and selects the matching agent. It runs **before** the single-agent and post-create branches, so a `--agent` mismatch in a single-agent connection surfaces as an error banner on the picker rather than silently picking the only available agent. The override is one-shot: cleared on consume so a later `agentsLoadedMsg` (e.g. after a user-driven create) doesn't re-fire it. See [chat-launch.md](chat-launch.md) for the full override-consumption story.
+- **Keep files is the default.** `tab` flips `m.keepFiles`, which becomes `!DeleteFiles` on the
+  `backend.DeleteAgentParams`. It defaults to **keep files** (`keepFiles=true` → `DeleteFiles=false`),
+  so a mistaken confirmation preserves the agent's file content — the user has to toggle off to
+  destroy it. The view's description line switches with the toggle so the user can read what the
+  current mode will do before pressing enter.
+- **Type-to-confirm as the disable mechanism.** `confirm-delete` is only emitted from `Actions()`
+  when the typed name matches the agent's display name (case-insensitive, whitespace-trimmed) and no
+  request is in flight. That presence-toggle *is* the disable mechanism for native-platform
+  embedders — the `Action` struct has no `Enabled` flag.
+- **Pending state is snapshotted** (`pendingDeleteID`, `pendingDeleteName`) at substate entry from
+  the passed `agentItem`, never re-read from `list.SelectedItem()` afterwards. A list re-render
+  mid-flight cannot resolve the destructive cmd to the wrong agent.
+- **Plain `d` is not bound** inside the substate because it's a printable character the user might
+  type as part of the agent name.
 
-## Selecting an agent
+On error `pendingDeleteName` is preserved so the user can retry without retyping. Keystrokes are
+ignored while `m.deleting` is true — the network call has already left.
 
-Pressing Enter on a highlighted agent calls `client.CreateSession(agentID, key)`. On success, `sessionCreatedMsg` carries the new session key and the app transitions to the chat view (`newChatModel(...)`). See [sessions.md](sessions.md) for the session lifecycle from this point.
+## Delete semantics are per-backend
 
-The `/agent <name>` slash command bypasses the picker entirely and reaches the same `sessionCreatedMsg` path — see [commands.md](commands.md#agent). From the chat input, `/agent ` followed by Tab autocompletes against the cached agent list.
+The destructive-vs-preserve interpretation differs by backend, and two of the choices are worth
+calling out:
 
-## Creating an agent
-
-Pressing `n` in the picker switches to a creation form (`subStateCreate`). The form's shape is driven by the active backend's `Capabilities.AgentWorkspace` flag (see `backend.Capabilities`).
-
-**OpenClaw** (workspace-aware):
-
-- **Name** — must start with a lowercase letter and contain only alphanumeric characters and hyphens. Validated on submit.
-- **Workspace** — a filesystem path that is auto-suggested but editable.
-
-On submit, `Backend.CreateAgent` is called with both fields. The gateway creates the agent and seeds an `IDENTITY.md` file in the workspace.
-
-**OpenAI-compatible** (local-agent backends):
-
-- **Name** — same validation rules as above.
-- The workspace field is hidden. On submit, the backend seeds `IDENTITY.md` and `SOUL.md` with defaults under `~/.lucinate/agents/<connection>/<agent>/`. Users edit those files on disk to customise the agent's identity and behaviour — see [connections.md](connections.md#openai-agent-storage).
-
-On success the agent list is reloaded and the new agent is auto-selected (see above). On failure the form stays open and the error is shown so the user can correct and retry.
-
-## Deleting an agent
-
-Pressing `d` on a highlighted agent enters `subStateConfirmDelete`. The substate is gated by the same `Capabilities.AgentManagement` flag as create — Hermes connections never expose it because profiles are server-managed.
-
-The view is deliberately loud: a red header with the agent's name, a bullet list of what's about to be removed (metadata, transcript, and on OpenClaw bindings), the local backup path, a `Delete files | Keep files` toggle, and a textinput labelled with the agent's display name.
-
-- **Type-to-confirm.** `confirm-delete` is only emitted from `Actions()` when the typed name matches the agent's display name (case-insensitive, whitespace-trimmed) and no request is in flight. That presence-toggle is the disable mechanism for native-platform embedders — the `Action` struct has no `Enabled` flag.
-- **Keep files toggle.** `tab` flips `m.keepFiles`, which becomes `!DeleteFiles` on the `backend.DeleteAgentParams` sent to the backend. It defaults to **keep files** (`keepFiles=true` → `DeleteFiles=false`), so a mistaken confirmation preserves the agent's file content — the user has to toggle off to destroy it. The view's description line switches with the toggle so the user can read what the current mode will do before pressing enter.
-- **Pending state is snapshotted** (`pendingDeleteID`, `pendingDeleteName`) at substate entry from the passed `agentItem`, never re-read from `list.SelectedItem()` afterwards. A list re-render mid-flight cannot resolve the destructive cmd to the wrong agent.
-- **Esc** triggers `cancel-delete` and clears all pending state. **Enter** without a matching name is a no-op.
-- **Plain `d` is not bound** inside the substate because it's a printable character the user might type as part of the agent name.
-
-`agentDeletedMsg` carries the result. On success the picker clears pending state and reloads via `loadAgents()`. On error `pendingDeleteName` is preserved so the user can retry without retyping; `deleteErr` surfaces inline. Keystrokes are ignored while `m.deleting` is true — the network call has already left.
-
-The destructive vs preserve interpretation is per-backend:
-
-- **OpenClaw** — `Backend.DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` to the gateway. The pointer is always set explicitly — the gateway's implicit "preserve files" default never applies.
-- **OpenAI-compatible** — when `DeleteFiles=true` the agent directory is wiped via `AgentStore.Delete` (`os.RemoveAll`); when false it's moved to `<root>/.archive/<id>-<unixts>/` via `AgentStore.Archive` so IDENTITY.md, SOUL.md, and history.jsonl are recoverable on disk. See [backend_openai.md](backend_openai.md#agent-storage).
-- **Hermes** — `DeleteAgent` returns a clear error pointing at `hermes profile delete`. The UI gate (AgentManagement=false) means the user shouldn't reach it; the reject is defensive.
+- **OpenClaw** — `Backend.DeleteAgent` sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}`
+  with the pointer always set explicitly, so the gateway's implicit "preserve files" default never
+  applies.
+- **OpenAI-compatible** — when `DeleteFiles=false` the agent is moved to
+  `<root>/.archive/<id>-<unixts>/` rather than wiped, so IDENTITY.md, SOUL.md, and history.jsonl stay
+  recoverable on disk. See the `backend-openai` spec.
+- **Hermes** — `DeleteAgent` returns a clear error pointing at `hermes profile delete`. The UI gate
+  (`AgentManagement=false`) means the user shouldn't reach it; the reject is defensive.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,93 +1,81 @@
-# Authentication
+# Authentication — lessons and rationale
 
-This document covers OpenClaw device pairing — the auth flow used by the OpenClaw backend. The OpenAI-compatible and Hermes backends use a simpler bearer-token model documented in [connections.md](connections.md#auth-recovery-modals) and [connections.md](connections.md#secrets-storage).
+The behavioural contract for authentication lives in
+[`openspec/specs/authentication/spec.md`](../openspec/specs/authentication/spec.md) — the
+device-pairing flow, identity storage, auth-recovery modals, reconnection, and scopes are all
+captured there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls,
+and design rationale behind that flow: the "why it works this odd way" that the spec's
+requirements don't dwell on.
 
-For OpenClaw connections, lucinate authenticates using device pairing — no usernames or passwords. Each device generates a persistent Ed25519 keypair and an administrator approves it on the gateway.
+## Re-dial after first-time pairing: the silent stall
 
-## Configuration
+This is the least obvious thing in the whole connect path, and it cost real debugging time.
 
-OpenClaw URLs can be added via the connections picker (the default UX) or via `OPENCLAW_GATEWAY_URL` (auto-added on first run). See [connections.md](connections.md#startup-decision-tree) for the resolution order.
+The bootstrap connect for a freshly approved device authenticates by Ed25519 device-key
+signature alone — the token field on `connect` is empty because the client doesn't have one
+yet, and the gateway issues the first device token in `hello-ok`.
+
+The trap: **reusing that bootstrap connection for scoped RPCs leaves `sessions.create` silently
+stalled** — no error, just a hang. The OpenClaw protocol expects scoped operations to run on a
+connection that authenticated *with* the token at connect time. So `internal/client/client.go`
+handles it inline: when `dial` observes it presented an empty token AND the gateway returned a
+non-empty `hello.Auth.DeviceToken`, it persists the token, closes the bootstrap
+`gateway.Client`, and dials a second time so the surviving connection carries the issued token.
+On subsequent launches (token already on disk → bootstrap presents it → gateway returns no new
+one) the second dial is skipped. `internal/client/dial_test.go` pins both branches — treat them
+as a regression fence.
+
+Defence in depth: the TUI wraps `CreateSession` in a per-call `context.WithTimeout` of `2×` the
+configured connect timeout, so if this region ever stalls again it surfaces as a UI error in the
+agent picker rather than freezing the view.
+
+## Per-endpoint identity is deliberate
+
+Each gateway endpoint gets its own Ed25519 keypair and device token under
+`~/.lucinate/identity/<endpoint>/`. The point is that switching `OPENCLAW_GATEWAY_URL` must not
+overwrite credentials you've already paired elsewhere — flipping between gateways should be
+lossless, not a re-pairing every time.
+
+## Token save is non-fatal, on purpose
+
+If persisting a freshly issued device token fails, we log a warning and carry on rather than
+aborting the session. A transient disk hiccup shouldn't cost you a working connection you just
+paired; worst case you re-pair next launch.
+
+## Auth recovery lives on the connect path, not the reconnect path
+
+The mid-session supervisor (`internal/client/supervisor.go`) reconnects automatically on a
+dropped socket, but if the gateway rejects the device token mid-session (`gateway token
+mismatch` / `token missing`) it **stops retrying** and tells you to switch connections via
+`/connections`. It deliberately does *not* try to drive the auth-recovery modal itself — that
+flow only exists on the connect path. Keeping the modal off the reconnect path avoids two code
+paths fighting over the same UI state; the cost is that a mid-session credential revocation
+needs a manual reconnect.
+
+Related: an interrupted stream is abandoned, not resumed. The gateway has no resume protocol for
+an in-flight run, so on a drop we just clear the streaming placeholder to make the input usable
+again rather than pretending we can pick the reply back up.
+
+## Pitfall: a stray `OPENCLAW_OPERATOR_SCOPES` in `.env`
+
+The gateway grants the *intersection* of the scopes you request and the scopes your device
+token actually carries. Requesting scopes beyond what the pairing grants is rejected outright as
+a scope mismatch, which is why `OPENCLAW_OPERATOR_SCOPES` exists — to *bound* the request down to
+what a limited pairing carries, e.g.:
 
 ```
-OPENCLAW_GATEWAY_URL=https://your-gateway-host
+OPENCLAW_OPERATOR_SCOPES=operator.read,operator.write,operator.approvals
 ```
 
-This can be set in the shell or in a `.env` file in the working directory. Lucinate derives the WebSocket endpoint automatically by replacing `https://` with `wss://` (or `http://` with `ws://`) and appending `/ws`. Both values are held in `internal/config/config.go` as `Config.GatewayURL` and `Config.WSURL`.
+The pitfall: because `config.Load()` reads `.env` from the working directory, a stray
+`OPENCLAW_OPERATOR_SCOPES` left in a `.env` silently bounds scopes for **every** connection,
+regardless of which gateway you selected. If admin-only operations such as creating an agent
+fail with `missing scope: operator.admin` despite a token that should carry admin, check for a
+forgotten `OPENCLAW_OPERATOR_SCOPES`. Admin-only client operations fail fast with a message
+pointing here rather than surfacing the raw gateway error — that fail-fast exists precisely
+because this was confusing to diagnose the first time.
 
-## Device identity
+## Historical note
 
-On first run, `identity.Store.LoadOrGenerate()` creates an Ed25519 keypair under `~/.lucinate/identity/<endpoint>/`, where `<endpoint>` is derived from the gateway URL's host and port (e.g. `gateway.example.com` or `localhost_8789`). Each gateway endpoint gets its own keypair and device token, so switching `OPENCLAW_GATEWAY_URL` does not overwrite existing credentials. The keypair acts as a stable device identity across restarts.
-
-## First-run pairing flow
-
-1. Run `lucinate` — the client connects to the gateway with the device identity but no token. The gateway responds `NOT_PAIRED` and registers a pending pairing request.
-2. The connecting view enters its `subStatePairingRequired` modal (`internal/tui/connecting.go`) with on-screen instructions. On the gateway host, an administrator approves the device:
-   ```
-   openclaw device list --pending
-   openclaw device approve <device-id>
-   ```
-3. The user presses Enter in the modal. `authResolvedMsg{}` triggers `retryConnect` (`internal/tui/app.go`), which re-invokes `Connect` on the same backend. The gateway accepts the connection and issues a fresh device token in `hello.Auth.DeviceToken`, which `client.dial` persists via `store.SaveDeviceToken`.
-4. `dial` then closes the bootstrap connection and re-dials with the freshly-issued token (see [Re-dial after first-time pairing](#re-dial-after-first-time-pairing)). The TUI advances to the agent picker — no process restart required.
-
-The token save is non-fatal — if it fails, a warning is logged but the session continues. On subsequent runs the saved token is loaded and presented on connect.
-
-**Note:** Bootstrap tokens were removed in v0.10.2. Device pairing is the only setup path.
-
-## Re-dial after first-time pairing
-
-The bootstrap connect for a freshly approved device authenticates by Ed25519 device-key signature alone — the token field on `connect` is empty because the client doesn't have one yet. The gateway issues the first device token in `hello-ok`. Reusing that bootstrap connection for scoped RPCs leaves `sessions.create` silently stalled; the OpenClaw protocol expects scoped operations to run on a connection that authenticated *with* the token at connect time.
-
-`internal/client/client.go` handles this inline: when `dial` observes that it presented an empty token AND the gateway returned a non-empty `hello.Auth.DeviceToken`, it persists the token, closes the bootstrap `gateway.Client`, and dials a second time so the surviving connection carries the issued token. Subsequent launches (token already on disk → bootstrap presents it → gateway returns no new one) skip the second dial. Tests pin both branches in `internal/client/dial_test.go`.
-
-The TUI also wraps `CreateSession` (`internal/tui/app.go`) in a per-call `context.WithTimeout` derived as `2 ×` the configured connect timeout, so any future stall in this region surfaces as a UI error in the agent picker rather than freezing the view.
-
-## Subsequent runs
-
-1. Load `OPENCLAW_GATEWAY_URL` from environment, or use a saved connection from `~/.lucinate/connections.json`.
-2. Load the Ed25519 identity and stored device token from `~/.lucinate/identity/<endpoint>/`.
-3. Open a WebSocket connection to the gateway with the identity and token. The gateway SDK (`github.com/a3tai/openclaw-go`) attaches the token to all API calls.
-4. On a successful `Hello` handshake, any refreshed token is saved back to disk; no second dial is needed because the connection already authenticated with a token.
-5. Proceed to the agent picker.
-
-If the token is expired or revoked the gateway rejects the connection and the connecting view opens the appropriate auth-recovery modal (see below).
-
-## Interactive auth recovery on connect
-
-When `Connect` fails with a recognised auth error, `runConnect` in `internal/tui/app.go` classifies it via the `isNotPairedErr` / `isTokenMismatchErr` / `isTokenMissingErr` / `isAPIKeyErr` predicates and `handleConnectResult` opens the matching modal sub-state in `internal/tui/connecting.go`:
-
-- **Not paired** (`NOT_PAIRED`) — pairing-required modal: instructions to run `openclaw device approve` on the gateway host, then Enter to retry. See [First-run pairing flow](#first-run-pairing-flow).
-- **Token mismatch** (`gateway token mismatch`) — the stored device token is no longer valid for this gateway (for example, the device was removed and re-added). The modal offers three choices, each routed through the `DeviceTokenAuth` sub-interface on the live backend:
-  1. Clear the stored token and retry pairing (`ClearToken`, default).
-  2. Reset the device identity entirely (new keypair) and retry pairing (`ResetIdentity`).
-  3. Cancel back to the connections picker.
-- **Token missing** (`gateway token missing`) — text prompt for a pre-shared token; submission stores via `DeviceTokenAuth.StoreToken` and the connect is retried.
-- **API key required** (HTTP 401/403 from any `/v1` request on OpenAI-compat or Hermes connections) — text prompt for an API key; submission stores via `APIKeyAuth.StoreAPIKey`.
-
-All four flows happen inside the running TUI — modal text inputs, not stdin. Cancellation routes back to the connections picker; the active backend is closed before the next pick.
-
-## Reconnect after disconnection
-
-Once the TUI is running, a supervisor in `internal/client/supervisor.go` watches the gateway connection (`Client.Done()`) and reconnects automatically if it drops — for example, when the gateway is restarted.
-
-- **Backoff schedule:** 1s, 2s, 4s, 8s, 15s, then 30s for every subsequent attempt. Each attempt's connect timeout comes from `prefs.ConnectTimeoutSeconds` (default 15s), the same knob that floors the initial connect.
-- **State surface:** the supervisor pushes `tui.ConnStateMsg` into the bubbletea program. The chat header shows `⚠ disconnected`, `⟳ reconnecting (attempt N)`, or `✖ auth failed`. A one-line system message is added to the chat scrollback on disconnect and on recovery.
-- **In-flight streams:** if a reply was streaming when the connection dropped, the placeholder is cleared so the input is usable again. The gateway has no resume protocol for an interrupted run; the partial reply is abandoned.
-- **Auth failures:** if the gateway rejects the device token mid-session (`gateway token mismatch` / `token missing`), the supervisor stops retrying. The chat banner advises switching connections via `/connections` so the connecting view's auth-recovery modal can run on the chosen connection. The supervisor cannot drive the modal itself — that flow lives on the connect path, not the reconnect path.
-
-## Scopes
-
-The client connects with operator-level scopes: `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals`. These are the default requested in `internal/client/client.go` and are required for session management, exec approval, and agent administration. The gateway grants the intersection of the requested scopes and those the device token actually carries, so the effective set can be narrower.
-
-`OPENCLAW_OPERATOR_SCOPES` (comma-separated, e.g. `operator.read,operator.write,operator.approvals`) overrides the default requested set. This is useful when a device's approved pairing only carries a subset of the defaults — requesting scopes beyond what the pairing grants is rejected as a scope mismatch, so bounding the request to match lets the connection through (without the admin-only operations).
-
-> **Pitfall:** because `config.Load()` reads `.env` from the working directory, an `OPENCLAW_OPERATOR_SCOPES` left in a `.env` silently bounds scopes for *every* connection, regardless of which gateway is selected. If admin-only operations such as creating an agent fail with `missing scope: operator.admin` despite a token that should carry admin, check for a stray `OPENCLAW_OPERATOR_SCOPES`. Admin-only client operations fail fast with a message pointing here rather than surfacing the raw gateway error.
-
-## Stored files
-
-| Path | Contents |
-|---|---|
-| `~/.lucinate/identity/<endpoint>/` | Ed25519 keypair and device token (per gateway endpoint) |
-| `~/.lucinate/secrets/secrets.json` | OpenAI-compat and Hermes API keys, keyed by connection ID (mode 0600) — see [connections.md](connections.md#secrets-storage) |
-| `~/.lucinate/connections.json` | Saved connection records — see [connections.md](connections.md) |
-| `~/.lucinate/hermes/<conn-id>/` | Per-connection Hermes state: `last_response_id` pointer + capped prompts log — see [backend_hermes.md](backend_hermes.md#local-state) |
-| `~/.lucinate/config.json` | UI preferences — not authentication-related |
+Bootstrap tokens were removed in v0.10.2. Device pairing is now the only setup path — if you
+find a reference to bootstrap-token setup anywhere, it's stale.

--- a/docs/backend_hermes.md
+++ b/docs/backend_hermes.md
@@ -1,68 +1,57 @@
-# Hermes backend
+# Hermes backend — lessons and rationale
 
-The Hermes backend (`internal/backend/hermes`) talks to a [Nous Research Hermes Agent](https://github.com/nousresearch/hermes-agent) profile via its OpenAI-compatible HTTP server (`/v1/...`). Unlike the OpenAI-compat backend (which treats the remote as a stateless `/v1/chat/completions` sink and keeps client-side identity / history), Hermes is **stateful server-side** — each profile owns its own SOUL, sessions, memories, and runs an API server on its own port — so this backend stays thin and lets the server be the source of truth.
+The behavioural contract for the Hermes backend lives in
+[`openspec/specs/backend-hermes/spec.md`](../openspec/specs/backend-hermes/spec.md) — the
+capabilities, status payload, one-profile-one-agent model, chat over `/v1/responses`, local
+state files, history walk-back, and connect/auth flow are all captured there as requirements and
+scenarios. This file keeps the hard-won lessons, pitfalls, and design rationale behind that
+contract: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-The backend is a sibling of the OpenAI backend, not a subclass. Both use the shared HTTP / SSE / event-emission primitives in `internal/backend/httpcommon` (request builder with bearer auth, SSE scanner, `protocol.Event` emitter). Beyond that they are independent: the wire shape, agent model, and history strategy all differ.
+## Why the backend stays thin
 
-See [connections.md](connections.md) for the cross-backend connection lifecycle this plugs into.
+Unlike the OpenAI-compat backend (which treats the remote as a stateless
+`/v1/chat/completions` sink and keeps client-side identity and history), Hermes is **stateful
+server-side** — each profile owns its own SOUL, sessions, memories, and runs an API server on
+its own port. So this backend stays thin and lets the server be the source of truth. It is a
+sibling of the OpenAI backend, not a subclass: beyond the shared HTTP / SSE / event-emission
+primitives in `internal/backend/httpcommon`, the wire shape, agent model, and history strategy
+all differ. The cross-backend connection lifecycle this plugs into is described by the
+`connections` spec.
 
-## Capabilities
+## Why chaining on `previous_response_id`, not a named conversation
 
-`Backend.Capabilities()` reports:
+`ChatSend` chains via `previous_response_id` rather than pinning a named conversation. Two
+reasons:
 
-- `AuthRecovery: AuthRecoveryAPIKey` — bearer-token auth-recovery modal, same as OpenAI.
-- `AgentManagement: false` — Hermes profiles are configured server-side (`hermes profile create` / `hermes profile delete` on the host), so the TUI's "new agent" and "delete agent" affordances are both hidden. `CreateAgent` and `DeleteAgent` both return clear errors if ever called regardless.
-- `GatewayStatus: true` — `/status` reports endpoint, auth, model, and (when present) the active `lastResponseID` thread. See [Status payload](#status-payload).
-- Everything else is off — `/compact`, `/think`, `/stats`, `/crons`, `!!` render a "not available on this connection" system message.
+- Hermes maintains conversation continuity server-side from the chained ID; we don't resend
+  history on every turn.
+- Pinning a named conversation per connection meant `/reset` wiped the local last-response
+  pointer but left Hermes' server-side thread alive, so the next chat continued the old
+  conversation. Chaining via `previous_response_id` makes `SessionDelete` actually start a fresh
+  chain. (Regression test: `TestSessionDelete_NextChatStartsFreshChain` in `backend_test.go`.)
 
-## Status payload
+The Runs API (`POST /v1/runs/{id}/stop`) exists for tool-heavy turns but isn't used in V1 —
+closing the SSE connection is enough for plain chat.
 
-`/status` on a Hermes connection returns a `BackendStatus` carrying:
+## Why the prompts log exists
 
-- `Type: "hermes"`, the API base URL, and the auth mode (`"API key"` or `"anonymous"`).
-- The discovered or configured default model (`opts.DefaultModel` wins over the model cached during connect via `profileModel`).
-- `Thread` populated when `lastResponseID` is set, so the user can see whether the next turn will chain onto an existing server-side conversation or start fresh.
+The prompts log (`prompts.jsonl`) exists because `GET /v1/responses/{id}` on Hermes returns
+only the assistant output — the user input field is omitted. Without a client-side mirror, the
+history-walk reconstruction would be assistant-only. The 100-entry cap matches Hermes'
+server-side LRU cap on stored responses, so the two stay in rough sync.
 
-The renderer omits the OpenClaw-specific gateway block entirely for Hermes — see [TUI rendering](#) in `internal/tui/commands.go` (`formatBackendStatus`) for the per-section gating.
+## Why the history walk is capped
 
-## One profile, one agent
+Hermes has no list-by-conversation endpoint (`GET /v1/conversations/<name>/responses` 404s), so
+`ChatHistory` walks the chain backwards from the stored last-response ID via repeated
+`GET /v1/responses/{id}`, following `previous_response_id`. The walk is capped at **3 hops** in
+`historyWalkLimit` because each hop is a separate round-trip and first-load latency adds up; the
+chat view doesn't need a deep transcript on connect.
 
-`ListAgents` returns a single synthetic entry (ID `hermes`) representing the connected Hermes profile. The display name is the model surfaced by `GET /v1/models` — Hermes advertises the profile's pinned upstream model there. `CreateAgent` and `DeleteAgent` are both rejected with clear errors pointing the user at `hermes profile create` / `hermes profile delete` on the host.
+## One profile, one agent — configure a second connection instead
 
-`SessionsList` returns one session keyed off the same synthetic ID. `CreateSession` is a no-op that round-trips the agent ID. There is no concept of multi-agent or multi-session within a single Hermes connection — to talk to a different personality, configure a different Hermes profile (which runs on its own port) and add it as a separate connection.
-
-## Chat over `/v1/responses`
-
-`ChatSend` posts to `/v1/responses` with `stream: true` and chains via `previous_response_id` rather than a named conversation. Two reasons:
-
-- Hermes maintains conversation continuity server-side from the chained ID; we don't resend history on every turn.
-- Pinning a named conversation per connection meant `/reset` wiped the local last-response pointer but left Hermes' server-side thread alive, so the next chat continued the old conversation. Chaining via `previous_response_id` makes `SessionDelete` actually start a fresh chain. (Regression test: `TestSessionDelete_NextChatStartsFreshChain` in `backend_test.go`.)
-
-The streaming SSE emits typed events — `response.created`, `response.output_text.delta`, `response.completed` — which the backend dispatches on the `type` field in each `data:` payload. Deltas accumulate into a string and surface as `protocol.ChatEvent` (state=delta) just like the OpenAI backend; `response.completed` produces a final event and persists the new response ID.
-
-`ChatAbort` cancels the streaming request context. The Runs API (`POST /v1/runs/{id}/stop`) exists for tool-heavy turns but isn't used in V1 — closing the SSE connection is enough for plain chat.
-
-## Local state
-
-Two small files per connection live under `~/.lucinate/hermes/<connection-id>/`:
-
-| File                | Purpose                                                                            |
-|---------------------|------------------------------------------------------------------------------------|
-| `last_response_id`  | The most recent response ID, used to chain `previous_response_id` on the next turn |
-| `prompts.jsonl`     | Append-only log of `{response_id, prompt, time}` entries, capped at 100            |
-
-Both files are mode `0600` and the directory is `0700`. They're cleared by `SessionDelete` (`/reset`).
-
-The prompts log exists because `GET /v1/responses/{id}` on Hermes returns only the assistant output — the user input field is omitted. Without a client-side mirror, the history-walk reconstruction would be assistant-only. The 100-entry cap matches Hermes' server-side LRU cap on stored responses, so the two stay in rough sync.
-
-## History via walk-back
-
-Hermes has no list-by-conversation endpoint (`GET /v1/conversations/<name>/responses` 404s). To populate the chat scrollback, `ChatHistory` walks the chain backwards from the stored last-response ID via repeated `GET /v1/responses/{id}`, following `previous_response_id`. The walk is capped at **3 hops** in `historyWalkLimit` because each hop is a separate round-trip and first-load latency adds up; the chat view doesn't need a deep transcript on connect.
-
-Each hop yields the assistant's output text from the server, paired with the user prompt looked up from the local prompts log. Both are emitted in chronological order (user → assistant per turn) so the chat view renders a normal transcript.
-
-## Connect and auth
-
-`Connect(ctx)` issues `GET /v1/models`, caching the discovered profile name as the synthetic agent's display model. A 401/403 surfaces as the canonical `api key required` error so the connecting view routes it to the API-key modal — same flow as OpenAI.
-
-The Hermes API server requires `API_SERVER_KEY` to be set on the server side; the client sends `Authorization: Bearer <key>`. The auth modal calls `StoreAPIKey` which updates the in-memory key on the live backend and (via the `secretAwareHermesBackend` shim in `app/factory.go`) persists it to `~/.lucinate/secrets/secrets.json`.
+There is no concept of multi-agent or multi-session within a single Hermes connection. Profiles
+are configured server-side (`hermes profile create` / `hermes profile delete` on the host), so
+the TUI's "new agent" and "delete agent" affordances are hidden and `CreateAgent` / `DeleteAgent`
+return clear errors pointing there. To talk to a different personality, configure a different
+Hermes profile (which runs on its own port) and add it as a separate connection.

--- a/docs/backend_openai.md
+++ b/docs/backend_openai.md
@@ -1,101 +1,86 @@
-# OpenAI-compatible backend
+# OpenAI-compatible backend — lessons and rationale
 
-The OpenAI-compat backend (`internal/backend/openai`) lets lucinate talk to any HTTP server that implements `/v1/chat/completions` and `/v1/models` — Ollama, vLLM, LM Studio, llamafile, OpenAI proper, and so on. Because those servers have no concept of agents, lucinate maintains agent state on disk locally.
+The behavioural contract for the OpenAI-compat backend lives in
+[`openspec/specs/backend-openai/spec.md`](../openspec/specs/backend-openai/spec.md) — the
+declared capabilities, status payload, connect and auth behaviour, local agent storage, session
+and history handling, skill-catalogue injection, streaming, and local compaction are all captured
+there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls, and design
+rationale behind that behaviour: the "why it works this odd way" that the spec's requirements
+don't dwell on.
 
-See [connections.md](connections.md) for the cross-backend connection lifecycle this plugs into. The Ollama preset on the connections form is just an opinionated OpenAI preset and is documented there.
+## Why `/think` is a no-op
 
-## Capabilities
+`/think` reports `Thinking: false` so it's gated off, even though several OpenAI-compatible
+providers expose reasoning controls in their own request shapes (OpenAI's `reasoning.effort`,
+Ollama's `think` flag on reasoning models, DeepSeek's `<think>` tags, Anthropic-via-proxy's
+`thinking` block). Wiring `/think` to translate into the active provider's reasoning shape is a
+known gap — tracked in [#80](https://github.com/lucinate-ai/lucinate/issues/80).
 
-`Backend.Capabilities()` reports `AuthRecovery: AuthRecoveryAPIKey`, `AgentManagement: true`, `SessionCompact: true` (the local summarisation pass — see [Compaction](#compaction) below), and `GatewayStatus: true` (`/status` — see [Status payload](#status-payload)). Everything else is off — `/think`, `/stats`, and `!!` render a "not available on this connection" system message.
+## IDENTITY.md and SOUL.md composition rationale
 
-## Status payload
+The two files are seeded with editable placeholders so users can shape an agent on disk without
+going through the TUI — `SystemPrompt(agentID)` reloads from disk on every chat send, so edits
+between sessions are picked up on the next send. `DefaultIdentity(name)` interpolates the agent's
+chosen name as the `Name:` header so the model addresses itself by the right label from turn one.
 
-`/status` returns a `BackendStatus` carrying:
+`SystemPrompt` handles all four presence combinations — both files, identity only, soul only, and
+neither — rather than assuming both exist. The "neither" case returns an empty string so the model
+gets no preamble instead of a stray `# Identity` / `# Soul` skeleton.
 
-- `Type: "openai"`, the configured `BaseURL`, the auth mode (`"API key"` or `"anonymous"`), and the configured `DefaultModel`.
-- `AgentCount` — the number of agent directories under the connection's store root.
-- `History` — the active agent's `history.jsonl` size and newline-counted message count. Files larger than `historyCountMaxBytes` (1 MiB) skip the count and the renderer falls back to size-only so an interactive command never blocks on a huge transcript.
+## Delete vs archive
 
-No `Gateway` block — that section is OpenClaw-specific and stays nil here.
+The keep-vs-delete-files toggle exists so a user can retire an agent without losing its files.
+`DeleteFiles=false` renames the agent dir into a sibling `.archive/<id>-<unixts>/` with
+IDENTITY.md, SOUL.md, history.jsonl, and agent.json surviving verbatim for manual recovery, rather
+than deleting anything.
 
-### `/think` is currently a no-op
+`AgentStore.List` filters by parsable `agent.json` at the top of each direct child of the picker
+root, so the `.archive` directory is naturally skipped (it has no `agent.json` of its own and
+`LoadMeta` returns an error). No special-case is needed.
 
-`/think` reports `Thinking: false` so it's gated off, even though several OpenAI-compatible providers expose reasoning controls in their own request shapes (OpenAI's `reasoning.effort`, Ollama's `think` flag on reasoning models, DeepSeek's `<think>` tags, Anthropic-via-proxy's `thinking` block). Wiring `/think` to translate into the active provider's reasoning shape is a known gap — tracked in [#80](https://github.com/lucinate-ai/lucinate/issues/80).
+`DeleteAgent` calls `LoadMeta` first to surface a "not found" error rather than silently
+succeeding on a stale agent ID — important because the UI presence-toggles its `confirm-delete`
+action on `nameMatches()`, which can theoretically pass while the underlying agent has already
+vanished.
 
-## Connect and auth
+## Why local compaction is needed, and its keep-tail / min-history reasoning
 
-`Connect(ctx)` issues `GET /v1/models`. A 401 or 403 is surfaced as the canonical `api key required` error so the connecting view routes it to the API-key modal. Any other ≥400 response surfaces as `connect: HTTP <code>: <body>`.
+`/compact` runs locally because there is no gateway-side compactor to lean on — `SessionCompact`
+issues its own summarisation request against the agent's configured model. `compactKeepTail`
+preserves the most recent messages verbatim after the summary so the tail of the conversation
+stays intact, while `compactMinHistory` gates the no-op-when-too-small case (it returns success
+without a network round-trip, so short sessions don't pay for a pointless model call).
 
-The API key is sent as `Authorization: Bearer <key>` when present and omitted otherwise (some endpoints — Ollama, vLLM without auth — accept anonymous requests). The auth modal calls `StoreAPIKey`, which updates the in-memory key on the live backend and (via the `secretAwareOpenAIBackend` shim in `app/factory.go`) writes through to `~/.lucinate/secrets/secrets.json` so the next launch reuses it without re-prompting.
+Streaming (rather than non-streaming) is intentional: some Ollama setups, particularly with
+reasoning-capable models, return an empty `message.content` on the non-streaming path while the
+streamed `delta.content` deltas produce the actual answer. Reusing the streaming code path means
+/compact works across the same compatibility matrix the regular chat send already covers.
 
-## Agent storage
+The `Summary` flag is what distinguishes a compact-produced digest from the legacy "skip stored
+system messages" defence in `runStream`: messages with `Summary: true` are forwarded on every turn
+after compaction, while any other `role: "system"` line in `history.jsonl` is still ignored.
+`ChatHistory` mirrors the same rule so the digest renders in the chat view rather than vanishing on
+history refresh.
 
-Each agent owns a directory under `~/.lucinate/agents/<connection-id>/<agent-id>/`:
+A previously-compacted session that gets compacted again folds the existing summary into the new
+one — `renderTranscriptForCompact` includes prior summaries under a `summary:` label so multiple
+compactions don't lose detail accumulated across earlier passes.
 
-| File            | Purpose                                                       |
-|-----------------|---------------------------------------------------------------|
-| `agent.json`    | Metadata: id, name, default model, created/updated timestamps |
-| `IDENTITY.md`   | Who the agent is — markdown, user-editable                    |
-| `SOUL.md`       | Tone / values / working style — markdown, user-editable       |
-| `history.jsonl` | Append-only transcript, one JSON message per line             |
+The transcript is dumped as labelled text inside a single `role: user` message, not forwarded as
+the literal user/assistant message sequence. Forwarding raw turns ends the request on
+`role: assistant` — and OpenAI-compatible servers (Ollama, vLLM, llama.cpp) interpret that as "the
+conversation is complete" and respond with empty content, defeating the summarisation. Wrapping the
+transcript in a user turn lets the model treat it as input data and produce the summary as a normal
+reply.
 
-All files are mode `0600` and the agent directory is `0700`. `agent.json` is rewritten via tempfile + rename so a crash mid-write can't truncate the metadata.
+## Why the status message count is capped
 
-The agent ID is derived from the user-supplied name via `slugify` (lowercase, alphanumerics and hyphens only) — the ID is also the session key, so it has to round-trip through gateway-protocol fields without escaping.
+`/status` counts `history.jsonl` messages by counting newlines, but files larger than
+`historyCountMaxBytes` (1 MiB) skip the count and fall back to size-only. The cap exists so an
+interactive command never blocks on a huge transcript.
 
-A sibling `~/.lucinate/agents/<connection-id>/.archive/` directory holds agents the user deleted with the "Keep files" option set — see below.
+## Slug IDs must round-trip through the protocol
 
-### IDENTITY.md and SOUL.md seeding
-
-On create, the form seeds both files with placeholders the user can edit on disk later:
-
-- `DefaultIdentity(name)` interpolates the agent's chosen name as the `Name:` header so the model addresses itself by the right label from turn one.
-- `DefaultSoul` is a static template covering tone and working style.
-
-Users can edit either file between sessions without going through the TUI — `SystemPrompt(agentID)` reloads from disk on every chat send.
-
-### System prompt composition
-
-`AgentStore.SystemPrompt(agentID)` reads IDENTITY.md and SOUL.md and concatenates them under `# Identity` / `# Soul` headers. All four cases are handled:
-
-- Both present → `# Identity\n\n…\n\n# Soul\n\n…`
-- Identity only → `# Identity\n\n…`
-- Soul only → `# Soul\n\n…`
-- Neither → empty string (model gets no preamble)
-
-### Delete vs archive
-
-`Backend.DeleteAgent(ctx, params)` dispatches on `params.DeleteFiles` (the user's keep-vs-delete-files toggle on the picker — see [agents.md](agents.md#deleting-an-agent)):
-
-- `DeleteFiles=true` → `AgentStore.Delete` (`os.RemoveAll(AgentDir(id))`). The on-disk content is gone.
-- `DeleteFiles=false` → `AgentStore.Archive` renames the agent dir to `<root>/.archive/<id>-<unixts>/`. IDENTITY.md, SOUL.md, history.jsonl, and agent.json all survive verbatim so the user can recover them by hand.
-
-`AgentStore.List` filters by parsable `agent.json` at the top of each direct child of the picker root, so the `.archive` directory is naturally skipped (it has no `agent.json` of its own and `LoadMeta` returns an error). No special-case is needed.
-
-`DeleteAgent` calls `LoadMeta` first to surface a "not found" error rather than silently succeeding on a stale agent ID — important because the UI presence-toggles its `confirm-delete` action on `nameMatches()`, which can theoretically pass while the underlying agent has already vanished.
-
-## Sessions and history
-
-Agent ≡ session, 1:1 — there is no session browser sub-list because there is nothing for it to list. `CreateSession` returns the agent ID as the session key. `/reset` calls `SessionDelete`, which clears `history.jsonl` (the agent metadata stays).
-
-`AppendMessage` writes one JSON-encoded `Message` line per call and touches `UpdatedAt` so `List()` orders recent agents first. `LoadHistory(limit)` returns up to `limit` most recent messages; `limit <= 0` returns the full transcript.
-
-## Skill catalog injection
-
-The chat layer passes the active skill catalog through `ChatSendParams.Skills`. The backend prepends a `System: Available agent skills (activate with /skill-name): …` block to the first turn of each session, then sets `catalogSent[sessionKey] = true` so subsequent turns omit it. The check-and-mark is mutex-guarded against concurrent sends.
-
-## Streaming
-
-`ChatSend` issues `POST /v1/chat/completions` with `stream: true` and parses the SSE response line-by-line, emitting `protocol.ChatEvent` for each `delta.content` chunk and a final event when `[DONE]` arrives. `ChatAbort` cancels the stored `context.CancelFunc` for the run, which terminates the in-flight HTTP request.
-
-## Compaction
-
-`/compact` runs locally — there is no gateway-side compactor, so `SessionCompact` issues a streaming `POST /v1/chat/completions` against the agent's configured model with a summarisation prompt and the older portion of the transcript as context. Deltas are accumulated into a string without touching the events channel, so the compaction is invisible to the chat view. The accumulated text is written back to `history.jsonl` as a single `role: "system"` message with `Summary: true`, followed by the most recent `compactKeepTail` messages preserved verbatim. `compactMinHistory` gates the no-op-when-too-small case (returns success without a network round-trip).
-
-Streaming (rather than non-streaming) is intentional: some Ollama setups, particularly with reasoning-capable models, return an empty `message.content` on the non-streaming path while the streamed `delta.content` deltas produce the actual answer. Reusing the streaming code path means /compact works across the same compatibility matrix the regular chat send already covers.
-
-The `Summary` flag is what distinguishes a compact-produced digest from the legacy "skip stored system messages" defence in `runStream`: messages with `Summary: true` are forwarded on every turn after compaction, while any other `role: "system"` line in `history.jsonl` is still ignored. `ChatHistory` mirrors the same rule so the digest renders in the chat view rather than vanishing on history refresh.
-
-A previously-compacted session that gets compacted again folds the existing summary into the new one — `renderTranscriptForCompact` includes prior summaries under a `summary:` label so multiple compactions don't lose detail accumulated across earlier passes.
-
-The transcript is dumped as labelled text inside a single `role: user` message, not forwarded as the literal user/assistant message sequence. Forwarding raw turns ends the request on `role: assistant` — and OpenAI-compatible servers (Ollama, vLLM, llama.cpp) interpret that as "the conversation is complete" and respond with empty content, defeating the summarisation. Wrapping the transcript in a user turn lets the model treat it as input data and produce the summary as a normal reply.
+The agent ID is derived from the user-supplied name via `slugify` (lowercase, alphanumerics and
+hyphens only). The constraint isn't cosmetic: the ID is also the session key, so it has to
+round-trip through gateway-protocol fields without escaping.

--- a/docs/backend_openclaw.md
+++ b/docs/backend_openclaw.md
@@ -1,59 +1,55 @@
-# OpenClaw backend
+# OpenClaw backend — lessons and rationale
 
-The OpenClaw backend (`internal/backend/openclaw`) is a thin adapter over `*client.Client` from the existing OpenClaw SDK. Every TUI call site that used to hold a `*client.Client` now holds a `backend.Backend`; the OpenClaw concrete type is recovered via type assertion at the few sites that still need gateway-only affordances.
+The behavioural contract for the OpenClaw backend lives in
+[`openspec/specs/backend-openclaw/spec.md`](../openspec/specs/backend-openclaw/spec.md) — the
+declared capabilities, connect and auth pass-throughs, agent and session model, skill-catalogue
+injection, the pass-through method surface, and the status payload are all captured there as
+requirements and scenarios. This file keeps the lessons, pitfalls, and design rationale behind
+that adapter: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-See [connections.md](connections.md) for the cross-backend connection lifecycle and [authentication.md](authentication.md) for device pairing.
+## The adapter adds no behaviour, on purpose
 
-## Capabilities
+`internal/backend/openclaw` is a thin adapter over `*client.Client` from the OpenClaw SDK. Every
+TUI call site that used to hold a `*client.Client` now holds a `backend.Backend`; the OpenClaw
+concrete type is recovered via type assertion at the few sites that still need gateway-only
+affordances. Most methods forward straight through unchanged — the adapter exists to satisfy the
+`backend.Backend` interface, not to add behaviour. Only the handful of methods below do anything
+non-obvious, and they are the ones worth remembering.
 
-`Backend.Capabilities()` reports the full surface — every optional sub-interface is implemented:
+## Skill catalogue is injected once, and the mutex matters
 
-| Capability        | Use site                                  |
-|-------------------|-------------------------------------------|
-| `GatewayStatus`   | `/status`                                 |
-| `RemoteExec`      | `!!` — see [shell-execution.md](shell-execution.md) |
-| `SessionCompact`  | `/compact`                                |
-| `Thinking`        | `/think`                                  |
-| `SessionUsage`    | `/stats`                                  |
-| `Cron`            | `/crons` — see [crons.md](crons.md)       |
-| `AuthRecovery`    | `AuthRecoveryDeviceToken` — see below     |
-| `AgentWorkspace`  | Workspace field on the create-agent form  |
+The catalogue block — `Available agent skills (activate with /skill-name): …` — is prepended only
+to the first turn of each session via `takePendingCatalog(sessionKey, skills)`, after which
+`catalogSent[sessionKey] = true` and later sends omit it.
 
-## Connect and auth
+The check-and-mark is mutex-guarded for a reason: two concurrent sends on the same session could
+otherwise both see the flag unset and both emit the catalogue. The guard is what makes "once per
+session" actually hold under concurrency, not just on the happy path.
 
-`Connect`, `Close`, `Events`, and `Supervise` are pass-throughs to the underlying client. The TUI's connecting view routes auth failures into modal sub-states:
+Every line of the block is prefixed with `System:` so it does double duty: the gateway's prompt
+assembler recognises it as a session-level system block (retained server-side across turns), and
+`stripSystemLines` on the client side hides it from the visible transcript on history refresh.
+Drop the prefix and it would either be treated as user input or leak into the visible transcript.
 
-- `NOT_PAIRED` → pairing-required modal: instructions to approve the device on the gateway host, then Enter to retry.
-- `gateway token mismatch` → device-token modal: clear / reset identity / cancel. `ClearToken` and `ResetIdentity` come from the `DeviceTokenAuth` sub-interface.
-- `gateway token missing` → device-token text prompt; submission stores via `StoreToken`.
+## `DeleteFiles: &flag` is always populated — the implicit default must never apply
 
-Tokens and the Ed25519 device identity live under `~/.lucinate/identity/<endpoint>/`, isolated per gateway endpoint. The first successful connect after a fresh approval re-dials transparently so the surviving connection authenticates with the issued token — see [authentication.md](authentication.md) for the full pairing flow and the re-dial rationale.
+`DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends
+`protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` over the wire. The `*bool` is a pointer
+precisely so the gateway can distinguish "not set" from "set to false" — and lucinate always
+populates it explicitly from the picker's keep-vs-delete-files toggle (see the `agents` spec,
+deleting-an-agent) so the gateway's implicit "preserve files" default never applies. If we ever
+passed a nil pointer here, a user who chose "delete files" could silently get them preserved.
 
-## Agent and session model
+## Health-fetch failure surfaces, it doesn't swallow
 
-Agents are owned by the gateway. `ListAgents` and `CreateAgent` (with name + workspace) call straight through. Sessions are created server-side and identified by the gateway-issued session key.
+If the `/health` fetch fails, `Status` still returns a populated payload with `Gateway.Health =
+nil` and passes the error back to the caller. The TUI then renders the body and the error as
+separate system messages rather than swallowing either — a partial status plus a visible error is
+more useful than a blank screen or a lost error.
 
-The gateway seeds an `IDENTITY.md` file in the agent's workspace on creation; lucinate does not author it.
+## `agentID` and `sessionKey` are ignored deliberately
 
-`DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` over the wire. The `*bool` is always populated explicitly from the picker's keep-vs-delete-files toggle (see [agents.md](agents.md#deleting-an-agent)) — the gateway's implicit "preserve files" default never applies. When `deleteFiles=false` the gateway drops bindings but leaves the agent's workspace files in place; when true the workspace is wiped along with the bindings.
-
-## Skill catalog injection
-
-The chat layer passes the active skill catalog through `ChatSendParams.Skills`. The backend prepends a `System:`-prefixed block — `Available agent skills (activate with /skill-name): …` — to the first turn of each session via `takePendingCatalog(sessionKey, skills)`. After the first turn, `catalogSent[sessionKey] = true` and subsequent sends omit the block.
-
-The check-and-mark is mutex-guarded so two concurrent sends on the same session can't both emit the catalog. Every line of the block is prefixed with `System:` so the gateway's prompt assembler can identify it as a session-level system block (retained server-side across turns) and so `stripSystemLines` on the client side hides it from the visible transcript on history refresh.
-
-## Pass-through methods
-
-`SessionsList`, `CreateSession`, `SessionDelete`, `ChatSend`, `ChatAbort`, `ChatHistory`, `ModelsList`, `SessionPatchModel`, and the capability-specific methods (`ExecRequest`, `ExecResolve`, `SessionCompact`, `SessionPatchThinking`, `SessionUsage`, `CronsList`, `CronRuns`, `CronAdd`, `CronUpdate`, `CronUpdateRaw`, `CronRemove`, `CronRun`) all forward to the underlying client unchanged. The adapter exists to satisfy the `backend.Backend` interface, not to add behaviour.
-
-## Status payload
-
-`Status(ctx, agentID, sessionKey)` assembles the cross-backend `BackendStatus` from a single gateway `/health` round-trip plus accessors on `*client.Client`:
-
-- Common header — `Type: "openclaw"`, the gateway WebSocket URL, and `"device token"` / `"anonymous"` derived from whether a token is loaded for this endpoint.
-- `Gateway` block — the health snapshot (sessions, agents, channels), the gateway version and uptime from the connect handshake, and the negotiated protocol version bounded by `protocol.MinProtocolVersion` and `protocol.ProtocolVersion` (the same pair advertised in `ConnectParams.MinProtocol`/`MaxProtocol`, so the displayed range matches what the handshake actually negotiated against).
-
-If the health fetch fails, `Status` still returns a populated payload with `Gateway.Health = nil` and surfaces the error to the caller; the TUI renders the body and the error as separate system messages rather than swallowing either.
-
-`agentID` and `sessionKey` are ignored — OpenClaw's per-session state lives on the gateway and is already reflected in the health snapshot.
+`Status(ctx, agentID, sessionKey)` takes those arguments to match the cross-backend signature but
+ignores them: OpenClaw's per-session state lives on the gateway and is already reflected in the
+health snapshot, so there is nothing local to look up. They are kept in the signature only so the
+backend satisfies the shared interface.

--- a/docs/chat-launch.md
+++ b/docs/chat-launch.md
@@ -1,68 +1,77 @@
-# Pre-navigated launch (`lucinate chat`)
+# Pre-navigated launch — lessons and rationale
 
-`lucinate chat` is a TUI entry point that accepts the same `--connection` / `--agent` / `--session` overrides as `lucinate send`, but instead of dispatching one turn and exiting it launches the regular interactive program with each override consumed at the transition that would otherwise have prompted the user. An optional positional message is auto-submitted as the first turn once the session's history loads.
+The behavioural contract for pre-navigated launch lives in
+[`openspec/specs/chat-launch/spec.md`](../openspec/specs/chat-launch/spec.md) — the `chat`
+subcommand, the `app.Chat` pre-flight lifecycle, override consumption, stale-override clearing,
+and the `ChatOptions` embedder seam are all captured there as requirements and scenarios. This
+file keeps the hard-won lessons, pitfalls, and design rationale behind that flow: the "why it
+works this odd way" that the spec's requirements don't dwell on.
 
-The user-facing CLI shape lives in [README.md](../README.md#skip-the-pickers). This doc covers the override plumbing and the seams the TUI uses to consume them safely.
+## Why a separate subcommand rather than a `send` flag
 
-## Why a separate subcommand
+`send` is a non-TUI lifecycle (connect → resolve → ChatSend → drain → exit). `chat` is the
+regular TUI lifecycle with the picker steps short-circuited. Both share connection / agent
+resolution helpers (`resolveSendConnection`, `resolveSendAgent` in `app/send.go`) but otherwise
+have nothing in common — `chat` does not call `ChatSend` itself, never owns a `replyCollector`,
+and never needs `--detach`. Bolting this onto `send` as a flag would have meant one command
+straddling two incompatible lifecycles.
 
-`send` is a non-TUI lifecycle (connect → resolve → ChatSend → drain → exit). `chat` is the regular TUI lifecycle with the picker steps short-circuited. Both share connection / agent resolution helpers (`resolveSendConnection`, `resolveSendAgent` in `app/send.go`) but otherwise have nothing in common — `chat` does not call `ChatSend` itself, never owns a `replyCollector`, and never needs `--detach`. Auth-recovery modals, supervisor reconnect, `/connections`, and every other TUI affordance keep working unchanged.
+`Chat` deliberately does not connect, list agents, or create a session itself. It defers all
+three to the TUI so a typo in `--agent` lands on the existing picker (with an error banner)
+rather than failing before the user can recover.
 
-## Lifecycle
+## The load-bearing precedence: auto-pick miss beats single-agent auto-pick
 
-`app.Chat` (`app/chat.go`) is a thin pre-flight stage:
+The single-agent auto-pick in `select.go` runs only when `autoPickName` was unset on entry.
+`--agent foo` against a single-agent connection where `foo` doesn't match must surface the error
+rather than silently picking the wrong agent — the one agent available is not necessarily the one
+the user asked for. This precedence ordering is the design's load-bearing detail;
+`TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick` (`internal/tui/select_test.go`)
+guards it. Treat that test as a regression fence.
 
-1. **Resolve the connection.** When `--connection` is set, `resolveSendConnection` matches by ID then case-insensitive Name; a miss is a clean error that distinguishes the empty-store first-run case from a typo against a populated store. When `--connection` is unset, `config.ResolveEntryConnection()` runs — same env-var / default-id / single-entry decision tree the bare `lucinate` invocation uses, including the `ShowPicker` outcome that lands the user on the connections picker.
-2. **Pack the overrides into `RunOptions`.** `InitialAgent`, `InitialSession`, `InitialMessage` go onto `RunOptions`; the existing `Initial *config.Connection` carries the resolved connection (or nil for the picker). Agent and session strings are trimmed; the message is taken verbatim so leading whitespace inside a quoted argument is preserved.
-3. **Hand off to `Run`.** From here it's the regular TUI. The TUI consumes each override at a defined transition — the resolution logic that would otherwise have prompted runs, then the override is cleared.
+## Why stale overrides are cleared on scope change
 
-`Chat` does not connect, list agents, or create a session itself. It defers all three to the TUI so a typo in `--agent` lands on the existing picker (with an error banner) rather than failing before the user can recover.
+Agent IDs and session keys aren't portable across connections. If the user backs out of a
+connection the original invocation targeted, applying the original `--agent` against the new
+connection's agent list would either error spuriously or silently match the wrong agent. So the
+overrides are cleared at exactly the points where the user is signalling a scope change: aborting
+the auth modal, an unrecoverable connect error that bounces back to the connections picker, and
+`/connections` mid-chat.
 
-## Override consumption
+The two cases that deliberately do *not* clear are the subtle part. A successful
+`authResolvedMsg` retry (token resolved, `cancelled` false) leaves the overrides set — the user
+just resolved the auth they originally intended to use, so the auto-pick should still fire. And
+`handleConnectResult` success consumes `initialAgent` but leaves `initialSession` and
+`initialMessage` to ride through to their later consumption points; clearing them there would
+strand the session and message overrides before they'd ever been used.
 
-The three overrides live on `AppModel` in `internal/tui/app.go` and are consumed at three different transition points:
+## Why no pre-flight validation
 
-| Override | Consumed at | Picker behaviour |
-|---|---|---|
-| `initialAgent` | `handleConnectResult` success branch — passed into `newSelectModel` as `autoPickName`. | The picker's `agentsLoadedMsg` handler (in `internal/tui/select.go`) runs ID-then-case-insensitive-name resolution **before** the existing single-agent auto-pick and post-create branches. A match sets `m.selected = true`; a miss sets `m.err = fmt.Errorf("agent %q not found", query)`. Either way the field is cleared so a second `agentsLoadedMsg` (e.g. after a user-driven agent create) doesn't re-fire. |
-| `initialSession` | `viewSelect` block of `update` — used to override `createKey` before `CreateSession` is invoked. | Beats both `"main"` and the connection's default-agent `MainKey`. Cleared on consume. |
-| `initialMessage` | `sessionCreatedMsg` handler — passed into `newChatModel` as a trailing arg, which appends it to `pendingMessages`. | The chat view's `historyLoadedMsg` handler returns `m.drainQueue()` when `pendingMessages` is non-empty and `!m.sending`, so the user turn lands *after* the history scrollback — matching what a human typing would see. |
+The TUI is the validator, on purpose. A typo in `--agent` lands on the picker with an error
+banner; a typo in `--session` reaches the backend's `CreateSession`, which decides whether to
+create-or-resume. Surfacing those errors before the TUI starts would mean a Connect + ListAgents
+round-trip from `Chat` itself, duplicating the picker's existing error path for no gain.
 
-The single-agent auto-pick at `select.go` runs only when `autoPickName` was unset on entry — `--agent foo` against a single-agent connection where foo doesn't match must surface the error rather than silently picking the wrong agent. This precedence ordering is the design's load-bearing detail; `TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick` (`internal/tui/select_test.go`) guards it.
+## Why `--message` isn't a script, and slash commands stay literal
 
-## Stale-override clearing
+`--message` is a single first-turn override, not a script — chains of turns belong on the TUI
+side (the user types follow-ups) or the `send` side (one turn per invocation, optionally
+`--detach`'d).
 
-Agent IDs and session keys aren't portable across connections. If the user backs out of a connection the original invocation targeted, applying the original `--agent` against the new connection's agent list would either error spuriously or silently match the wrong agent. The `AppModel.update` method clears all three overrides at the points where the user is signalling a scope change:
+The auto-submit is easy to misread as "type this into the box and press Enter", but it drains
+through `drainQueue`, not the textarea's Enter handler. `drainQueue` recognises `!` and `!!` exec
+prefixes and does skill-reference expansion, but it does **not** dispatch slash commands. A
+message of `/sessions` is sent to the agent as the literal string `/sessions`, not routed to the
+sessions browser. Scripted workflows that want slash-command effects should call the
+corresponding RPC directly — the same advice as `send`.
 
-- **`authResolvedMsg{cancelled:true}`** — user aborted the auth modal, returns to the connections picker.
-- **`handleConnectResult` unrecoverable-error branch** — connect failed in a way that bounces back to the connections picker with an error banner.
-- **`showConnectionsMsg`** — user invoked `/connections` mid-chat to switch connection.
+## Embedder seam: what deliberately isn't in `ChatOptions`
 
-Successful `authResolvedMsg` retries (token resolved, `cancelled` false) leave the overrides set: the user just resolved the auth they originally intended to use, so the auto-pick should still fire.
-
-`handleConnectResult` success does **not** clear the overrides — it consumes `initialAgent` (passing it into `newSelectModel`), but `initialSession` and `initialMessage` ride through to their later consumption points.
-
-## Embedding `app.Chat` from Go
-
-`ChatOptions` is the embedder seam:
-
-```go
-err := app.Chat(ctx, app.ChatOptions{
-    Connection:       "my-con",   // empty → ResolveEntryConnection
-    Agent:            "main",
-    Session:          "",          // empty → main-session default
-    Message:          "hello",
-    BackendFactory:   nil,         // nil → DefaultBackendFactory
-    ConnectionsStore: nil,         // nil → LoadConnections()
-})
-```
-
-`resolveChatRunOptions` (the unexported core that builds `RunOptions` without spinning up Bubble Tea) is what the unit tests in `app/chat_test.go` exercise; embedders that want to layer additional `RunOptions` fields (`HideInputArea`, `OnActionsChanged`, …) should call `Chat`'s peer logic themselves rather than relying on internals — those callbacks are TUI-host concerns that don't belong in `ChatOptions`.
-
-The function is a single-shot launcher. There is no resume surface and no incremental progress callback — once the TUI is running, embedders interact with it through the `app.Program` API the bare invocation uses.
-
-## Non-goals
-
-- **Pre-flight agent / session validation.** The TUI is the validator. A typo in `--agent` lands on the picker with an error banner; a typo in `--session` reaches the backend's `CreateSession`, which decides whether to create-or-resume. Surfacing those errors before the TUI starts would mean a Connect + ListAgents round-trip from `Chat` itself, duplicating the picker's existing error path.
-- **Multi-turn pre-seeding.** `--message` is a single first-turn override, not a script. Chains of turns belong on the TUI side (the user types follow-ups) or the `send` side (one turn per invocation, optionally `--detach`'d).
-- **Slash-command parsing.** The auto-submit drains through `drainQueue`, not the textarea's Enter handler — `drainQueue` recognises `!` and `!!` exec prefixes and does skill-reference expansion, but it does **not** dispatch slash commands. A message of `/sessions` is sent to the agent as the literal string `/sessions`, not routed to the sessions browser. Scripted workflows that want slash-command effects should call the corresponding RPC directly, same advice as `send`.
+`resolveChatRunOptions` (the unexported core that builds `RunOptions` without spinning up Bubble
+Tea) is what the unit tests in `app/chat_test.go` exercise — that split exists so the resolution
+logic is testable without a running TUI. Embedders that want to layer additional `RunOptions`
+fields (`HideInputArea`, `OnActionsChanged`, …) should call `Chat`'s peer logic themselves rather
+than relying on internals — those callbacks are TUI-host concerns that don't belong in
+`ChatOptions`. `Chat` is a single-shot launcher with no resume surface and no incremental
+progress callback by design; once the TUI is running, embedders interact with it through the same
+`app.Program` API the bare invocation uses.

--- a/docs/chat-ux.md
+++ b/docs/chat-ux.md
@@ -1,177 +1,113 @@
-# Chat UX
+# Chat UX — lessons and rationale
 
-## Input key bindings
+The behavioural contract for the chat surface lives in
+[`openspec/specs/chat-ux/spec.md`](../openspec/specs/chat-ux/spec.md) — the key bindings, streaming
+animation, header bar, view region order, notifications, routine status, tool activity, history
+depth and resync, connect timeout, and the mouse/scrolling model are all captured there as
+requirements and scenarios. This file keeps the hard-won lessons, pitfalls, and design rationale
+behind that contract: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-| Key | Action |
-|---|---|
-| Enter | Send message — or, on empty input with an active routine, advance the routine ([routines.md](routines.md)) |
-| Alt+Enter | Insert newline |
-| Ctrl+W | Delete word backward |
-| Up arrow (empty input) | Recall the last queued message for editing, or start a bash-style walk back through previously sent messages |
-| Down arrow (while walking) | Walk forward again; at the newest entry, clear the input |
-| Tab | Open slash menu, extend to longest common prefix, then cycle |
-| Shift+Tab | While slash-menu is cycling: cycle backward through candidates. Otherwise, with an active routine: cycle the routine's mode (auto ↔ manual) |
-| Page Up / Page Down | Scroll message history |
-| Mouse wheel | Scroll message history — see [Scrolling, selection, and the mouse](#scrolling-selection-and-the-mouse) |
-| Mouse click-drag | Select transcript text; copies to the clipboard on release |
-| Esc | Cancel in-progress response — or, with an active routine, end the routine and (if streaming) cancel the turn |
+## The 999% peg: why context usage is session-scoped
 
-Alt+Enter is configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter is not supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
+The right-hand context-usage percentage is scoped to the *current session* on purpose. The older
+approach of calling `SessionUsage("")` returned gateway-wide aggregates and pegged the value at
+999%. `loadContextUsage()` fixes this by calling `SessionsList(agentID)`, finding the entry whose
+`key` matches `m.sessionKey`, and reading `totalTokens` (numerator — a per-turn prompt-token
+snapshot of `input + cacheRead + cacheWrite`, intentionally excluding output) and `contextTokens`
+(denominator), falling back to `defaults.contextTokens` when the entry omits the window.
 
-## Message recall
+The handler discards results whose `sessionKey` no longer matches `m.sessionKey` so a
+navigated-away-and-back race can't apply a stale snapshot. And the renderer still caps the
+displayed percentage at 999% regardless — a runaway numerator never widens the header past three
+digits.
 
-When the textarea is empty and the user presses Up arrow, the last entry in `m.pendingMessages` is popped and inserted into the textarea with the cursor at the end. This allows editing and resending a recently queued message without retyping it.
+## Mid-turn history resync: why the merge is not a wholesale replacement
 
-With no queued messages, Up starts a bash-style walk back through previously submitted user messages (`historyBrowseIndex` / `historyBrowseValue` in `chat.go`): repeated Up steps older, Down steps newer, and reaching the newest entry clears the input. The walk ends as soon as the recalled text is edited — Up/Down then revert to ordinary cursor movement within multi-line content. Because mouse capture is on by default, the terminal never synthesises arrow keys from the wheel, so scrolling can't accidentally trigger a walk (see [Scrolling, selection, and the mouse](#scrolling-selection-and-the-mouse)).
+After a turn finalises, the chat view fetches `chat.history` and merges it into `m.messages`. The
+merge is deliberately *not* a wholesale replacement — that would wipe live state (the next routine
+step's placeholder, a system row the user just took an action on).
 
-## Streaming animation
+The mechanism is a generation counter (`chatModel.gen`, a monotonic `uint64` starting at 1). Every
+`appendMessage(...)` stamps the current `m.gen` onto the row. A successful `final` (or
+`error`/`aborted`) calls `bumpGen()`, capturing the current value as the "boundary" before
+advancing; that boundary is what `refreshHistoryAt(boundary)` carries. When the resulting
+`historyRefreshMsg` lands, `mergeHistoryRefresh(server, boundary)` keeps every existing row with
+`gen > boundary` (the live tail — appended by the post-bump `drainQueue` / `maybeAdvanceRoutine` /
+recovery path) and prepends the server-fetched canonical state.
 
-When a message is sent, an assistant message with `streaming: true` is appended to the display immediately so there is always visible feedback. A braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) animates at 120 ms intervals via `spinnerTickCmd()`. Each frame increments `m.spinnerFrame` and re-renders the last message line.
+The non-obvious consequences worth remembering:
 
-As delta events arrive from the gateway, the message content is built up in place. When the final event arrives, `streaming` is set to false and the spinner stops. If the final event arrives before any delta (empty response), the placeholder is removed from the display entirely.
+- Rows imported from `chat.history` carry `gen=0` (the chatMessage zero value), so any subsequent
+  refresh treats them as history-side and replaces them cleanly.
+- Tool activity is not part of `m.messages` at all — it lives in `chatModel.activeTools` — so the
+  merge neither preserves nor wipes it; it's reset per turn independently.
+- Empty `final` acks (the gateway ping that arrives before any real content) intentionally do NOT
+  bump the gen, because no turn has actually completed.
 
-The same spinner also decorates pending system rows (`chatMessage.pending`) — the in-flight placeholders posted by `/compact` and `/reset` after confirmation. `hasStreamingMessage()` treats any pending system row as a reason to keep ticking, and the result handler swaps the placeholder for the outcome via `replacePendingSystem` so the spinner is replaced in place rather than appended after. See [commands.md](commands.md#confirmation-pattern) for the wiring.
+Tests pin the contract: `TestMergeHistoryRefresh_PreservesLiveTail`,
+`TestMergeHistoryRefresh_NoLiveTail`, `TestHandleEvent_FinalBumpsGen`,
+`TestHandleEvent_FinalEmptyAckDoesNotBumpGen`. Treat them as a regression fence.
 
-See [message-rendering.md](message-rendering.md#streaming-placeholder) for the rendering side of this.
+## Per-agent header colour: why it's keyed on the agent ID
 
-## Thinking levels
+The header background override is stored against the agent ID under
+`prefs.Agents[agentID].HeaderColor`, and the renderer calls `prefs.HeaderColorFor(m.agentID)` each
+frame. Keying it on the agent (rather than a single global setting) is what lets switching to
+another agent pick up that agent's own colour, or fall back to the default accent purple. The
+colour is applied to both `headerStyle` and the warn-badge background so the badges stay legible
+against a customised header.
 
-The gateway supports extended thinking for supported models. The level is stored in `m.thinkingLevel` and displayed in the header bar when set and not `"off"`.
+## Update check: the escape hatches and why they exist
 
-Valid levels: `off`, `minimal`, `low`, `medium`, `high`.
+The daily startup update check is owned by `internal/update`: a single
+`GET https://lucinate.ai/latest.json` with a 5-second timeout, fired once per day from
+`AppModel.Init()`. It's designed to fail silently — offline, captive portal, malformed manifest, or
+a non-stable build all make `update.Check` return `nil, nil`, so a flaky network never produces a
+badge or an error.
 
-`/think` (no argument) shows the current level. `/think <level>` validates the input and calls `client.SessionPatchThinking(sessionKey, level)`. See [commands.md](commands.md) for the command dispatch.
+Two env-var escape hatches exist for good reason:
 
-The spinner also appears while the model is thinking before any response deltas arrive, giving immediate feedback after sending.
+- `LUCINATE_DISABLE_UPDATE_CHECK=1` is an unconditional opt-out on top of the `/settings` toggle,
+  useful in CI where you don't want any outbound request.
+- `LUCINATE_UPDATE_MANIFEST_URL` overrides the manifest URL for local testing without touching the
+  production endpoint.
 
-## Header bar
+The badge is suppressed once seen: `prefs.LatestSeenVersion` records the manifest version on every
+successful check, and the badge only reappears when the manifest moves *past* that version.
 
-The header line shows:
+## Why mouse capture is on by default
 
-- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected) · update-available badge (only when `prefs.UpdateChecksEnabled()` and the startup check found a newer release)
-- **Right:** context usage (`tokens: 65k/1.0m (7%)  $0.42`) when the gateway has reported a context window for the active session; otherwise the legacy `tokens: 125.5K (2.3K cached)  $0.42` shape.
+Mouse capture (SGR cell-motion tracking) is on by default because it's what lets wheel scrolling,
+click-drag selection, and Up/Down input recall coexist without fighting. With tracking on, the
+terminal never translates the wheel into arrow keys, so scrolling can't collide with the bash-style
+input-recall walk — the arrow keys stay exclusively input recall. The cost of `/mouse off` is
+losing wheel scrolling (it hands click-drag back to the terminal's native selection), which is why
+capture-on is the default rather than the opt-in.
 
-Two independent loads feed the right-hand side:
+One related nicety: if you've scrolled up, new streaming output does not yank you back down; new
+messages re-anchor to the bottom only when you're already there (`GotoBottom()` after each update).
 
-- `loadContextUsage()` populates `m.promptTokens` and `m.contextWindow`. It calls `SessionsList(agentID)`, finds the entry whose `key` matches `m.sessionKey`, and reads `totalTokens` (numerator — a per-turn prompt-token snapshot of `input + cacheRead + cacheWrite`, intentionally excluding output) and `contextTokens` (denominator), falling back to `defaults.contextTokens` when the entry omits the window. This is what makes the percentage scoped to the *current session*; the older approach of calling `SessionUsage("")` returned gateway-wide aggregates and pegged the value at 999%. The cmd refreshes on chat init, on every `historyRefreshMsg` (so the percentage tracks turn-by-turn), and on `modelSwitchedMsg` (a new model can change the window). The handler discards results whose `sessionKey` no longer matches `m.sessionKey` so a navigated-away-and-back race can't apply a stale snapshot.
-- `loadStats()` continues to call `client.SessionUsage()` for the cumulative cost figure shown on the right of the header (and for the `/stats` table). The percentage display falls back to its token+cache layout when `loadContextUsage` hasn't produced a window yet.
+## Why Alt+Enter, not Shift+Enter, inserts a newline
 
-The renderer caps the percentage at 999% so a runaway numerator never widens the header past three digits.
+Newline is bound to Alt+Enter via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")`. Shift+Enter is
+deliberately not supported: enabling it would require `ReportAllKeysAsEscapeCodes`, which is
+disabled precisely to preserve shifted punctuation input.
 
-The header background defaults to the accent purple but can be overridden per agent with `/header <hex>` — see [commands.md → /header](commands.md#header). The override is stored against the agent ID under `prefs.Agents[agentID].HeaderColor`; the renderer calls `prefs.HeaderColorFor(m.agentID)` each frame and applies the colour to both `headerStyle` and the warn-badge background. Switching to another agent picks up that agent's own colour (or the default).
+## Notifications replaced transient system rows
 
-The connection-status badge is rendered in the error colour and only appears when the gateway connection is degraded:
+The `chatModel.notifications` store (`internal/tui/notifications.go`) exists because appending
+`chatMessage{role:"system"}` rows for transient state was the wrong home for it. Notifications live
+outside `m.messages`, so they survive `historyRefreshMsg` and never reach the gateway, and they're
+cleared at the top of the Enter handler on the user's next action — the assumption being that any
+state worth showing has been read or no longer applies by then.
 
-| Badge | Meaning |
-|---|---|
-| `⚠ disconnected` | The supervisor has just observed the WebSocket close; reconnect not yet attempted. |
-| `⟳ reconnecting` (or `attempt N`) | A reconnect attempt is in progress. The attempt counter is shown from the second attempt onwards. |
-| `✖ auth failed` | The gateway rejected the device token mid-session. The supervisor has stopped retrying — open `/connections` and re-pick the same connection so the connecting view's auth-recovery modal can prompt for a fix. |
+Persistent client-side rows (the inline `! cmd` / `!! cmd` shell-execution scrollback, gateway
+connect/disconnect notes, the `/help` / `/stats` / `/skills` info dumps) still go in `m.messages`
+because their value is in being scrollable history, not in a one-shot read.
 
-A matching one-line system message is also added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. See [authentication.md](authentication.md#reconnect-after-disconnection) for the full lifecycle.
+## Connect timeout: bump it for cold-starting local LLMs
 
-### Update-available badge
-
-A second header badge — `↑ vX.Y.Z`, rendered in the same warn style as `⚠ disconnected` — appears when the daily startup update check finds a newer release. The check is owned by `internal/update`: a single `GET https://lucinate.ai/latest.json` with a 5-second timeout, fired once per day from `AppModel.Init()`. Anything goes wrong (offline, captive portal, malformed manifest, non-stable build) and `update.Check` returns `nil, nil` — no badge, no error.
-
-The badge is suppressed once the user has seen it: `prefs.LatestSeenVersion` records the manifest version on every successful check, and the badge only appears when the manifest moves *past* that version. Toggle the whole thing off via the `Check for updates on startup` row in `/settings`, or set `LUCINATE_DISABLE_UPDATE_CHECK=1` for an unconditional opt-out (useful in CI). The manifest URL itself can be overridden via `LUCINATE_UPDATE_MANIFEST_URL` for local testing.
-
-## View region order
-
-`chatModel.View()` (`internal/tui/chat.go`) assembles the chat view top→bottom in this fixed order. Every region between the header and the input reserves conversation-viewport height via `applyLayout`, and each only renders when it has content:
-
-1. **Header** — the status bar (connection, agent, model, token/cost).
-2. **Info notifications** — informational one-shots such as `copied … to clipboard`, pinned just below the header.
-3. **Conversation viewport** — the scrollable transcript.
-4. **Completion menu** — slash-command / mention candidates, while active.
-5. **Routine status row** — when a routine is active.
-6. **Tool-activity strip** — what the agent is running this turn (collapses to a summary when idle).
-7. **Queued-message footer** — messages typed while a turn streams, awaiting dispatch.
-8. **Error notifications** — error one-shots; the bottommost region above the input.
-9. **Input box.**
-10. **Help line.**
-
-Informational and error notifications are deliberately split to opposite ends. An informational confirmation reads naturally at the top beside the status bar, while an error surfaces at the bottom next to the input, where the user will act on it. Both are drawn from the same `chatModel.notifications` store, filtered on the `isError` flag by `renderInfoNotifications` / `renderErrorNotifications`.
-
-## Notifications
-
-Ephemeral state messages — confirmation prompts, cancel acks, routine state changes ([routines.md](routines.md)) — render as one or more width-padded rows, styled with `statusStyle` (or `errorStyle` for is-error rows). They are split by kind: **informational** rows pin to the top just below the header, and **error** rows drop to the bottommost region below the queued-message footer — see [View region order](#view-region-order) for how they sit relative to the other regions.
-
-The store is `chatModel.notifications []notification` (`internal/tui/notifications.go`). Notifications live outside `m.messages`, so they survive `historyRefreshMsg` and never reach the gateway. They are cleared at the top of the Enter handler whenever the user submits a non-empty input, and on the empty-Enter routine-advance path — the assumption is that any state worth showing in a notification has been read or no longer applies once the user takes their next action.
-
-`m.notify(text)`, `m.notifyError(text)`, and `m.clearNotifications()` are the only entry points; each calls `applyLayout()` so the conversation viewport reflows when notifications appear or disappear. Empty text is dropped silently so callers can `notify(maybeFmt(...))` without a guard.
-
-This replaced the older pattern of appending `chatMessage{role:"system"}` rows for transient state. Persistent client-side rows (the inline `! cmd` / `!! cmd` shell-execution scrollback, gateway connect/disconnect notes, the `/help` / `/stats` / `/skills` info dumps) still go in `m.messages` because their value is in being scrollable history, not in a one-shot read.
-
-## Routine status row
-
-When `m.activeRoutine != nil`, a single styled row renders immediately above the input box:
-
-```
-routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
-```
-
-`AUTO`/`MANUAL` reflects the controller's mode; `(paused)` is appended when `paused` is set. The row is sourced by `routineStatusLine()` and styled by `routineStatusStyle` in `routines_chat.go`. `applyLayout()` subtracts one from the viewport height when a routine is active, mirroring the notification-row accounting. See [routines.md](routines.md) for the full controller surface.
-
-## Tool activity strip
-
-When the agent invokes a tool, it appears in an ephemeral strip above the input (not in the scrollback) — name, one-line argument summary, and a state glyph that animates while running and resolves to ✓ or ✖. Once the turn finishes the strip collapses to a one-line summary (`✓ called search ×3, read ×2`) that clears when the next turn begins. Lucinate opts into the `tool-events` capability on connect; backends without tool events (e.g. the OpenAI-compatible adapter) simply never emit them. Tool output bodies are not yet expandable — see [message-rendering.md](message-rendering.md#tool-activity-strip) for the rendering contract and the open follow-up for an expand/collapse affordance.
-
-## History depth
-
-The number of messages loaded from the gateway on session init is configurable. The default is 50. It can be changed via `/settings` ("History limit") in steps of 10 (range 10–500). The value is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
-
-When restored history is non-empty, a dimmed separator row is rendered above the new turn, labelled with the relative time of the most recent restored message (`Resumed from 2h ago`, `…`). The label comes from `formatSeparatorLabel` (`render.go`), driven by the `timestampMs` field on the synthetic separator `chatMessage`. See [message-rendering.md](message-rendering.md#message-roles) for the role.
-
-See [sessions.md](sessions.md#lifecycle) for how history loading fits into the session lifecycle.
-
-## Mid-turn history resync
-
-After a turn finalises, the chat view fetches `chat.history` from the gateway and merges it into `m.messages`. The merge is *not* a wholesale replacement — that would wipe live state (the next routine step's placeholder, a system row the user just took an action on). (Tool activity lives outside `m.messages`, so it's untouched by the merge.)
-
-The mechanism is a generation counter:
-
-- `chatModel.gen` is a monotonically increasing `uint64` (starts at 1).
-- Every `appendMessage(...)` stamps the current `m.gen` onto the row.
-- A successful `final` (or `error`/`aborted`) calls `bumpGen()`, which captures the current value as the "boundary" and then advances the counter. The boundary is what the just-issued `refreshHistoryAt(boundary)` carries.
-- When the resulting `historyRefreshMsg` lands, `mergeHistoryRefresh(server, boundary)` keeps every existing row with `gen > boundary` (the live tail — appended by the post-bump `drainQueue` / `maybeAdvanceRoutine` / recovery path) and prepends the server-fetched canonical state.
-
-Practical consequences:
-
-- Rows imported from `chat.history` carry `gen=0` (the chatMessage zero value), so any subsequent refresh treats them as history-side and replaces them cleanly.
-- Tool activity is not part of `m.messages` at all (it lives in `chatModel.activeTools`, rendered in the [strip](#tool-activity-strip)), so the merge neither preserves nor wipes it — it's reset per turn independently.
-- Empty `final` acks (the gateway ping that arrives before any real content) intentionally do NOT bump the gen, because no turn has actually completed.
-
-Tests pin the contract: `TestMergeHistoryRefresh_PreservesLiveTail`, `TestMergeHistoryRefresh_NoLiveTail`, `TestHandleEvent_FinalBumpsGen`, `TestHandleEvent_FinalEmptyAckDoesNotBumpGen`.
-
-## Connect timeout
-
-Each (re)connect attempt has a per-attempt deadline applied to the WebSocket / HTTP handshake. The default is 15 seconds; the range is 5–300 seconds via `/settings` ("Connect timeout"). The configured value is loaded by `app.DefaultBackendFactory` (`app/factory.go`) for every backend dispatch, so the same setting governs the initial connect and the supervisor's reconnect attempts. Bump it when targeting a slow local LLM that cold-starts on first request.
-
-## Scrolling, selection, and the mouse
-
-The message history is a Bubble Tea viewport. Mouse capture (SGR cell-motion
-tracking) is **on by default**, which makes the three core interactions
-coexist cleanly:
-
-- **Wheel / trackpad scrolls the history.** Wheel events are forwarded to the
-  viewport directly. Because tracking is on, the terminal never translates the
-  wheel into arrow keys, so scrolling can't collide with input recall. If
-  you've scrolled up, new streaming output does not yank you back down; new
-  messages re-anchor to the bottom only when you're already there
-  (`GotoBottom()` after each update).
-- **Click-drag selects and copies.** Dragging over the transcript draws a
-  reverse-video highlight; on release the selected text is copied to the
-  clipboard (both OSC 52 through the terminal and the OS clipboard directly),
-  with a "Copied …" confirmation row. Implemented in
-  `internal/tui/selection.go`. Selections are char-precise, span multiple
-  lines, auto-scroll when dragged past the viewport edge, and strip styling
-  from the copied text.
-- **Up/Down remain input recall.** The bash-style walk through previously
-  submitted messages (and queued-message editing) owns the arrow keys
-  exclusively; scrolling never reaches them.
-
-Page Up/Down still scroll a page at a time. `/mouse off` opts out of capture,
-handing click-drag back to the terminal's native selection at the cost of
-wheel scrolling (the previous default behaviour); `/mouse on` restores the
-default.
+The per-attempt handshake deadline (default 15s) is loaded by `app.DefaultBackendFactory`
+(`app/factory.go`) for every backend dispatch, so the one setting governs both the initial connect
+and the supervisor's reconnect attempts. The practical note: bump it when targeting a slow local
+LLM that cold-starts on first request, or the first connect will time out before the model is ready.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,129 +1,81 @@
-# Slash commands
+# Slash commands — lessons and rationale
 
-Slash commands are local TUI commands that begin with `/`. They are intercepted by `handleSlashCommand()` in `internal/tui/commands.go` before any message is sent to the gateway. The function returns `(handled bool, cmd tea.Cmd)` — if `handled` is true, the input is consumed locally and never forwarded.
+The behavioural contract for slash commands lives in
+[`openspec/specs/commands/spec.md`](../openspec/specs/commands/spec.md) — dispatch and
+interception, the full built-in command catalogue, tab completion, the yes/no confirmation
+pattern, and the routine-active navigation gate are all captured there as requirements and
+scenarios. This file keeps the hard-won lessons, pitfalls, and design rationale behind those
+commands: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-## Dispatch
+## `model not allowed`: patch with the qualified reference
 
-Input that starts with `/` and contains no spaces is matched case-insensitively against a `switch` statement of built-in commands. Commands that accept an argument (e.g. `/agent foo`, `/model sonnet`, `/think high`) are matched by prefix check after the switch.
+Both switch paths — the `/model <name>` command and the `/models` picker — patch with the
+**qualified `<provider>/<id>` reference** produced by `qualifiedModelRef()`
+(`internal/tui/models.go`), not the bare id. `models.list` reports a provider-local id (e.g.
+`deepseek/deepseek-v4-pro`) alongside a separate `provider` field (e.g. `openrouter`), but
+`sessions.patch` — like the agent's configured `model.primary` — validates against the
+fully-qualified form (`openrouter/deepseek/deepseek-v4-pro`). Sending the bare id makes the
+gateway reject the switch with `INVALID_REQUEST: model not allowed: <id>`. Backends that
+leave `provider` empty (openai, hermes) keep the bare id unchanged.
 
-Slash input that isn't a built-in is checked against the loaded skill names: if the first token (`/foo` from `/foo bar`) matches a skill, `handleSlashCommand` returns `(false, nil)` and lets the regular send path expand it via `expandSkillReferences` — see [skills.md](skills.md#activation). If it matches neither a built-in nor a skill, an error system message is shown.
+## `/cron`: names aren't unique, and `/crons` wins the switch
 
-## Built-in commands
+`/cron` requires a name argument, and bare `/cron` points at `/crons`. That works because the
+plural browser is matched by the switch first, so a `/cron ` prefix never swallows it.
 
-| Command | What it does |
-|---|---|
-| `/agent` | Return to the agent picker (alias for `/agents`) |
-| `/agent <name>` | Switch to a named agent without going through the picker — see below |
-| `/agents` | Return to the agent picker by emitting `goBackMsg{}` |
-| `/cancel` | Cancel the in-progress response (also triggered by Escape) — see [chat-ux.md](chat-ux.md) |
-| `/clear` | Wipe `m.messages` from the local display (does not affect gateway history) |
-| `/compact` | Compact the session context — see [sessions.md](sessions.md#compact-and-reset) |
-| `/config` | Backward-compatible alias for `/settings` |
-| `/connections` | Open the connections picker mid-session, tearing down the active backend — see [connections.md](connections.md) |
-| `/crons` | Open the cron browser filtered to the current agent — see [crons.md](crons.md) — **OpenClaw only** |
-| `/crons all` | Open the cron browser unfiltered (jobs across all agents) — **OpenClaw only** |
-| `/cron <name>` | Resolve a named cron job and run it immediately after a y/n confirmation — see below — **OpenClaw only** |
-| `/exit`, `/quit` | Exit via `tea.Quit` |
-| `/export` | Write the current session's canonical history to a transcript file — see below |
-| `/export all` | Same as `/export` |
-| `/export routine` | Convert the session's user prompts into routine steps and open the form prepopulated — see below |
-| `/header` | Show the chat header background colour for the current agent |
-| `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted per agent across runs — see below |
-| `/header reset` | Restore the default header colour for the current agent (also accepts `default` or `off`) |
-| `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
-| `/model` | Report the model in use for the current session |
-| `/model <name>` | Switch model — see below |
-| `/models` | Open the model picker (filter as you type) |
-| `/mouse` | Report the current mouse-capture state |
-| `/mouse on` | Enable mouse capture (the default): wheel scrolls history, click-drag selects and copies — see [chat-ux.md](chat-ux.md#scrolling-selection-and-the-mouse) |
-| `/mouse off` | Disable capture, handing click-drag back to the terminal's native selection (wheel scrolling stops) |
-| `/mouse toggle` | Flip the capture state |
-| `/record` | Show whether transcript capture is on, and where it's writing |
-| `/record on` | Begin streaming canonical conversation messages to a transcript file — see below |
-| `/record off` | Stop the active recording and report the file path |
-| `/reset` | Delete the session and start fresh — see [sessions.md](sessions.md#compact-and-reset) |
-| `/routine <name>` | Activate a stored routine in the current session — see [routines.md](routines.md) |
-| `/routines` | Open the routines manager (list/view/edit/delete) — see [routines.md](routines.md) |
-| `/sessions` | Open the session browser — see [sessions.md](sessions.md#session-browser) |
-| `/settings` | Open the settings view by emitting `showConfigMsg{}` (alias: `/config`) |
-| `/skills` | List discovered skills — see [skills.md](skills.md) |
-| `/stats` | Show a token usage and cost table for the current session — **OpenClaw only** |
-| `/status` | Show backend status — common header (type, endpoint, auth, default model) plus backend-specific blocks: OpenClaw gateway health / versions / agents / channels, OpenAI agent count + current `history.jsonl` stats, Hermes thread state |
-| `/think` | Show the current thinking level — **OpenClaw only** |
-| `/think <level>` | Set the thinking level — see [chat-ux.md](chat-ux.md#thinking-levels) — **OpenClaw only** |
+Cron job names are **not unique**, so `matchCronJobs()` is tiered — exact (case-insensitive)
+`Name`, then exact `ID`, then substring on either — and returns every job in the winning tier.
+When more than one lands, the ambiguity row lists each candidate's name, `id`, and schedule and
+tells the user to re-run `/cron <id>`, because IDs *are* unique and that's the only reliable way
+to disambiguate. Since names live on the gateway, resolution is asynchronous and `/cron <name>`
+always re-lists to resolve the actual run — the tab-completion snapshot may have gone stale
+mid-session.
 
-Backend-only commands render a "not available on this connection" system message on connections that don't support them — see [connections.md](connections.md#capability-negotiation).
+## `/header`: no fallback to a global setting
 
-### /agent
+Overrides are scoped per agent and stored under a nested `agents` sub-object in `config.json`,
+keyed by agent ID, so future per-agent settings can sit alongside `headerColor` without growing
+the file horizontally. When the active agent has no ID (e.g. an unbound chat), `/header`
+reports an error rather than falling back to a global setting — there's deliberately no global
+header colour to fall back to.
 
-`handleAgentCommand()` covers both shapes. With no argument it emits `goBackMsg{}`, returning to the agent picker just like `/agents`. With a name it calls `client.ListAgents()`, fuzzy-matches case-insensitively against agent names and IDs (exact match first, then substring), then calls `client.CreateSession(agentID, "main")` and emits the same `sessionCreatedMsg` the picker selection path uses — so the chat view rebuild is identical to picking from the list. Lookup failures (no match, or backend error) are rendered inline as a system message via `agentSwitchFailedMsg` rather than bouncing the user back to the picker.
+## Tab completion: LCP drives it, curated order no longer does
 
-### /model
+The curated order in `slashCommands` (e.g. `/agents` before `/agent`, `/model` before
+`/models`) now only breaks ties for the inline ghost-hint and the legacy `completeSlashCommand`
+callers — Tab uses the longest-common-prefix extension, so the order no longer steers it. The
+cycle-mode snapshot persists across presses because Tab returns early before
+`refreshCompletionMenu` runs; any non-Tab keystroke clears cycling and recomputes candidates.
 
-`handleModelCommand()` reports the current model for the active session when called with no argument (falling back to `gateway default` when `m.modelID` is empty), pointing the user at `/models` and `/model <name>` to change it. With a name it calls `client.ModelsList()` to retrieve available models from the gateway, fuzzy-matches against model IDs and names (exact match first, then substring), then calls `client.SessionPatchModel(sessionKey, modelRef)` and updates `m.modelID` in the header. `/models` (plural) opens the picker via `showModelPickerMsg`.
+Agent- and cron-name completion silently degrade to a no-op when the list hasn't loaded or the
+backend errored — the matcher returns nil, the candidate list is empty, and the menu simply
+stays hidden rather than surfacing an error.
 
-Both switch paths — the `/model <name>` command and the `/models` picker — patch with the **qualified `<provider>/<id>` reference** produced by `qualifiedModelRef()` (`internal/tui/models.go`), not the bare id. `models.list` reports a provider-local id (e.g. `deepseek/deepseek-v4-pro`) alongside a separate `provider` field (e.g. `openrouter`), but `sessions.patch` — like the agent's configured `model.primary` — validates against the fully-qualified form (`openrouter/deepseek/deepseek-v4-pro`). Sending the bare id makes the gateway reject the switch with `INVALID_REQUEST: model not allowed: <id>`. Backends that leave `provider` empty (openai, hermes) keep the bare id unchanged.
+### Menu vs ghost-hint fallback
 
-### /cron
+The live menu is the primary surface, but it can't always render. The single-line greyed-out
+ghost hint (`slashCommandHint` / `agentNameHint`) exists purely as a fallback for short
+terminals: the menu suppresses itself entirely when the baseline can't leave at least
+`completionMenuViewportFloor` rows for the conversation, and Tab still does LCP extension on the
+underlying state even with the menu hidden. So completion never depends on the menu being
+visible.
 
-`handleCronCommand()` is gated on `backend.CronBackend` (OpenClaw only); on other connections it reports "not available". It requires a name argument — bare `/cron` errors and points at `/crons` (the plural browser is matched by the switch first, so a `/cron ` prefix never swallows it).
+## Confirmation pattern: drop the prompt so `(y/n)` doesn't linger
 
-Because names live on the gateway, resolution is asynchronous: the handler returns a command that calls `CronsList` and dispatches a `cronResolveMsg` carrying the query and the matched jobs. `matchCronJobs()` is tiered — exact (case-insensitive) `Name`, then exact `ID`, then substring on either — and returns every job in the winning tier because cron job names are **not unique**. `chatModel.Update` turns the result into one of: an error row (list failed or no match), an ambiguity row listing each candidate's name, `id`, and schedule (re-run `/cron <id>` — IDs are unique — to disambiguate), or, for a single match, a `pendingConfirmation` (see [Confirmation pattern](#confirmation-pattern)). The confirm prompt shows the schedule and next run and ends in `(y/n)`; on `y` the action calls `CronRun(id, force=true)` — run now regardless of schedule, matching the crons browser's "Run now" — and reports the outcome via `chatCronRanMsg` → `replacePendingSystem`.
+Commands that need a yes/no (`/compact`, `/reset`, `/cron <name>`) use a two-step confirmation
+to prevent accidental data loss. The subtlety worth remembering: on the answering Enter,
+`removeConfirmPrompt()` drops the tagged prompt row either way — a brief `Confirmed.` /
+`Cancelled.` notification reports which — so the `(y/n)` question doesn't linger in the
+scrollback once answered.
 
-### /stats
+When `runningStatus` is set, the handler animates the same braille spinner used for in-flight
+assistant turns, and the result handler calls `replacePendingSystem` to swap the placeholder for
+the outcome line **in place** — no stale "Compacting session…" stuck above the result.
 
-Stats are loaded asynchronously via `client.SessionUsage()` on chat init and after each message exchange. `/stats` formats `m.stats` through `formatStatsTable()` in `internal/tui/render.go`, which produces a text table of input/output/cache tokens and cost breakdown.
+## Routine-active navigation gate: keep the two flows apart
 
-### /header
-
-`handleHeaderCommand()` parses the argument, runs it through `config.NormalizeHexColor()` (accepts `#RRGGBB`, `#RGB`, with or without the leading `#`), then writes the canonical `#RRGGBB` value via `prefs.SetHeaderColor(agentID, hex)`, persists with `config.SavePreferences()`, and emits `prefsUpdatedMsg` so `AppModel.prefs` and `chatModel.prefs` stay in sync. The chat view's `View()` calls `m.prefs.HeaderColorFor(m.agentID)` each render and overrides `headerStyle.Background()` (and the update-available warn-badge background, which sits inside the header) when a value is set for the current agent. Bare `/header` reports the current agent's value; `/header reset` (also `default`, `off`) clears it.
-
-The colour is scoped per agent — switching to another agent shows that agent's own colour (or the built-in default). Per-agent overrides are stored under a nested `agents` sub-object in `config.json`, keyed by agent ID, so future per-agent settings can sit alongside `headerColor` without growing the file horizontally. When the active agent has no ID (e.g. an unbound chat), `/header` reports an error rather than falling back to a global setting.
-
-### /record and /export
-
-Both commands persist the session's canonical chat history to a Markdown file under `<dataDir>/transcripts/`. `/record on` streams new turns as they finalise; `/export [all]` dumps the current state in one shot; `/export routine` skips the file write and opens the routines manager prefilled with the session's user prompts.
-
-The canonical-history tap, dedup signature, file layout, and lifecycle are documented in [export-and-recording.md](export-and-recording.md).
-
-## Tab completion
-
-A live menu (rendered between the conversation viewport and the input) appears as soon as the cursor sits at the end of a completable token with at least one matching candidate. Two sources feed the same menu and the same Tab/Shift+Tab semantics:
-
-- **Slash commands and skills** — `matchingSlashCommands(prefix)` (`completion.go`) returns built-ins from the static `slashCommands` slice in their curated order, followed by skill names. Source detection: `findSlashTokenAt(value, cursorByte)`.
-- **Agent names** — the argument of `/agent <name>`. `matchingAgentNames(prefix)` returns every loaded agent whose lowercased form has the prefix as a prefix, preserving each agent's original casing. Source detection: `findAgentArgAt(value, cursorByte)`, which treats the entire tail of the line after `/agent ` as the token (so names with spaces complete in one shot).
-- **Cron names** — the argument of `/cron <name>`. `matchingCronNames(prefix)` mirrors the agent source over `m.cronNames`, which `loadCronNames()` populates on init from `CronsList` (a no-op on non-OpenClaw connections). Source detection: `findCronArgAt(value, cursorByte)` (line begins with `/cron ` — the trailing space excludes `/crons`). The snapshot may go slightly stale mid-session; `/cron <name>` always re-lists to resolve the actual run.
-
-`completionAtCursor()` resolves the active source — slash commands take priority — and returns a `completionContext{start, cursorByte, prefix, candidates}`. The Tab handler dispatches a single `handleCompletionTab(ctx)` over this context, applying bash-style menu-complete semantics:
-
-- One match → full completion in place.
-- Multiple matches with a longest common prefix beyond what the user typed → the input is extended up to that LCP. `longestCommonPrefixFold(strs)` computes a case-insensitive LCP using the first candidate's casing — agent names like `Main` and `Mail` collapse to `Mai`, slash candidates (already lowercase) behave identically to the byte-wise variant.
-- Multiple matches at the LCP → enter cycle mode. The first Tab snapshots the candidate list into `m.completion.cycleCandidates`, sets `cycleIndex = 0`, and replaces the input with the first candidate. Subsequent Tab presses advance the index modulo the snapshot length; Shift+Tab decrements with the same wraparound. The snapshot persists across presses because Tab returns early before `refreshCompletionMenu` runs.
-
-Any non-Tab keystroke routes through `refreshCompletionMenu`, which clears `cycling` and recomputes `candidates` from the current textarea contents via `completionAtCursor()`. The menu auto-hides when no source applies (whitespace breaks a slash token, cursor leaves end-of-line in the agent-arg context, the input is cleared, or the message is sent — `Reset()` calls in the Enter handler explicitly invoke `refreshCompletionMenu` so the menu doesn't outlive the input).
-
-The curated order in `slashCommands` (e.g. `/agents` before `/agent`, `/model` before `/models`) now only breaks ties for the inline ghost-hint and the legacy `completeSlashCommand` callers — Tab uses LCP, so the order no longer steers it.
-
-`setTextareaToValueWithCursor` performs the in-place replacement and repositions the cursor at the end of the inserted text.
-
-### Inline ghost-hint fallback
-
-`slashCommandHint` and `agentNameHint` still drive a single-line greyed-out hint in the help bar — but only as a fallback for short terminals where the menu can't render. With the menu visible, the help line switches to `Tab: extend · Shift+Tab: back · N matches`.
-
-### Layout
-
-`chatModel.baseViewportHeight` records the viewport height with the menu hidden; `applyLayout()` shrinks the viewport by `menuRowsToRender()` whenever menu state changes, so the conversation pane reflows cleanly. The menu suppresses itself entirely when the baseline cannot leave at least `completionMenuViewportFloor` rows for the conversation — Tab still does LCP extension on the underlying state. Candidate counts above `completionMenuMaxRows` collapse the tail into a `+N more` line.
-
-### Agent name source
-
-The chat model fetches the agent list once on init via `loadAgentNames()` and stores display names in `m.agentNames`; completion silently degrades to a no-op when the list hasn't loaded yet or the backend errored (`matchingAgentNames` returns nil, so `completionAtCursor` reports an empty candidate list and the menu stays hidden). `findAgentArgAt` recognises the argument context only when the cursor sits at end-of-line and the line begins with `/agent ` (single space). Empty prefix matches every agent — Tab on `/agent ` opens the menu listing the full roster, with the LCP/cycle flow taking over from there.
-
-## Confirmation pattern
-
-Commands that need a yes/no (`/compact`, `/reset`, `/cron <name>`) use a two-step confirmation. On first invocation a `pendingConfirmation` struct is stored on the model containing the prompt string, an optional `runningStatus` line, and an action closure. The prompt is appended to the chat scrollback as a system row tagged `confirmPrompt: true`. On the next Enter keypress, if the input is `y` or `yes` the closure is executed; anything else cancels — and either way `removeConfirmPrompt()` drops the tagged prompt row (a brief `Confirmed.`/`Cancelled.` notification reports which) so the `(y/n)` question doesn't linger once answered. This prevents accidental data loss.
-
-When `runningStatus` is set, the confirmation handler also appends a pending system row (`pending: true`) carrying that status text to the chat scrollback. The renderer animates the same braille spinner used for in-flight assistant turns next to the row, and `hasStreamingMessage` keeps `spinnerTickCmd` firing until the action returns. The result handler (`sessionCompactedMsg`, `sessionClearedMsg`, `chatCronRanMsg`) calls `replacePendingSystem` to swap the placeholder for the outcome line in place — no stale "Compacting session…" stuck above the result.
-
-## Routine-active navigation gate
-
-Slash commands that strand or replace the chat model — `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections`, `/routine <name>`, `/routines` — route through `gateNavigation()` (`internal/tui/routines_chat.go`) when a routine is active. A `pendingNavConfirm` is set, the prompt is rendered as a notification, and the Enter handler resolves it: `y` cancels any in-flight turn, ends the routine cleanly (closing the log file), and dispatches the navigation; `n` or Esc dismisses the prompt and the routine continues. The state is independent of the generic `pendingConfirmation` so the two flows don't compete. See [routines.md → Slash commands and gating](routines.md#slash-commands-and-gating) for the full rationale.
+Slash commands that strand or replace the chat model route through `gateNavigation()`
+(`internal/tui/routines_chat.go`) when a routine is active, so navigating away doesn't silently
+abandon a running routine. The `pendingNavConfirm` state is kept **independent** of the generic
+`pendingConfirmation` on purpose, so the two confirmation flows don't compete over the same UI
+state. See the `routines` spec (slash commands and gating) for the full rationale.

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -1,88 +1,83 @@
-# Connections and backends
+# Connections and backends — lessons and rationale
 
-A connection is a saved target lucinate can connect to (URL + type + auth identity). The list is persisted to `~/.lucinate/connections.json` and managed through the connections picker (`viewConnections`) — accessible as the entry view on first run, via `/connections` mid-session, or via the **Connections** action on the agent picker. The picker also exposes a **Settings** action (key `s`) that opens the settings screen without leaving the pre-chat flow.
+The behavioural contract for connections and backends lives in
+[`openspec/specs/connections/spec.md`](../openspec/specs/connections/spec.md) — the connection
+types, the picker and form, the startup decision tree, the connection lifecycle, capability
+negotiation, auth-recovery modals, and secrets storage are all captured there as requirements
+and scenarios. This file keeps the hard-won lessons, pitfalls, and design rationale behind that
+contract: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-## Connection types
+## Sibling backends, not a base class and a subclass
 
-Three backend types ship today; all implement `backend.Backend` (`internal/backend/backend.go`) so the chat / sessions / commands views are backend-agnostic. The OpenAI and Hermes backends both speak HTTP+SSE+JSON over Bearer-token auth and share the request builder, SSE scanner, and event emitter in `internal/backend/httpcommon` — but they're sibling implementations, not a base class and a subclass. Backend-specific behaviour is documented in dedicated files:
+The OpenAI and Hermes backends both speak HTTP+SSE+JSON over Bearer-token auth and share the
+request builder, SSE scanner, and event emitter in `internal/backend/httpcommon` — but they're
+sibling implementations, not a base class and a subclass. The shared plumbing is a convenience,
+not an inheritance hierarchy, and treating it as one leads you astray when their request/response
+shapes diverge (`/v1/chat/completions` vs `/v1/responses` server-state chaining).
 
-- [backend_openclaw.md](backend_openclaw.md) — full capability surface, device-token auth, server-side agents
-- [backend_openai.md](backend_openai.md) — `/v1/chat/completions` streaming, on-disk agents (IDENTITY.md + SOUL.md), API-key auth
-- [backend_hermes.md](backend_hermes.md) — `/v1/responses` server-state chaining, one synthetic agent per connection, API-key auth
+## Why the factory switch is enough to reach a new backend everywhere
 
-| Type      | URL shape                                                   | Auth                                   | Agent storage                                                                  |
-|-----------|-------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------|
-| OpenClaw  | `https://`/`http://`/`wss://`/`ws://` (WS endpoint derived) | Ed25519 device pairing                 | Server-side on the gateway                                                     |
-| OpenAI    | `http(s)://host/v1`                                         | Optional `Authorization: Bearer <key>` | Local under `~/.lucinate/agents/<conn-id>/<agent-id>/`                         |
-| Hermes    | `http(s)://host:8642/v1` (default loopback)                 | `Authorization: Bearer <API_SERVER_KEY>` | Server-side in the Hermes profile; only `last_response_id` + prompts log local |
+`DefaultBackendFactory` (`app/factory.go`) has two non-TUI consumers, and both are wired so that
+landing a new connection type in the factory's switch is all it takes to reach them. `app.Send`
+(`lucinate send`) calls the factory directly for one-shot dispatch, so a new type is automatically
+reachable from the scripted CLI mode without further wiring. `app.Chat` (`lucinate chat`) defers
+all connect / list / create work to the TUI and just packs overrides into `RunOptions`, so a new
+type is reachable there as soon as it works in the regular TUI. Worth knowing before you go
+hunting for extra plumbing to add.
 
-`AllConnectionTypes` (`internal/config/connections.go`) drives the picker form's type radio. Adding a fourth backend means: implementing `backend.Backend`, extending the enum, dispatching in `DefaultBackendFactory` (`app/factory.go`), adjusting the form's type-conditional rendering, and writing a `backend_<name>.md` doc for it.
+## Auto-add doesn't persist until a successful connect
 
-`DefaultBackendFactory` has two non-TUI consumers. `app.Send` (`lucinate send`) calls it directly to build a backend for one-shot dispatch — a new connection type that lands in the factory's switch is automatically reachable from the scripted CLI mode without further wiring (see [one-shot.md](one-shot.md)). `app.Chat` (`lucinate chat`) defers all connect / list / create work to the TUI and just packs `Connection` / `Agent` / `Session` / `Message` overrides into `RunOptions`, so a new connection type is reachable there as soon as it works in the regular TUI (see [chat-launch.md](chat-launch.md)).
+In the startup decision tree, auto-add from `OPENCLAW_GATEWAY_URL` / `LUCINATE_OPENAI_BASE_URL`
+mutates the in-memory store but does **not** persist it until a successful connect. This is
+deliberate: a typo in the env URL would otherwise accumulate ghost entries in
+`~/.lucinate/connections.json` on every launch.
 
-## Startup decision tree
+## The driver owns Close
 
-`config.ResolveEntryConnection()` (`internal/config/startup.go`) decides what the TUI's entry view is:
+In managed mode the driver, not the TUI, owns closing the backend once it's published. Picking a
+different connection mid-session publishes `nil` to the driver, which closes the active backend
+before binding to the next pick. TUI code never closes the backend itself. Keeping Close in one
+place avoids two paths racing to tear down the same connection.
 
-1. If `OPENCLAW_GATEWAY_URL` is set, find or auto-add a matching OpenClaw connection.
-2. Else if `LUCINATE_OPENAI_BASE_URL` is set, find or auto-add a matching OpenAI connection (with `LUCINATE_OPENAI_DEFAULT_MODEL` if provided).
-3. Else if a saved `defaultId` resolves to a known entry → use it (last-used = default).
-4. Else if exactly one connection is stored → auto-pick it.
-5. Else → open the connections picker.
+## Auth-modal dispatch is on `authNeed`, not interface assertion
 
-Auto-add (steps 1–2) mutates the in-memory store but does **not** persist it until a successful connect, so a typo in the env URL doesn't accumulate ghost entries.
+The connecting view (`internal/tui/connecting.go`) dispatches modal submissions on
+`connectingModel.authNeed` rather than on a Go interface assertion. The trap: the OpenClaw wrapper
+implements **both** `DeviceTokenAuth` and `APIKeyAuth`, so a naive type-switch would always pick
+the first arm and store the wrong kind of credential. See `connecting.go` `case "enter":` for the
+dispatch.
 
-`lucinate chat --connection <name>` short-circuits this tree: the named connection is resolved against the store directly (ID-then-case-insensitive-name) and a miss is a hard error rather than falling through to the env-var / default-id path. With `--connection` unset, `chat` runs the same `ResolveEntryConnection` the bare invocation does. See [chat-launch.md](chat-launch.md) for the override plumbing.
+## Hermes leaves agent management off on purpose
 
-## Connection lifecycle
+`Capabilities.AgentManagement` gates both the "new agent" and "delete agent" affordances. Hermes
+leaves it false because profiles are configured server-side via `hermes profile create` on the
+host — there's nothing for the picker to create or delete. As defence in depth `Backend.CreateAgent`
+and `Backend.DeleteAgent` both reject if ever reached, so a stray call can't half-create a profile
+the picker was never meant to touch.
 
-The TUI owns the lifecycle in managed mode (`AppOptions.Store != nil`):
+## Secrets are on disk for now
 
-- A successful connect calls `OnBackendChanged(backend)` so the app driver in `app/app.go` rewires the events pump and supervisor onto the new backend.
-- Picking a different connection mid-session (`/connections`, the picker action, or any other `showConnectionsMsg`) publishes `nil` to the driver, which closes the active backend before binding to whatever the next pick produces.
-- The driver owns Close — TUI code never closes the backend itself once it's published.
+API keys live at `~/.lucinate/secrets/secrets.json` (mode 0600). The `secretAwareOpenAIBackend`
+and `secretAwareHermesBackend` shims in `app/factory.go` wrap their concrete backends so
+`StoreAPIKey` writes through to that file during the auth-modal resolution path, letting the next
+launch reuse the key without re-prompting. The shim exists so the concrete backends stay unaware
+of on-disk storage — the write-through is bolted on at the factory rather than baked into each
+backend.
 
-Legacy mode (`AppOptions.Backend != nil`, no `Store`) is for native-platform embedders that manage the connection elsewhere; the connections picker and `/connections` are unavailable, and Close is the caller's responsibility.
+A future enhancement is to back this with the OS keychain (Keychain on macOS, libsecret on Linux,
+Credential Manager on Windows) and fall back to the JSON file when no keychain is available — kept
+on disk for now to avoid platform-specific dependencies on first run.
 
-## Capability negotiation
+## Switching presets clears the localhost prefill
 
-`backend.Backend.Capabilities()` reports a `Capabilities` struct (`internal/backend/backend.go`); the TUI type-asserts against optional sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `CronBackend`, `DeviceTokenAuth`, `APIKeyAuth`) at the relevant call sites. OpenClaw implements all of them. OpenAI implements `APIKeyAuth`, `CompactBackend` (the latter via a local summarisation pass — see [backend_openai.md](backend_openai.md#compaction)), and `StatusBackend`. Hermes implements `APIKeyAuth` and `StatusBackend`. Backend-only commands the active connection doesn't support (`/think`, `/stats`, `/crons`, `!!` on OpenAI/Hermes; `/compact` on Hermes) render a "not available on this connection" system message instead of erroring.
+The Ollama and Hermes presets pre-fill a localhost Base URL. Switching to either preset and back
+clears the prefill so the user isn't stranded with the wrong localhost URL sitting in a gateway
+field. Without the clear, a half-configured form would carry a stale value that looks plausible
+but points at the wrong backend.
 
-`/status` works on every backend, with each one populating only the sub-blocks of `BackendStatus` that apply: OpenClaw fills the gateway-health block, OpenAI fills agent-count and `history.jsonl` stats, Hermes fills the lastResponseID thread block. See the per-backend "Status payload" sections in [backend_openclaw.md](backend_openclaw.md#status-payload), [backend_openai.md](backend_openai.md#status-payload), and [backend_hermes.md](backend_hermes.md#status-payload).
+## Ollama isn't distinguishable after save
 
-The `Capabilities.AgentManagement` flag gates both the picker's "new agent" affordance and its "delete agent" affordance. OpenClaw and OpenAI opt in (the user creates and deletes agents via the picker). Hermes leaves it false because profiles are configured server-side via `hermes profile create` on the host, so both buttons are hidden on Hermes connections; `Backend.DeleteAgent` and `Backend.CreateAgent` both reject defensively if reached.
-
-## Auth-recovery modals
-
-`Connect` errors are routed into modal sub-states by the connecting view (`internal/tui/connecting.go`):
-
-- `gateway token mismatch` → device-token modal: clear / reset identity / cancel. `ClearToken` and `ResetIdentity` come from `DeviceTokenAuth`.
-- `gateway token missing` → device-token text prompt; submission stores via `DeviceTokenAuth.StoreToken`.
-- `api key required` (HTTP 401/403 from any `/v1` request) → API-key text prompt; submission stores via `APIKeyAuth.StoreAPIKey`.
-
-The submission flow dispatches on `connectingModel.authNeed` rather than on Go interface assertion: the OpenClaw wrapper implements both `DeviceTokenAuth` and `APIKeyAuth`, so a naive type-switch would always pick the first arm. See `connecting.go` `case "enter":` for the dispatch.
-
-## Secrets storage
-
-API keys live at `~/.lucinate/secrets/secrets.json` (mode 0600), keyed by connection ID. `config.GetAPIKey(connID)` and `config.SetAPIKey(connID, key)` are the public surface. `LUCINATE_OPENAI_API_KEY` falls back when no per-connection key is stored.
-
-The `secretAwareOpenAIBackend` and `secretAwareHermesBackend` shims in `app/factory.go` wrap their respective concrete backends so `StoreAPIKey` writes through to `~/.lucinate/secrets/secrets.json` during the auth-modal resolution path; the next launch reuses the key without re-prompting.
-
-A future enhancement is to back this with the OS keychain (Keychain on macOS, libsecret on Linux, Credential Manager on Windows) and fall back to the JSON file when no keychain is available — kept on disk for now to avoid platform-specific dependencies on first run.
-
-## Connections form
-
-`internal/tui/connections.go` implements the picker. The form has a fixed type radio plus type-conditional fields:
-
-| Preset   | Persisted Type | Fields                                                     |
-|----------|----------------|------------------------------------------------------------|
-| OpenClaw | `openclaw`     | Type, Name, Gateway URL                                    |
-| OpenAI   | `openai`       | Type, Name, Base URL, Default model (optional)             |
-| Ollama   | `openai`       | Type, Name, Base URL, Default model (optional)             |
-| Hermes   | `hermes`       | Type, Name, Base URL, Profile name                         |
-
-The picker offers four presets but only three persisted types — Ollama is an opinionated OpenAI preset that pre-fills `Name = ollama` and `Base URL = http://localhost:11434/v1`. Hermes is its own type with a pre-filled `Base URL = http://127.0.0.1:8642/v1` and a "Profile name" model field. Switching to either preset and back clears the prefill so the user isn't stranded with the wrong localhost URL in a gateway field.
-
-The type radio renders vertically (one preset per line) so the list reflows cleanly on narrow terminals. ↑/↓ cycles the presets when the radio is focused; Tab moves between fields. Edit forms drop the radio entirely (type is immutable post-create) and start focus on the name field. Edited connections show the persisted type as a dimmed read-only label — Ollama-created connections render as "OpenAI-compatible" on edit because the Ollama preset isn't distinguishable post-save.
-
-Delete confirmation is exposed as a sub-state with confirm/cancel pairs in `Actions()`, so native-platform embedders render them as buttons rather than relying on inline `y/n` keys.
+Ollama is an opinionated OpenAI preset — it persists type `openai`, not a distinct type. The
+consequence is that an Ollama-created connection renders as "OpenAI-compatible" when edited,
+because there's nothing on disk that marks it as having come from the Ollama preset. Not a bug,
+just a limit of treating it as a preset rather than its own persisted type.

--- a/docs/crons.md
+++ b/docs/crons.md
@@ -1,110 +1,89 @@
-# Cron jobs
+# Cron jobs — lessons and rationale
 
-The cron browser (`internal/tui/crons.go`) lets users list, inspect, run, edit, create, and delete the gateway's scheduled jobs without leaving the TUI. Cron is gateway-side scheduling, not a lucinate concept — only backends that implement `backend.CronBackend` expose the view.
+The behavioural contract for the cron browser lives in
+[`openspec/specs/crons/spec.md`](../openspec/specs/crons/spec.md) — the two entry points, the
+capability surface, the four substates, the transcript view, the form constraints, and what is
+deliberately out of scope are all captured there as requirements and scenarios. This file keeps
+the hard-won lessons, pitfalls, and design rationale behind that flow: the "why it works this
+odd way" that the spec's requirements don't dwell on.
 
-## Entry points
+## `k` is repurposed from vim-style up-navigation
 
-There are two entry points, both emitting `showCronsMsg{filterAgentID, filterLabel}`:
+The agent picker's `k: View crons` action reuses a key that the list would otherwise bind to
+vim-style up-navigation. That binding is dropped in `newSelectModel`, keeping `↑` for up. Worth
+remembering if you ever wonder why `k` doesn't move the cursor in this one list.
 
-- **From chat** — `/crons` and `/crons all`. The slash-command handler (`internal/tui/commands.go`) type-asserts the active backend against `backend.CronBackend`:
-  - Assertion fails → `"/crons is not available on this connection"` system message, no view transition (same pattern as `/compact` on Hermes).
-  - Assertion succeeds → the message is emitted. With `/crons` the filter is the chat's current agent; `/crons all` clears the filter so jobs across every agent are listed.
-- **From the agent picker** — the `k: View crons` action (`internal/tui/select.go`), gated on the same `backend.CronBackend` assertion so it only appears for OpenClaw connections. No agent is selected on the picker, so it always opens **unfiltered** (`filterAgentID: ""`, like `/crons all`). `k` is repurposed from the list's vim-style up-navigation (which is dropped in `newSelectModel`, keeping `↑`).
+## Run-now is `!`, not `R`
 
-The `AppModel` records the opening view in `cronsReturn` so `esc`/Back returns there — chat for `/crons`, the picker for the picker action (mirrors `configReturn`).
+Run-now is bound to `!` rather than the more obvious `R` because the case-sensitive pair (`R`
+run vs. `r` refresh) was a misfire trap on terminals that don't preserve shift on letter keys.
 
-## Capability surface
+A `running` flag on `cronsModel` gates duplicate keystrokes while the request is in flight — the
+detail view renders a transient `Triggering run...` banner the moment `!` fires, replaced by
+`Run triggered.` (or `Run failed: <err>`) once `cronJobRanMsg` arrives.
 
-`backend.CronBackend` (`internal/backend/backend.go`) wraps six gateway RPCs:
+## Transcript view: the run log is the source of truth
 
-| Method | Wire call | Used for |
-|---|---|---|
-| `CronsList` | `cron.list` | List substate |
-| `CronRuns` | `cron.runs` | Run history in detail substate |
-| `CronAdd` | `cron.add` | Create form submit |
-| `CronUpdate` | `cron.update` (typed) | Toggle enable / disable |
-| `CronUpdateRaw` | `cron.update` (raw map) | Edit form submit — see [Raw-patch edit semantics](#raw-patch-edit-semantics) |
-| `CronRemove` | `cron.remove` | Confirm-delete substate |
-| `CronRun` | `cron.run` (`mode=force`) | Manual run-now |
+`T` rebuilds a read-only transcript rather than doing a `chat.history` round-trip, because cron
+runs with `sessionTarget=isolated` don't persist a queryable session entry on the gateway —
+especially when the run errors before `persistSessionEntry` fires. The run log itself is the
+source of truth, and it's the same data the detail page's run-history previews already render,
+so transcript content matches what the previews promise.
 
-Capability is also reported as `Capabilities.Cron` so embedders can hide the entry up-front.
+Repeating the payload per run in the transcript is intentional — each run is an independent
+invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
 
-## Substates
+The action is gated by `hasTranscriptContent`: if no run carries a `Summary` or `Error`, the `T`
+entry is suppressed so it doesn't dangle on jobs with nothing to show.
 
-`cronsModel` is a single view with four substates:
+The transcript chat view has no input box, so `Esc` would otherwise be a no-op; the chat key
+handler emits `goBackFromCronTranscriptMsg` when `chatModel.transcript` is set, and
+`cronsModel.subset`/`selectedID` are preserved across the transcript hop so the user lands back
+on the originating detail page.
 
-| Substate | Purpose |
-|---|---|
-| `cronSubList` | Default — paginated, filtered job list |
-| `cronSubDetail` | Drill-down into a selected job + run history |
-| `cronSubForm` | Create or edit form |
-| `cronSubConfirmDelete` | y/n prompt before `CronRemove` fires |
+## Form is deliberately constrained to `cron` + `agentTurn`
 
-Each substate exposes its own discoverable actions through `Actions()`; `TriggerAction(id)` is the single dispatcher both keystrokes and embedder-issued `TriggerActionMsg`s flow through.
-
-## List substate
-
-The list view loads on `Init()` via `loadJobs()`, which calls `CronsList(Enabled: "all", SortBy: "nextRunAtMs", SortDir: "asc")`. The full slice is cached on the model so the agent-filter toggle (`a` key) can re-apply locally without a round-trip — server-side filtering is not exposed in `CronListParams`. Each row renders:
-
-- **Line 1**: bold name + dim relative-time chip (`in 8h`, `due`, `—`).
-- **Line 2**: chips for session target (`main`/`isolated`), wake mode (`now`/`heartbeat`), agent ID, and a status badge (`ok`/`error`/`disabled`/`idle`).
-
-`enter` opens detail; `r` refreshes; `n` opens the create form; `d` opens the create form pre-populated from the highlighted job (the duplicate flow — see [Duplicate flow](#duplicate-flow)); `esc` emits `goBackFromCronsMsg{}` to return to the view that opened the browser (chat, or the agent picker — see [Entry points](#entry-points)).
-
-## Detail substate
-
-`enter` on the list emits a `loadRuns(jobID)` command alongside the substate transition; `cronRunsLoadedMsg` populates the run-history table (most recent 10 entries, formatted by `formatRunLogEntry`). Rendered fields:
-
-- Schedule (cron expression + timezone, or fallback for `at`/`every` kinds)
-- Description, Agent, Model (from `payload.Model`), Session target, Wake mode
-- Delivery (always shown — `none`, `announce (channel)`, or `webhook → URL`)
-- Next run, Last run (with status), Payload body
-- Run history table
-
-Actions: `!` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open a read-only transcript reconstructed from the run log (see [Transcript view](#transcript-view)), `r` refresh, `esc` back to list.
-
-Run-now is bound to `!` rather than the more obvious `R` because the case-sensitive pair (`R` run vs. `r` refresh) was a misfire trap on terminals that don't preserve shift on letter keys. The detail view renders a transient `Triggering run...` banner the moment `!` fires, replaced by `Run triggered.` (or `Run failed: <err>`) once `cronJobRanMsg` arrives — a `running` flag on `cronsModel` gates duplicate keystrokes while the request is in flight.
-
-### Transcript view
-
-`T` emits `cronTranscriptMsg{job, runs, agentName}`; the AppModel hands it to the chat view with `hideInput=true` and pre-seeds `chatModel.messages` from `buildCronTranscriptMessages` (`internal/tui/history.go`). No `chat.history` round-trip is made — cron runs with `sessionTarget=isolated` don't persist a queryable session entry on the gateway (especially when the run errors before `persistSessionEntry` fires), so the run log itself is the source of truth. The run log is also the same data the detail page's run-history previews already render, so transcript content matches what the previews promise.
-
-The builder walks `m.runs` (newest-first as returned by `cron.runs sortDir=desc`) in reverse and emits, per run: a separator with `RunAtMs`, a user turn with the cron's `payload.Text` / `payload.Message`, and either an assistant turn with `Summary` (Glamour-rendered when it looks like markdown) or an `errMsg` assistant turn with `Error`. Repeating the payload per run is intentional — each run is an independent invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
-
-The action itself is gated by `hasTranscriptContent`: if no run carries a `Summary` or `Error`, the `T` entry is suppressed from `Actions()` so it doesn't dangle on jobs with nothing to show.
-
-The transcript chat view sets `chatModel.transcript = true`. With no input box to consume it, `Esc` would otherwise be a no-op, so the chat key handler emits `goBackFromCronTranscriptMsg` when the flag is set; `AppModel` switches state back to `viewCrons`, where `cronsModel.subset`/`selectedID` are preserved across the transcript hop, so the user lands back on the originating detail page.
-
-## Form substate
-
-The create and edit form share `cronForm` and the `cronFormField` enum (12 fields, tab-ordered). To avoid a TUI form modelling every union the gateway protocol exposes (`CronSchedule.Kind` ∈ `at`/`every`/`cron`; `CronPayload.Kind` ∈ `systemEvent`/`agentTurn`), the form is **constrained to `cron` schedules and `agentTurn` payloads**. Editing a job whose existing kind is anything else loads the form in a refused state:
+To avoid a TUI form modelling every union the gateway protocol exposes
+(`CronSchedule.Kind` ∈ `at`/`every`/`cron`; `CronPayload.Kind` ∈ `systemEvent`/`agentTurn`),
+the form is constrained to `cron` schedules and `agentTurn` payloads. Editing (or duplicating) a
+job whose existing kind is anything else loads the form in a refused state:
 
 > Edit not supported for schedule kind "every". Use the openclaw CLI.
 
-The save path is suppressed in this state — we surface the brittleness rather than silently round-trip a truncated representation.
+The save path is suppressed in this state — we surface the brittleness rather than silently
+round-trip a truncated representation. The duplicate flow refuses for the same reason, and
+shares `populateFormFromJob` with `newEditForm` so the two flows can't drift in which fields
+they carry over.
 
-Tab/Shift+Tab navigates fields. Space toggles the cycle/checkbox controls (`sessionTarget`, `wakeMode`, `deliveryMode`, `enabled`). Inside the payload `textarea`, Enter inserts a newline; Ctrl+S (or Alt+Enter) saves from anywhere; Esc cancels and returns to whichever substate opened the form.
+## Raw-patch edit semantics: why `CronUpdateRaw`
 
-### Duplicate flow
+The toggle action and the create-form submit use the typed
+`protocol.CronUpdateParams`/`CronAddParams`, but the **edit-form submit goes through
+`CronUpdateRaw(jobID, patch map[string]any)` instead**. Every string field on
+`protocol.CronJobPatch` and `CronPayload` is tagged `json:",omitempty"` — once Go marshals an
+empty value, the field is dropped from the JSON, and the gateway can't distinguish "user cleared
+this field" from "user didn't touch this field" (it keeps the prior value). The map-based path
+emits empty strings verbatim (see `buildJobPatchMap`) so clearing model, description, or
+delivery actually persists.
 
-`d` on the list substate opens the same form as `n`, but pre-populated from the highlighted job. The form stays in `mode=create` with `editingID=""`, so submission goes through `CronAdd` (not `CronUpdateRaw`) and produces a brand-new job rather than mutating the source. The name is prefixed with `Copy of ` so the duplicate is visually distinguishable in the list before the user edits it; every other field — schedule, timezone, agent, model, payload, session/wake, delivery, enabled — is copied verbatim. `populateFormFromJob` is shared with `newEditForm` so the two flows can't drift in which fields they carry over. Duplicating a job whose schedule kind is anything other than `cron` (or whose payload kind is anything other than `agentTurn`) is refused with the same banner the edit flow shows, for the same reason: the TUI form would silently truncate the unmodelled union fields.
+Toggle stays on the typed path because it only mutates a `*bool`, which doesn't have the
+omitempty problem.
 
-### Raw-patch edit semantics
+## Payload field mapping: `message` vs `text`
 
-The toggle action (`t` on detail) and the create-form submit use the typed `protocol.CronUpdateParams`/`CronAddParams`. The **edit-form submit goes through `CronUpdateRaw(jobID, patch map[string]any)` instead**, because every string field on `protocol.CronJobPatch` and `CronPayload` is tagged `json:",omitempty"` — once Go marshals an empty value, the field is dropped from the JSON, and the gateway can't distinguish "user cleared this field" from "user didn't touch this field" (it keeps the prior value). The map-based path emits empty strings verbatim (see `buildJobPatchMap`) so clearing model, description, or delivery actually persists. Toggle stays on the typed path because it only mutates a `*bool`, which doesn't have the omitempty problem.
+`protocol.CronPayload` exposes both `Text` and `Message` because the gateway's payload schema is
+a union. For `agentTurn` the prompt travels in `message` (the `agentTurn` schema declares
+`additionalProperties: false` and rejects `text`); for `systemEvent` it travels in `text`. The
+TUI form models `agentTurn` only, so `buildAddParams` and `buildJobPatchMap` populate `message`
+and never emit `text`. On the read side, `populateFormFromJob` and `cronPayloadText` prefer
+`Message` and fall back to `Text` only for historical jobs that may still carry the prompt under
+the systemEvent-style field.
 
-### Payload field mapping (`message` vs `text`)
+## Capability gating mirrors `/compact`
 
-`protocol.CronPayload` exposes both `Text` and `Message` because the gateway's payload schema is a union. For `agentTurn` the prompt travels in `message` (the `agentTurn` schema declares `additionalProperties: false` and rejects `text`); for `systemEvent` it travels in `text`. The TUI form models `agentTurn` only, so `buildAddParams` and `buildJobPatchMap` populate `message` and never emit `text`. On the read side, `populateFormFromJob` and `cronPayloadText` prefer `Message` and fall back to `Text` only for historical jobs that may still carry the prompt under the systemEvent-style field.
-
-## Confirm-delete substate
-
-`x` on detail transitions to a y/n prompt. `y` calls `CronRemove(jobID)` and refreshes the list (returning to `cronSubList`). `n` or `esc` returns to detail without action.
-
-## Out of scope
-
-- Server-side cron filtering by agent (would need `agentId` added to `CronListParams` upstream).
-- Edit support for `at`/`every` schedules and `systemEvent` payloads.
-- Pagination of run history beyond the most recent 10 entries.
-- Live updates via cron-related gateway events — there is no streaming for cron state changes today, so the user must press `r` to refresh.
-- Replaying a cron run as a live chat session — the transcript is rebuilt from the run log, not from a queryable gateway session, so it's read-only by design.
+The `/crons` slash command and the picker action are both gated on the same
+`backend.CronBackend` type assertion, so the view only surfaces for OpenClaw connections. When
+the assertion fails, `/crons` shows `"/crons is not available on this connection"` with no view
+transition — the same pattern as `/compact` on Hermes. Capability is also reported as
+`Capabilities.Cron` so embedders can hide the entry up-front rather than discovering it's
+unavailable at use time.

--- a/docs/export-and-recording.md
+++ b/docs/export-and-recording.md
@@ -1,53 +1,93 @@
-# Export and recording
+# Export and recording — lessons and rationale
 
-Two slash commands let the user persist a session's conversation to disk: `/record` for live capture and `/export` for an after-the-fact dump. The implementation lives in `internal/tui/recorder.go` and the handlers in `internal/tui/commands.go`.
+The behavioural contract for export and recording lives in
+[`openspec/specs/export-and-recording/spec.md`](../openspec/specs/export-and-recording/spec.md) —
+the transcript source, on-disk file layout, the canonical-history tap, deduplication, the
+`/record` and `/export` lifecycles, and the known limitations are all captured there as
+requirements and scenarios. This file keeps the hard-won lessons, pitfalls, and design
+rationale behind that behaviour: the "why it works this odd way" that the spec's requirements
+don't dwell on.
 
-Both commands draw from the same source: the canonical chat history the backend reports, never the streaming deltas. Streaming placeholders, the tool-activity strip, system rows (compact/reset notices, exec output, error banners) and the inline separators inserted at session resume are intentionally excluded — the transcript is meant to be the conversation as the gateway / OpenAI-compat backend would replay it, not as the TUI rendered it.
+## Why the transcript taps canonical history, not the rendered view
 
-## Files on disk
+Both commands draw from the canonical chat history the backend reports, never the streaming
+deltas. Streaming placeholders, the tool-activity strip, system rows (compact/reset notices,
+exec output, error banners) and the inline separators inserted at session resume are
+intentionally excluded — the transcript is meant to be the conversation as the gateway /
+OpenAI-compat backend would replay it, not as the TUI rendered it.
 
-Transcripts are written to `<dataDir>/transcripts/` — `~/.lucinate/transcripts/` by default, or whatever `LUCINATE_DATA_DIR` / `config.SetDataDir` resolves to (see [connections.md](connections.md) for data-dir resolution). The directory is created on demand with mode `0o700`; individual files are mode `0o600`.
+The canonical view arrives through two `tea.Msg` types produced by `fetchHistory`:
+`historyLoadedMsg` on chat-view entry, and `historyRefreshMsg`, the server-canonical resync
+issued from the chat-event `final`/`error`/`aborted` handlers. The subtle bit is the refresh:
+`mergeHistoryRefresh` keeps the live tail intact for display, but the `messages` slice on the
+message itself is the authoritative gateway view up to that point — that slice, not the merged
+display state, is what gets recorded.
 
-Filenames follow `<kind>-<agent>-<session>-<UTCtimestamp>.md`, where `kind` is `record` or `export`. Agent and session names are passed through `sanitiseForPath`, which collapses anything outside `[A-Za-z0-9_-]` to `-` and trims separators — so `main session` becomes `main-session`, `Agent Name` becomes `Agent-Name`. The timestamp resolves to the second (`20060102T150405`); two recordings started inside the same second to the same session would collide and the second would truncate the first, which is fine in practice and avoided by `/record on` opening with `O_CREATE|O_TRUNC`.
+## Why dedup is needed, and the `role|ts|hex` scheme
 
-The body is plain Markdown: a header listing connection / agent / model / session / timestamp, a `---` divider, then one `## User` or `## Assistant` block per turn. When a per-message `timestampMs` is reported by the backend it's appended to the heading as ` · <RFC3339>`. Assistant messages preserve any thinking content as a leading `> _thinking_` blockquote so the file is self-contained even when the chat view collapses thinking.
+Each canonical refresh delivers the *entire* history (capped by `historyLimit`), so every row
+arrives repeatedly. Without dedup the transcript would gain a fresh copy of the whole
+conversation on every turn. `recorder.seenSig` guards against this, keyed by
+`messageSignature(role, timestampMs, sourceText)`.
 
-## Canonical-history tap
+Two non-obvious choices are baked in:
 
-The chat view receives canonical messages through two `tea.Msg` types, both produced by `fetchHistory` in `internal/tui/history.go`:
+- `sourceText` is `chatMessage.raw` when the row was glamour-rendered and `chatMessage.content`
+  otherwise. Preferring the markdown source guarantees the dedup key matches the bytes that get
+  written, and avoids ANSI-rendered assistant turns leaking escape codes into the transcript.
+- The hash is FNV-64a, formatted as `role|ts|hex` rather than a bare content hash. This makes a
+  user/assistant collision on identical content impossible, and lets a repeated user message at
+  a later timestamp still be recorded.
 
-- `historyLoadedMsg` — initial fetch on chat-view entry.
-- `historyRefreshMsg` — server-canonical resync issued from the chat-event `final`/`error`/`aborted` handlers in `internal/tui/events.go`. The merge boundary keeps the live tail intact (see `mergeHistoryRefresh` in `chat.go`) but the `messages` slice on the message itself is the authoritative gateway view of the conversation up to that point.
+The signature set lives only for the lifetime of one recording. A new `/record on` starts with
+an empty set and reseeds the file from scratch — see below.
 
-Both arms call `chatModel.recordCanonical(msg.messages)` after consuming the message. When `chatModel.recorder` is `nil` (recording is off) this is a no-op; otherwise the slice is forwarded to `recorder.writeNew`, which iterates and writes any rows it hasn't seen before.
+## Why `/record on` opens with `O_TRUNC`
 
-## Dedup signature
+The underlying `os.OpenFile` uses `O_CREATE|O_TRUNC`, so a new recording reseeds the file from
+scratch rather than appending. This is deliberate: the empty signature set and a truncated file
+have to agree, or a re-recording would re-dedup against rows it never actually wrote. Truncation
+also neatly handles the same-second filename collision — two recordings started inside the same
+UTC second to the same session collide, and the second truncates the first, which is fine in
+practice.
 
-Each canonical refresh delivers the entire history (capped by `historyLimit`), so every row arrives repeatedly. `recorder.seenSig` is a `map[string]bool` keyed by `messageSignature(role, timestampMs, sourceText)`, where `sourceText` is `chatMessage.raw` when the row was glamour-rendered and `chatMessage.content` otherwise — preferring the markdown source guarantees the dedup key matches the bytes that get written, and avoids ANSI-rendered assistant turns leaking escape codes into the transcript. The hash is FNV-64a, formatted alongside role and timestamp as `role|ts|hex` so a user/assistant collision on identical content is impossible and a repeated user message at a later timestamp is recorded.
+## Why `/record on` captures already-loaded history immediately
 
-The signature set lives only for the lifetime of one recording. A new `/record on` starts with an empty set and reseeds the file from scratch (the underlying `os.OpenFile` uses `O_TRUNC`).
+`/record on` calls `recordCanonical(m.messages)` right after attaching the recorder, so any
+history already in the chat view is captured before the next refresh. It deliberately does *not*
+re-fetch from the gateway here — the assumption is that `m.messages` already reflects the most
+recent canonical state, because `historyLoadedMsg` and every `historyRefreshMsg` have already
+passed through.
 
-## Lifecycle
+## Why all four teardown sites must stop recording
 
-`/record on` opens the file, writes the header, attaches a `*transcriptRecorder` to `chatModel`, then immediately calls `recordCanonical(m.messages)` so any history already loaded into the chat view is captured before the next refresh. The chat view does not re-fetch from the gateway at this point — the assumption is that `m.messages` reflects the most recent canonical state, since `historyLoadedMsg` and every `historyRefreshMsg` have already passed through.
+The chat model's teardown sites in `app.go` — `sessionSelectedMsg`, `cronTranscriptMsg`,
+`newSessionCreatedMsg`, `sessionCreatedMsg` — each call `stopRecording` before the field is
+reassigned. If any one of them missed it, a recording would silently outlive its session and
+keep writing another session's turns into the old file. Recording does **not** resume on the new
+chat; the user has to opt in again.
 
-`/record off` and `chatModel.stopRecording()` close the writer and clear the field. The chat model's teardown sites in `app.go` — `sessionSelectedMsg`, `cronTranscriptMsg`, `newSessionCreatedMsg`, `sessionCreatedMsg` — call `stopRecording` before the field is reassigned, so a recording does not silently outlive its session. Recording does **not** resume on the new chat; the user has to opt in again.
+## Why a write failure stops recording rather than retrying
 
-A write failure on `recordCanonical` (disk full, broken permissions, file removed under us) closes the recorder and surfaces a one-shot system error in the chat view. Subsequent canonical refreshes are no-ops because the field has been cleared — the alternative was repeated error rows on every turn, which would be more annoying than informative.
-
-## /export
-
-`exportTranscript` in `commands.go` is the synchronous one-shot path. It opens a fresh `export-...md` file, writes the same header (with `kind = "export"`), and walks the supplied `[]chatMessage` slice — typically `m.messages` — applying the same role and content filters as the recorder. Streaming rows are skipped explicitly (so an export issued mid-turn doesn't capture a half-typed assistant message); empty content is skipped; `raw` wins over `content` for rendered turns. The function returns the resolved path so the chat view can surface it.
-
-`/export routine` doesn't write a file. `extractUserPromptsForRoutine` walks `m.messages` for non-empty user rows (preferring `raw` over `content`) and the handler dispatches `showRoutinesMsg{prefillSteps: …}`. `app.go`'s `showRoutinesMsg` arm constructs the routines model, calls `routinesModel.openCreateFormWithSteps(steps)` to skip the list and drop straight into the create form, and pre-populates one step per prompt. The user fills in the name and mode, then saves through the normal routines flow (see [routines.md](routines.md)). An empty session reports a no-op error rather than opening an empty form.
+A write failure on `recordCanonical` (disk full, broken permissions, file removed under us)
+closes the recorder and surfaces a one-shot system error. Because the field is then cleared,
+subsequent canonical refreshes are no-ops — the alternative was repeated error rows on every
+turn, which would be more annoying than informative.
 
 ## Limitations
 
-- **Backend-agnostic but content-limited.** Both backends expose canonical history through the same `Backend.ChatHistory` RPC, so the recorder works against OpenClaw and OpenAI-compat alike. The OpenClaw gateway, however, does not expose tool call payloads in its history view — only the user/assistant turns survive the round-trip — so even if we wanted to surface tool I/O in the transcript today we couldn't pull it from the canonical fetch. Tool-card capture would need a separate event-side tee.
-- **No live tail capture.** Streaming deltas are intentionally excluded. A recording started mid-turn captures the assistant reply only after `final` lands and the refresh fires.
-- **History limit.** `historyLimit` (a chat-view preference, see [chat-ux.md](chat-ux.md#history-depth)) caps the canonical fetch. For very long sessions, older turns may have already fallen off the window when `/record on` runs — the recorder only sees what `fetchHistory` returns. `/export` has the same constraint.
-- **Filename collisions.** Two recordings started inside the same UTC second to the same session truncate the first. Practically impossible for `/record`, plausible only for tight scripted `/export` loops.
-
-## Tests
-
-`internal/tui/recorder_test.go` covers the header layout, dedup across refreshes, role/streaming filters, raw-vs-rendered fidelity, the export round-trip, routine extraction, path sanitisation, filename shape, and signature distinctness. The tests use `config.SetDataDir(t.TempDir())` so they don't touch the user's real `~/.lucinate`.
+- **Backend-agnostic but content-limited.** Both backends expose canonical history through the
+  same `Backend.ChatHistory` RPC, so the recorder works against OpenClaw and OpenAI-compat
+  alike. The OpenClaw gateway, however, does not expose tool call payloads in its history view —
+  only the user/assistant turns survive the round-trip — so even if we wanted to surface tool
+  I/O in the transcript today we couldn't pull it from the canonical fetch. Tool-card capture
+  would need a separate event-side tee.
+- **No live tail capture.** Streaming deltas are intentionally excluded. A recording started
+  mid-turn captures the assistant reply only after `final` lands and the refresh fires.
+- **History limit.** `historyLimit` (a chat-view preference, see the `chat-ux` spec) caps the
+  canonical fetch. For very long sessions, older turns may have already fallen off the window
+  when `/record on` runs — the recorder only sees what `fetchHistory` returns. `/export` has the
+  same constraint.
+- **Filename collisions.** Two recordings started inside the same UTC second to the same session
+  truncate the first. Practically impossible for `/record`, plausible only for tight scripted
+  `/export` loops.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,48 +1,48 @@
-# Logging
+# Logging — lessons and rationale
 
-`internal/logging` configures the process-wide `slog.Default` logger from three environment variables and one runtime hint (`Options.TUI`). Every other package logs through `log/slog` against the default logger; nothing in the codebase calls `log.Print*` directly.
-
-The user-facing summary lives in the [README → Environment variables](../README.md#environment-variables). This doc covers the design, the destination-resolution rule, and the TUI-safety constraints that drove the defaults.
+The behavioural contract for logging lives in
+[`openspec/specs/logging/spec.md`](../openspec/specs/logging/spec.md) — the destination-resolution
+rule, level parsing, the environment variables, and the TUI-safety constraints are all captured
+there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls, and design
+rationale behind that configuration: the "why it works this odd way" that the spec's requirements
+don't dwell on.
 
 ## Why a side file by default
 
-The TUI owns the terminal. Anything written to stdout or stderr while a frame is being rendered will corrupt it — the cursor lands inside half-drawn ANSI sequences and the next repaint inherits the garbage. The pre-slog code worked around this by hardcoding a debug file (`/tmp/lucinate-events.log`) inside an `init()` hook in `internal/tui/logging.go`; the file was opened on every start regardless of whether anyone wanted to read it, and there was no concept of severity.
+The TUI owns the terminal. Anything written to stdout or stderr while a frame is being rendered
+will corrupt it — the cursor lands inside half-drawn ANSI sequences and the next repaint inherits
+the garbage. The pre-slog code worked around this by hardcoding a debug file
+(`/tmp/lucinate-events.log`) inside an `init()` hook in `internal/tui/logging.go`; the file was
+opened on every start regardless of whether anyone wanted to read it, and there was no concept of
+severity. `internal/logging` keeps the side-file default for TUI invocations but gates everything
+behind a level and a configurable destination.
 
-`internal/logging` keeps the side-file default for TUI invocations but gates everything behind a level and a configurable destination, so the same `slog.Warn` call can:
+## Why truncate on start
 
-- land in `<os-tempdir>/lucinate-events.log` during a TUI session (resolved via `os.TempDir()` so the path is sensible on every platform),
-- stream to stderr during `lucinate send` so the operator sees it inline,
-- or land in a JSON file the user pointed at, for piping into `jq`.
+Truncate-on-start matches the pre-slog behaviour and keeps the file scoped to the current session —
+handy when you're tailing it while reproducing a bug. If you want to keep history across runs, point
+`LUCINATE_LOG_FILE` at a path you'll archive yourself.
 
-Below the configured level, calls are dropped by the slog handler before they reach the writer.
+## Why the default level is `warn`
 
-The handler is plain `slog.NewTextHandler` / `slog.NewJSONHandler` — no custom formatter, no third-party dependency.
+The default of `warn` means a bare `lucinate` run produces no log noise at all unless something
+genuinely worth flagging happens. That preserves the previous "silent unless you opted into the
+debug file" behaviour while still giving the operator a knob to turn up.
 
-## Destination resolution
+## Why unrecognised levels fall back silently
 
-`openDestination` (`internal/logging/logging.go`) implements the rule:
+Anything unrecognised falls back to `warn` silently — we don't want a typo in a user's shell rc to
+fail the launch.
 
-| `LUCINATE_LOG_FILE` set | `Options.TUI` | Destination |
-|---|---|---|
-| yes | either | the named file, opened `O_TRUNC` (current session only) |
-| no  | true   | `DefaultTUIFile()` (`<os.TempDir()>/lucinate-events.log`), opened `O_TRUNC` |
-| no  | false  | `os.Stderr` |
+## Why TUI detection lives in `cli.Run`
 
-Truncate-on-start matches the pre-slog behaviour and keeps the file scoped to the current session — handy when you're tailing it while reproducing a bug. If you want to keep history across runs, point `LUCINATE_LOG_FILE` at a path you'll archive yourself.
+`Options.TUI` is set by `cli.Run` based on `isTUIInvocation(args)`. That subcommand-specific routing
+lives in `cli.Run` deliberately — moving it into `app.Run` would mean every embedder has to
+re-implement the same TUI / non-TUI distinction.
 
-`Options.TUI` is set by `cli.Run` based on `isTUIInvocation(args)`: empty args (bare `lucinate`) and `lucinate chat` are TUI; everything else (`send`, `help`, `--version`, unknown subcommands) is non-TUI. Subcommand-specific routing lives in `cli.Run` deliberately — moving it into `app.Run` would mean every embedder has to re-implement the same TUI / non-TUI distinction.
+## The `closeForTest` re-truncation gotcha
 
-## Levels
-
-Standard `log/slog` levels: `debug`, `info`, `warn` (the default), `error`. Parsing is case-insensitive and tolerant of `warning` for warn. Anything unrecognised falls back to `warn` silently — we don't want a typo in a user's shell rc to fail the launch.
-
-The default of `warn` means a bare `lucinate` run produces no log noise at all unless something genuinely worth flagging happens. That preserves the previous "silent unless you opted into the debug file" behaviour while still giving the operator a knob to turn up.
-
-TUI lifecycle call sites in `internal/tui/{events,sessions,chat,commands}.go` use `slog.Debug` directly with `key, value` attrs. Earlier revisions kept a `logEvent(format, args...)` shim around the printf-style calls; that shim is gone and new code should follow the same pattern.
-
-## Re-init and tests
-
-`Init` is idempotent: a second call closes the previously opened file (if any) and installs a fresh handler. The package keeps the open file handle in `currentFile` so a re-init doesn't leak a fd. Tests use `closeForTest` to flush and close without re-init (which would re-truncate the file mid-test).
-
-Outside tests, nothing currently re-inits — `cli.Run` calls `Init` once at the top of the dispatch and the rest of the process inherits `slog.Default`.
-
+`Init` is idempotent: a second call closes the previously opened file and installs a fresh handler,
+so a re-init doesn't leak the fd tracked in `currentFile`. But re-init also re-truncates the file.
+Tests therefore use `closeForTest` to flush and close without re-init — a re-init mid-test would wipe
+the file you're asserting against.

--- a/docs/message-rendering.md
+++ b/docs/message-rendering.md
@@ -1,83 +1,67 @@
-# Message rendering
+# Message rendering — lessons and rationale
 
-## Message roles
+The behavioural contract for message rendering lives in
+[`openspec/specs/message-rendering/spec.md`](../openspec/specs/message-rendering/spec.md) — the
+message roles and their display, injected-content hiding, conditional markdown rendering, the
+tool-activity strip, the streaming placeholder, and the queued-message footer are all captured
+there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls, and design
+rationale behind that contract: the "why it works this odd way" that the spec's requirements
+don't dwell on.
 
-Each chat message has a role that determines how it is displayed in the TUI:
+## Why injected content must be hidden from restored history
 
-- `user` — sent by the local user; shown right-aligned.
-- `assistant` — returned by the agent; rendered as markdown via Glamour.
-- `system` — local-only notices (errors, status, command output); shown in a muted style and never sent to the gateway.
-- `separator` — a dim divider row inserted between restored history and a new turn; labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`). The `timestampMs` field on `chatMessage` carries the unix-ms used by `formatSeparatorLabel`.
+Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but
+must not be shown in the local chat history when it is loaded back. If it isn't stripped on
+reload, the skill catalog and skill envelopes reappear as raw noise in the transcript. Two
+complementary conventions keep them out, and both strippers are applied to user messages on
+history reload.
 
-Tool calls are **not** message rows. They are tracked separately and rendered in an ephemeral strip above the input — see [Tool activity strip](#tool-activity-strip).
-
-## Hiding injected content from history
-
-Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but must not be shown in the local chat history when it is loaded back. Lucinate uses two complementary conventions for this.
-
-### System: line prefix
-
-Each line of the block is prefixed with `System: ` (or `System (<qualifier>): ` for gateway-rewritten variants like `System (untrusted):`). `prefixAllLines()` in `internal/tui/skills.go` applies the prefix; `stripSystemLines()` in `internal/tui/history.go` removes matching lines on history reload, and `isSystemLine()` recognises both forms.
-
-This convention is used for the **skill catalog** prepended to the first user message of each session — see [skills.md](skills.md) and [backend_openclaw.md](backend_openclaw.md).
+The **`System:` line prefix** is used for the skill catalog prepended to the first user message of
+each session. Each line carries `System: ` so `stripSystemLines()` can match and remove it:
 
 ```
 System: Available agent skills (activate with /skill-name):
 System:   - review: Perform a code review
 ```
 
-### `<local-agent-skill>` envelope
+The `System (<qualifier>): ` form (e.g. `System (untrusted):`) exists for gateway-rewritten
+variants — the gateway re-labels injected content it doesn't fully trust, and `isSystemLine()`
+has to recognise both forms or the qualified lines leak through on reload.
 
-When the user invokes a skill (`/review` alone or `use /review on x`), `expandSkillReferences()` in `internal/tui/skills.go` produces a payload prefixed with `Please use the following skill(s):` followed by one or more `<local-agent-skill name="…">…</local-agent-skill>` blocks. `stripLocalAgentSkillBlocks()` in `internal/tui/history.go` elides the preamble line and every block (inclusive) on history reload. See [skills.md](skills.md#activation) for the full payload shape and substitution rules.
+The **`<local-agent-skill>` envelope** covers explicit skill invocations. `stripLocalAgentSkillBlocks()`
+elides the `Please use the following skill(s):` preamble and every block inclusive; the preamble
+line matters because without it the orphaned lead-in would survive the block strip.
 
-Both strippers are applied to user messages on history reload.
+## Markdown-detection heuristic and the box-drawing wrap gotcha
 
-## Markdown rendering
+Assistant messages are only rendered through Glamour when `looksLikeMarkdown()` finds markdown
+signals (code fences, bold markers, pipe tables, list prefixes, headings, numbered lists). The
+point of the heuristic is to avoid Glamour's unwanted paragraph indentation on short plain
+replies — running everything through the renderer looks wrong for a one-line answer.
 
-Assistant messages are conditionally rendered with Glamour. `looksLikeMarkdown()` in `internal/tui/history.go` checks for code fences, bold markers, pipe tables, list prefixes, headings, and numbered lists. If none are found the text is shown as plain text, avoiding unwanted paragraph indentation on short replies.
+The Glamour renderer is created with a wrap width of the terminal width **minus 4**, and
+`wordWrap()` in `render.go` runs afterwards. The gotcha: `wordWrap()` must preserve lines
+containing box-drawing characters (table borders), otherwise it splits table borders mid-row and
+the rendered table falls apart.
 
-The Glamour renderer is created in `setSize()` with a wrap width equal to the terminal width minus 4. `wordWrap()` in `render.go` is applied after rendering and preserves lines containing box-drawing characters (table borders) so they are not split.
+## Why tool calls stay off the message list (the delta-accumulation bug)
 
-## Tool activity strip
+Tool calls are deliberately kept **off** the message list (`chatModel.activeTools`) and shown in
+the ephemeral strip instead. An earlier design appended a `role: "tool"` message per call, which
+froze the streaming assistant row so each subsequent tool split the reply onto a fresh row.
+Because the gateway streams the whole turn's text *cumulatively* (every delta carries all text so
+far), that split made each post-tool row re-render everything before it — the "delta accumulation
+/ repeated content" bug. Keeping tools out of the message list leaves the streaming assistant row
+intact, so the whole turn lands on one row and the cumulative full-replace is correct.
 
-When the agent invokes a tool, lucinate shows it in an ephemeral **activity strip** rendered directly above the input, not inline in the scrollback. The strip is driven by `agent` events with `stream == "tool"` from the gateway — declared via the `tool-events` capability on connect (see `internal/client/client.go`).
+The strip is also cleared on error/aborted, not just at the start of a turn, so a tool left
+mid-run can't strand a spinning glyph.
 
-Tool calls are deliberately kept **off** the message list (`chatModel.activeTools`, a `[]toolActivity`). An earlier design appended a `role: "tool"` message per call, which froze the streaming assistant row so each subsequent tool split the reply onto a fresh row. Because the gateway streams the whole turn's text *cumulatively* (every delta carries all text so far), that split made each post-tool row re-render everything before it — the "delta accumulation / repeated content" bug. Keeping tools out of the message list leaves the streaming assistant row intact, so the whole turn lands on one row and the cumulative full-replace is correct.
+## Why `summariseArgs` truncates to 80 runes
 
-While a turn is in flight (or any tool is still running), the strip lists each tool on its own line — a state glyph, the tool name, and a one-line argument summary:
-
-```
-✓ search (query="hello world")
-⠋ read (path="/big/file")
-```
-
-The running glyph cycles through the same braille spinner as the streaming cursor (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`), then flips to `✓` on success or `✖` on error (errors append a one-line message extracted from the tool result). When more than `maxToolStripRows` tools have run, the oldest fold into a leading `…N earlier` line so the newest stay visible.
-
-Once the turn is idle and every tool has resolved, the strip collapses to a single summary line grouping calls by name, which persists until the next turn begins:
-
-```
-✓ called search ×3, read ×2
-✖ called fetch ×2 (1 failed)
-```
-
-The mapping from event payload to strip lives in `handleAgentEvent` (`internal/tui/events.go`):
-
-- `phase: "start"` — appends a `toolActivity{state: "running"}`. The streaming assistant row is left untouched.
-- `phase: "update"` — currently a no-op. Partial result streaming is deferred (see issue for expand/collapse output).
-- `phase: "result"` — finds the matching entry by `callID` and flips its state to `"success"` or `"error"`.
-
-The strip is cleared at the start of each turn (`resetToolActivity`), and on error/aborted so a tool left mid-run can't strand a spinning glyph. Its rendered height is subtracted from the viewport in `applyLayout` (via `toolStripHeight`), the same way the completion menu and notification rows reserve space.
-
-The `summariseArgs` helper picks a human-readable key from the args object (priority order: `command`, `path`, `file`, `filePath`, `query`, `url`, `name`, `message`, `text`) or falls back to compact JSON, truncated to 80 runes.
-
-The full output of a tool call is not currently rendered; only the header line is. An expand/collapse affordance similar to the official OpenClaw TUI's Ctrl+O is tracked separately.
-
-## Streaming placeholder
-
-When the user sends a message, an empty assistant message with `streaming: true` is appended immediately so there is always something to animate (see [chat-ux.md](chat-ux.md#streaming-animation)). As delta events arrive, the message content is built up incrementally. If the final event arrives before any delta (e.g. an error), the placeholder message is removed from the display.
-
-The same spinner glyph also decorates *pending system rows* — `chatMessage.pending` flags a system message as in-flight, and the renderer appends the current spinner frame after the body. `/compact` and `/reset` use this to give visible feedback while their actions run; the result handler clears `pending` (or replaces the row entirely) once the outcome lands.
-
-## Queued-message footer
-
-Messages the user submits while a turn is streaming are held in `chatModel.pendingMessages` and rendered by `renderPendingMessages` as dim/italic `You:` shadows in a fixed footer **below** the tool-activity strip — not in the scrollable transcript. This keeps the reading order intuitive: transcript (what happened) → tool strip (what's running) → queued shadows (what's next). Only an error notification sits lower, between the queue and the input; see [chat-ux.md → View region order](chat-ux.md#view-region-order) for the full top-to-bottom layout. The footer's height is reserved in `applyLayout` via `pendingHeight`, and `applyLayout` is re-run wherever the queue changes (enqueue, `drainQueue`, up-arrow recall, cancel) so the viewport reclaims the rows as the queue drains. Each queued message is dispatched in FIFO order by `drainQueue` once the in-flight turn finalises.
+`summariseArgs` picks a human-readable key from the args object (priority order: `command`,
+`path`, `file`, `filePath`, `query`, `url`, `name`, `message`, `text`) or falls back to compact
+JSON. It truncates to 80 runes because the summary is a single line in the strip: an untruncated
+`command` or JSON blob would blow past the terminal width and wreck the strip layout. The full
+tool output isn't rendered at all yet — only the header line — with an expand/collapse affordance
+(like the official OpenClaw TUI's Ctrl+O) tracked separately.

--- a/docs/one-shot.md
+++ b/docs/one-shot.md
@@ -1,95 +1,96 @@
-# One-shot mode
+# One-shot mode — lessons and rationale
 
-`lucinate send` is a non-TUI entry point that dispatches a single chat turn through a stored connection / agent / session and (by default) prints the assistant's first complete reply to stdout. It is the scripting surface alongside the interactive TUI, and it deliberately reuses the TUI's connection store, backend factory, and event channel so retry / auth / capability behaviour stays consistent across both modes.
+The behavioural contract for one-shot mode lives in
+[`openspec/specs/one-shot/spec.md`](../openspec/specs/one-shot/spec.md) — the `app.Send`
+lifecycle, the default-session rule, detach semantics, the `ask` alias, the embedder seam,
+reply-text extraction, and the deliberate non-goals are all captured there as requirements and
+scenarios. This file keeps the hard-won lessons, pitfalls, and design rationale behind that
+flow: the "why it works this odd way" that the spec's requirements don't dwell on.
 
-The user-facing CLI shape is documented in [README.md](../README.md#one-shot-mode). This doc covers the lifecycle, the wire-format edges, and the seams that exist for embedders.
+## Why one-shot deliberately reuses the TUI's seams
 
-## Lifecycle
+`lucinate send` reuses the TUI's connection store, backend factory, and event channel on
+purpose, so retry / auth / capability behaviour stays consistent across both modes. When you
+touch one path, keep the other in mind — the value of the shared seams is that they don't drift.
 
-`app.Send` (`app/send.go`) runs an eight-step pipeline:
+## No supervision for one-shot turns
 
-1. **Resolve the connection.** `LoadConnections()` from `internal/config`, then `resolveSendConnection` matches the user-supplied `--connection` first by ID and then case-insensitively by `Name`. A missing connection is a clean error — the resolver does not fall through to the entry-view decision tree (`config.ResolveEntryConnection`), which is TUI-only.
-2. **Build the backend.** `DefaultBackendFactory` (`app/factory.go`) dispatches by `Connection.Type` — same factory the TUI uses, same auth wiring (per-connection secrets store, env-var fallback for OpenAI, etc.).
-3. **Connect.** `backend.Backend.Connect`. A failure tears the backend back down before returning. There is no auth-recovery modal in this mode; an auth error surfaces as a normal error and the process exits non-zero.
-4. **Mark the connection as last-used.** Mirrors the TUI's "last used = default" pattern via `Connections.MarkUsed` + `config.SaveConnections` so the next launch (TUI or `send`) picks the same connection by default.
-5. **List agents and resolve the agent.** `ListAgents`, then `resolveSendAgent` matches first by ID and then by case-insensitive `Name`.
-6. **Default the session key.** `defaultSessionKey` mirrors the TUI's pick in `internal/tui/select.go`: `AgentsListResult.MainKey` when the chosen agent is the default agent (`agent.ID == list.DefaultID`), otherwise the literal string `"main"`. An explicit `--session` flag short-circuits this.
-7. **Create or resume the session.** `CreateSession` round-trips through the backend; the canonical key it returns is what `ChatSend` uses. OpenClaw asks the gateway; OpenAI-compat returns `agentID` (agent ≡ session); Hermes returns the synthetic agent ID.
-8. **Subscribe before send, then dispatch.** A `replyCollector` goroutine starts draining `backend.Events()` *before* `ChatSend` is called so the final event cannot race past the consumer. `ChatSend` returns its RPC ack containing the run ID; the collector is told the run ID after the ack lands so events from concurrent turns on the same session are filtered out.
+`Send` does not run `Backend.Supervise`. A one-shot turn is short-lived enough that
+auto-reconnect is dead weight; a dropped socket surfaces as a clean failure ("backend event
+channel closed before reply") rather than triggering exponential backoff. The TUI's
+`app.Program` keeps Supervise — the lifetimes are different.
 
-Detach mode skips step 8's wait: after `ChatSend` returns, `Send` returns nil regardless of subsequent events.
+## The race-before-send gotcha
 
-`Send` does not run `Backend.Supervise`. A one-shot turn is short-lived enough that auto-reconnect is dead weight; a dropped socket surfaces as a clean failure ("backend event channel closed before reply") rather than triggering exponential backoff. The TUI's `app.Program` keeps Supervise — the lifetimes are different.
+The `replyCollector` goroutine starts draining `backend.Events()` *before* `ChatSend` is called
+so the final event cannot race past the consumer. Then, because events from concurrent turns on
+the same session share the channel, the collector is told the run ID only *after* the `ChatSend`
+ack lands, so those other turns' events are filtered out. Subscribe-first-then-filter is the
+order that matters here; flipping it reintroduces the race.
 
-## Default session selection
+## Why detach is not guaranteed to deliver a reply
 
-The default-key rule is shared with the TUI agent picker so `lucinate send` and "select agent → main" land on the same gateway-side session:
+`--detach` returns as soon as `ChatSend` resolves its RPC ack. That does guarantee validation
+errors surface synchronously and that the gateway has accepted the turn and assigned a run ID.
+It does **not** guarantee that the assistant will reply, or that a reply — if it arrives — ever
+reaches stdout: the run continues server-side, and the streaming events are consumed nowhere in
+detach mode. The reply is rendered the next time the user opens the TUI on that session, just as
+if a previous TUI window had been closed mid-turn.
 
-| Agent | `--session` unset → key passed to `CreateSession` |
-|-------|---------------------------------------------------|
-| Default agent (`agent.ID == list.DefaultID`) | `list.MainKey` |
-| Any other agent                              | `"main"` (literal)                                |
+That is by design. Detach is intended for cron-style automation ("nudge the agent at 09:00 to
+draft the morning digest, render the result on my next browse") and for fire-and-forget
+shell-pipeline steps that don't care about the response text.
 
-If the same key already exists on the gateway, `CreateSession` resumes it; if not, the gateway provisions one. From the script's point of view, `lucinate send --connection X --agent Y "hello"` repeats into the same conversation forever unless `--session` is supplied.
+## The `ask` alias is not a second code path
 
-The literal-`"main"` fallback for non-default agents matches what the TUI passes when the user picks a non-default agent and accepts the picker's "main" session. Backends that don't keep server-side session state (OpenAI, Hermes) ignore the key shape and route by `agentID` regardless.
+`lucinate ask` is a thin wrapper over the same `app.Send` pipeline — there is no second code
+path. The only real difference is where the flags' default values come from (saved
+`AskDefaults`) and that it returns an `ask:`-prefixed error pointing at
+`/settings ▸ Ask command defaults` for a blank connection or agent, rather than letting
+`app.Send`'s `send:`-prefixed "required" error surface for what is, in `ask`'s world, a
+configuration gap.
 
-## Detach semantics
+The `KEEP IN SYNC` reasoning: `config.AskDefaults` has one field per `send` flag, and three
+files carry mutual `KEEP IN SYNC` comments (`internal/cli/send.go`, `internal/cli/ask.go`,
+`internal/config/preferences.go`). A new field added to `send` should gain an `AskDefaults`
+field and a row in the TUI sub-screen so `ask` stays a *complete* alias — miss any of the three
+and the alias quietly falls behind `send`.
 
-`--detach` returns as soon as `ChatSend` resolves its RPC ack. That guarantees:
+## Why the wire-format parser is a single seam
 
-- Validation errors surface synchronously: missing flag, no such agent, no such connection, wire-level rejection (auth, idempotency conflict, malformed input).
-- The gateway has accepted the turn and assigned a run ID.
+The shared parser at `internal/backend/chatevent.go` is deliberately the single place that
+knows the two shapes a chat event's `Message` can take (a plain JSON string delta, or a
+`{ content: [{type, text}, ...] }` final object). Both the TUI's chat view
+(`internal/tui/events.go`) and `send`'s `replyCollector` call `ExtractChatText` so they agree on
+what the visible body is. If a backend ever changes the wire shape, both consumers update
+together — that's the whole point of keeping it one seam rather than two parsers that can drift.
 
-It does **not** guarantee:
+`Send` ignores `ExtractChatThinking` blocks because the contract for
+`--connection X --agent Y "msg"` is "the assistant's reply on stdout", not the deliberation that
+led to it.
 
-- That the assistant will reply.
-- That a reply, if it arrives, ever reaches stdout — the run continues server-side, and the streaming events are consumed nowhere in detach mode. The reply is rendered the next time the user opens the TUI on that session, just as if a previous TUI window had been closed mid-turn.
+## Why the default-session rule is shared with the picker
 
-Detach is intended for cron-style automation ("nudge the agent at 09:00 to draft the morning digest, render the result on my next browse") and for fire-and-forget shell-pipeline steps that don't care about the response text.
+The default-key rule is shared with the TUI agent picker (`internal/tui/select.go`) so
+`lucinate send` and "select agent → main" land on the same gateway-side session. The
+consequence worth knowing: `lucinate send --connection X --agent Y "hello"` repeats into the
+same conversation forever unless `--session` is supplied — `CreateSession` resumes the existing
+key if it's there and provisions one otherwise.
 
-## The `ask` alias
+The literal-`"main"` fallback for non-default agents exists to match what the TUI passes when
+the user picks a non-default agent and accepts the picker's "main" session. Backends that keep
+no server-side session state (OpenAI, Hermes) ignore the key shape and route by `agentID`
+regardless — the shared rule costs them nothing.
 
-`lucinate ask` (`internal/cli/ask.go`) is a thin wrapper over the same `app.Send` pipeline — there is no second code path. The only difference from `send` is where the flags' default values come from:
+## Non-goals, and why
 
-- `runAsk` loads `config.LoadPreferences().Ask` (a `config.AskDefaults` block in `config.json`) and seeds the `ask` flag set's defaults with it. An omitted `-c`/`-a`/`-s`/`-d` falls back to the saved value; an explicit flag still overrides it, because `flag` parsing runs after the defaults are set.
-- After parsing, `runAsk` guards on a blank connection or agent and returns an `ask:`-prefixed error pointing the user at `/settings ▸ Ask command defaults`, rather than letting `app.Send`'s `send:`-prefixed "required" error surface for what is, in `ask`'s world, a configuration gap.
-- Everything else — message join, `--`/dash handling, the `app.Send` dispatch — is identical to `runSend`.
-
-`config.AskDefaults` has one field per `send` flag (`Connection`, `Agent`, `Session`, `Detach`). The three files carry mutual `KEEP IN SYNC` comments (`internal/cli/send.go`, `internal/cli/ask.go`, `internal/config/preferences.go`): a new field added to `send` should gain an `AskDefaults` field and a row in the TUI sub-screen so `ask` stays a complete alias. The defaults are edited in the TUI under `/settings ▸ Ask command defaults` (`internal/tui/askconfigview.go`); see [commands.md](commands.md) for `/settings` dispatch.
-
-## Embedding `app.Send` from Go
-
-`SendOptions` is the embedder's seam set:
-
-```go
-err := app.Send(ctx, app.SendOptions{
-    Connection:       "my-con",
-    Agent:            "main",
-    Session:          "",       // empty → main-session default
-    Message:          "hello",
-    Detach:           false,
-    Out:              os.Stdout,
-    BackendFactory:   nil,      // nil → DefaultBackendFactory
-    ConnectionsStore: nil,      // nil → LoadConnections()
-})
-```
-
-`Out` is where the reply is written when not detached. `BackendFactory` lets tests substitute a fake backend (see `app/send_test.go` for the pattern) without going through `DefaultBackendFactory`'s auth / secrets wiring. `ConnectionsStore`, when non-nil, suppresses the implicit `SaveConnections` after `MarkUsed` so test runs don't leave a dirty `connections.json` on disk; production callers leave it nil.
-
-The function is single-shot — there is no streaming surface and no incremental callback. Embedders that need to observe deltas, tool events, or thinking blocks should drive `app.Program` directly.
-
-## Reply text extraction
-
-The shared wire-format parser lives at `internal/backend/chatevent.go`:
-
-- `backend.ExtractChatText(raw)` handles the two shapes a chat event's `Message` can take — a plain JSON string (delta) or a `{ content: [{type, text}, ...] }` object (final). Used by the TUI's chat view (`internal/tui/events.go`) and by `app/send.go`'s `replyCollector` so both paths agree on what the visible body is.
-- `backend.ExtractChatThinking(raw)` returns the concatenated `type:"thinking"` blocks from a final event. Currently only the TUI consumes this; `Send` ignores thinking blocks because the contract for `--connection X --agent Y "msg"` is "the assistant's reply on stdout", not the deliberation that led to it.
-
-If a backend ever changes the wire shape, both consumers update together — the parser is the single seam.
-
-## Non-goals
-
-- **Slash-command parsing.** A message body of `/help` is sent verbatim to the agent; the TUI's command dispatcher is intentionally not on this path. Scripts that want a command's effect should call the corresponding RPC directly rather than typing it as chat input.
-- **Skill catalog injection.** The TUI sends `Skills` in `ChatSendParams` so the gateway can advertise local skills to the model; `Send` deliberately omits it. Skills are a TUI-discovery concept (slash-command activation, mid-message expansion); revisit if scripted workflows ever want `lucinate send … "/review the diff"` to expand the same way.
-- **Auth recovery modals.** The TUI routes `token-mismatch` / `401` into modal flows; `Send` lets them bubble. Scripts that need to bootstrap auth should run `lucinate` once interactively and let the TUI's auth flow seed the secrets store.
+- **Slash-command parsing.** A message body of `/help` is sent verbatim to the agent; the TUI's
+  command dispatcher is intentionally not on this path. Scripts that want a command's effect
+  should call the corresponding RPC directly rather than typing it as chat input.
+- **Skill catalog injection.** The TUI sends `Skills` in `ChatSendParams` so the gateway can
+  advertise local skills to the model; `Send` deliberately omits it. Skills are a TUI-discovery
+  concept (slash-command activation, mid-message expansion); revisit if scripted workflows ever
+  want `lucinate send … "/review the diff"` to expand the same way.
+- **Auth recovery modals.** The TUI routes `token-mismatch` / `401` into modal flows; `Send`
+  lets them bubble. Scripts that need to bootstrap auth should run `lucinate` once interactively
+  and let the TUI's auth flow seed the secrets store.

--- a/docs/openclaw-go-fork.md
+++ b/docs/openclaw-go-fork.md
@@ -1,4 +1,14 @@
-# openclaw-go fork
+# openclaw-go fork — lessons and process
+
+The hard constraints for the fork live in
+[`openspec/specs/openclaw-go-fork/spec.md`](../openspec/specs/openclaw-go-fork/spec.md) —
+the `require`+`replace` wiring, pinning a tag rather than a branch or SHA, and retiring the
+fork once upstream reaches parity are all captured there as requirements. This file keeps
+the rationale behind those constraints and the operational procedure: why the SDK is
+forked, how to bump and re-sync it, the patch-queue model, and the conditions under which
+it is retired.
+
+## Why we fork
 
 Lucinate's gateway client depends on **our fork** of `openclaw-go`
 ([`outofcoffee/openclaw-go`](https://github.com/outofcoffee/openclaw-go)),
@@ -8,22 +18,10 @@ process that lags the gateway itself by weeks, so fixes we need (e.g. gateway
 protocol v4 support) are not yet available upstream. The fork lets us ship
 without waiting on an upstream merge.
 
-## How the dependency is wired
-
-`go.mod` keeps the upstream module path in `require` and redirects it to a
-**tag on our fork** with a `replace`:
-
-```
-require github.com/a3tai/openclaw-go v1.20260325.1-...   // upstream pseudo-version
-replace github.com/a3tai/openclaw-go => github.com/outofcoffee/openclaw-go v1.20260430.0-lucinate.2
-```
-
-The module path stays `github.com/a3tai/openclaw-go` (the fork does not rename
-its module), so upstream and fork stay drop-in compatible and the day upstream
-ships what we need we delete the `replace` line and bump the `require`.
-
-We pin a **tag**, never a branch HEAD or a one-off feature SHA, so a build is
-always reproducible and dependency bumps are deliberate.
+The `replace` points at a **tag** on the fork, never a branch HEAD or a one-off feature
+SHA. Reproducibility is the whole point: a build resolved today should resolve the same way
+next month, and every dependency bump should be a deliberate, reviewable change to `go.mod`
+rather than something that drifts when a branch moves under us.
 
 ## Patch-queue model (fork side)
 
@@ -38,6 +36,10 @@ The fork carries our not-yet-upstreamed patches as a queue on top of upstream:
   cherry-picked. This is the only thing lucinate depends on. It is tagged
   `v1.20260430.<base>-lucinate.<n>`, where the date is the upstream base and
   `<n>` increments per patch-set revision.
+
+Keeping each patch as a standalone branch and PR is what lets the queue shrink over time:
+when upstream accepts one, we simply stop carrying it rather than untangling it from a
+combined branch.
 
 ## Bumping / re-syncing (when upstream moves)
 

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -1,112 +1,57 @@
-# Routines
+# Routines — lessons and rationale
 
-Routines are ordered prompt sequences stored on disk and replayed against the active session via `/routine <name>`. Each step is a complete user message; the controller dispatches them one at a time, optionally auto-advancing after each assistant reply. Routines are a chat-only concept — there is no gateway counterpart, and every backend works with them.
+The behavioural contract for routines lives in
+[`openspec/specs/routines/spec.md`](../openspec/specs/routines/spec.md) — the STEPS.md file
+format, disk storage, the controller lifecycle, the auto-advance hook, stale-event filtering,
+directives, logging, the manager view, slash-command gating, notifications, the status row, and
+key bindings are all captured there as requirements and scenarios. This file keeps the hard-won
+lessons, pitfalls, and design rationale behind that flow: the "why it works this odd way" that
+the spec's requirements don't dwell on.
 
-The user-facing surface is `/routine <name>` (activate) and `/routines` (manage). Routine state lives entirely in `chatModel`; on disk, each routine is a directory under `~/.lucinate/routines/` containing a single `STEPS.md` file. The implementation splits across `internal/routines/` (file format + storage) and `internal/tui/` (controller + manager view).
+## Auto-advance hook ordering in the final event
 
-## STEPS.md format
+Auto-advance lives in the `final` case of `handleEvent` (`internal/tui/events.go`), and the
+order of operations is load-bearing. The sequence is: finalise the streaming message, capture
+the merge boundary via `bumpGen()`, then — while a routine is active — log the assistant content
+and run `applyDirectives` *before* any auto-advance fires, so a `/routine:stop` or
+`/routine:pause` is honoured before the next step could be dispatched. Only after the
+unconditional `refreshHistoryAt(boundary)` and queue drain does `maybeAdvanceRoutine()` get its
+chance.
 
-Plain markdown. Optional YAML frontmatter delimited by `---` lines carries routine metadata. The body is split into steps on lines containing exactly `---`.
+The reason the boundary is captured before the routine work: the just-finalised turn is now on
+the history-side of any refresh issued from here on, and subsequent appends (the next step's
+placeholder, system rows) get the new gen and survive the merge. The merge in the
+`historyRefreshMsg` handler is non-destructive precisely because those live-tail rows carry a
+higher gen than the boundary.
 
-```markdown
----
-name: demo
-mode: auto              # auto | manual; default = manual
-log: ./demo.log         # absolute or relative-to-cwd; omit to disable logging
----
+The queue is drained via `drainQueueSkipRefresh` rather than plain `drainQueue`: user-typed
+messages jump ahead of the routine, and the `SkipRefresh` variant avoids duplicating the resync
+we already queued above — `drainQueue`'s built-in empty-queue refresh would otherwise fire it
+twice.
 
-generate two integers between 1 and 10
+`error` and `aborted` also `bumpGen()` so the boundary stays monotonic, and set `paused = true`
+instead of advancing — a transient gateway error must not loop the next step at the user. The
+user can press Enter (empty input) to retry or Esc to end. Those cases don't issue their own
+refresh; the next successful turn's refresh covers the canonical reconciliation.
 
----
+## The Pre-Layer-3 drift, and why every final now reconciles
 
-if the sum is greater than 10 say /routine:stop, otherwise /routine:continue
+The unconditional refresh is the heart of the resync architecture. Pre-Layer-3, the refresh was
+deferred to "queue empty AND no routine to advance", which meant a 10-step auto-mode routine
+accumulated drift across all 10 steps before the first server-canonical reconciliation. With
+drift large enough, stale-event filtering became the only line of defence against spurious step
+submission. Now every `final` reconciles, every step — the drift never gets a chance to build.
 
----
+## Stale-event filtering by finalised run: the back-to-back race
 
-say "the sum is less than or equal to 10"
-```
+The OpenClaw gateway has been observed emitting a duplicate `delta` event with the full content
+right *after* the matching `final`, on the same `runID`. Without filtering, that delta lands on
+the next routine step's freshly-appended placeholder, flipping `awaitingDelta` and letting a
+subsequent empty-content `final` falsely finalise an empty turn — which spuriously auto-advances
+the routine.
 
-Parser rules (`internal/routines/parse.go`):
-
-- If the first non-blank line is `---`, consume YAML frontmatter until the next `---` line. Anything else is treated as body with no frontmatter.
-- The body is split on lines whose `strings.TrimRight(line, " \t\r")` equals `---`.
-- Each chunk is `strings.TrimSpace`'d. Empty chunks are dropped, so consecutive `---` lines collapse harmlessly.
-- The on-disk directory name is the routine's identity (`Routine.Name`); `frontmatter.name` is informational.
-
-`Format(r Routine)` is the round-trip — frontmatter is emitted only when at least one field is non-empty, and steps are joined with `\n---\n\n`. `TestFormatRoundTrip` pins the parse→format→parse invariant.
-
-## Disk layout
-
-Resolved through `config.DataDir()`:
-
-```
-~/.lucinate/routines/
-  <name>/
-    STEPS.md
-```
-
-`internal/routines/store.go` exposes:
-
-| Function | Behaviour |
-|---|---|
-| `Dir()` | `<data-dir>/routines` (not auto-created) |
-| `List()` | Scan + parse every subdirectory; entries that fail to parse are silently skipped so one bad file doesn't sink the listing |
-| `Load(name)` | Returns `Routine{}` + `ErrNotFound` if the directory is missing |
-| `Save(r)` | `MkdirAll(0o700)` + atomic `WriteFile`/`Rename` of `STEPS.md` |
-| `Delete(name)` | `os.RemoveAll(<dir>/<name>)` |
-
-Two name predicates live in `internal/routines/`:
-
-- `validName` (path safety) rejects empty, `.`, `..`, leading-dot, and any name containing `/`, `\\`, or NUL. `Load` and `Delete` use this predicate so existing on-disk directories — including any non-kebab names left over from earlier versions — keep working.
-- `IsValidKebab` (form rule) tightens to lowercase ASCII letters, digits, and hyphens; no leading or trailing hyphen, no consecutive hyphens. `Save` enforces it, so any new save or rename lands on disk with a typeable, lowercase identifier. The companion `ToKebab(s string) string` produces a best-effort kebab version of arbitrary input — used by the form's submit error to suggest a fix when the user typed `My Routine!` or similar.
-
-## Controller
-
-The active routine lives on `chatModel.activeRoutine` (`internal/tui/routines_chat.go`):
-
-```go
-type activeRoutine struct {
-    routine routines.Routine
-    mode    routines.Mode
-    sent    int                 // count of steps already dispatched
-    paused  bool
-    logger  *routines.Logger    // nil if no `log:` configured
-}
-```
-
-Lifecycle entry points on `*chatModel`:
-
-| Method | Purpose |
-|---|---|
-| `startRoutine(name)` | Load + parse from disk, open the log if configured, append the "Routine started" notification, return the `tea.Cmd` for step 0's send |
-| `sendNextRoutineStep()` | Read `Steps[ar.sent]`, increment `ar.sent`, append the user message + assistant placeholder to `m.messages`, set `m.sending=true`, log the user line, return `sendMessage(...)` |
-| `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Completion fires first: when the answered step was the last, calls `endRoutine("completed")` regardless of mode and returns nil so the user always gets the same notification + cleared `activeRoutine`. Otherwise returns `sendNextRoutineStep` only when mode is auto and not paused; in manual or paused mid-routine it returns nil and the user drives the next step. |
-| `applyDirectives(reply)` | Scans the assistant reply for `/routine:` directives and applies them in order |
-| `endRoutine(reason)` | Closes the logger, clears `activeRoutine`, posts a "Routine X <reason>" notification |
-| `cycleRoutineMode()` | Bound to `Shift+Tab` (mirrors Claude Code's mode-cycle gesture) — flips between auto and manual; entering auto unsets `paused`. Yields to slash-menu cycling when the completion menu is active. |
-
-Step indexing is strictly monotonic: only `sendNextRoutineStep` increments `ar.sent`, and it does so once per call. Auto-advance is gated solely on `ar.sent < len(Steps)` and the directive/pause flags — there is no path that decrements or skips.
-
-## Auto-advance hook
-
-Auto-advance lives in the `final` case of `handleEvent` (`internal/tui/events.go`). The order matters:
-
-1. Mark the streaming assistant message as finalised (existing behaviour).
-2. Capture the merge boundary via `bumpGen()` — the just-finalised turn is now on the history-side of any refresh issued from here on; subsequent appends get the new gen and survive the merge.
-3. If `m.activeRoutine != nil`: log the assistant content (when a logger is configured) and call `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before any auto-advance fires.
-4. Always queue `refreshHistoryAt(boundary)` and `loadStats()`. The merge in the `historyRefreshMsg` handler is non-destructive — the live tail of the next routine step (placeholder, system rows) survives because those rows carry a higher gen than the boundary.
-5. Drain `m.pendingMessages` via `drainQueueSkipRefresh` — user-typed queue jumps ahead of the routine. The `SkipRefresh` variant is used because we already queued the resync above; `drainQueue`'s built-in empty-queue refresh would otherwise duplicate it.
-6. If the queue was empty and `m.sending` is now false, call `maybeAdvanceRoutine()`. If it returns a cmd, append it to the batch (sending the next step).
-
-The unconditional refresh is the heart of the resync architecture. Pre-Layer-3, the refresh was deferred to "queue empty AND no routine to advance", which meant a 10-step auto-mode routine accumulated drift across all 10 steps before the first server-canonical reconciliation. With drift large enough, stale-event filtering became the only line of defence against spurious step submission. Now every `final` reconciles, every step.
-
-`error` and `aborted` also `bumpGen()` so the boundary stays monotonic, and set `paused = true` instead of advancing — so a transient gateway error doesn't loop the next step. The user can press Enter (empty input) to retry the next step or Esc to end the routine. They do not currently issue their own refresh; the next successful turn's refresh covers the canonical reconciliation.
-
-## Stale-event filtering
-
-The OpenClaw gateway has been observed emitting a duplicate `delta` event with the full content right *after* the matching `final`, on the same `runID`. Without filtering, that delta lands on the next routine step's freshly-appended placeholder, flipping `awaitingDelta` and letting a subsequent empty-content `final` falsely finalise an empty turn — which spuriously auto-advances the routine.
-
-`chatModel.finalisedRuns` is a bounded LRU set (cap `finalisedRunsCap = 32`) of run IDs we have already finalised; the top of the chat-event branch in `handleEvent` drops any event whose `RunID` is a member:
+The guard is `chatModel.finalisedRuns`, a bounded LRU set of run IDs already finalised; the top
+of the chat-event branch in `handleEvent` drops any event whose `RunID` is a member:
 
 ```go
 if m.finalisedRuns.contains(chatEv.RunID) {
@@ -115,162 +60,98 @@ if m.finalisedRuns.contains(chatEv.RunID) {
 }
 ```
 
-The set is added to inside the `final`, `error`, and `aborted` paths, but only when the corresponding state mutation actually happened (gated on the same `finalised` flag). FIFO eviction keeps a long-lived chat from growing the filter unboundedly.
+The set's depth is the subtle part. A single-deep filter is enough for the immediate
+duplicate-after-final case, but back-to-back routine steps open a wider window: a stale event
+for run N-2 can arrive while run N is streaming, and with only the most-recent run remembered
+that earlier id slips past and corrupts the live placeholder. Hence the cap of 32
+(`finalisedRunsCap`) with FIFO eviction — deep enough to cover overlapping runs, bounded so a
+long-lived chat can't grow the filter unboundedly. The set is added to only when the
+corresponding state mutation actually happened (gated on the same `finalised` flag), so we never
+remember a run we didn't really finalise.
 
-The set's depth matters: a single-deep filter is enough for the immediate duplicate-after-final case, but back-to-back routine steps open a wider window. A stale event for run N-2 can arrive while run N is streaming; with only the most-recent run remembered, that earlier id slips past and corrupts the live placeholder. `TestHandleEvent_StaleDeltaAfterFinalIgnored` pins the duplicate case; `TestHandleEvent_StaleDeltaFromOlderRunIgnored` pins the back-to-back race; `TestFinalisedRunSet_EvictsOldestPastCap` pins the FIFO bound.
+## Directive regex: anchored, per-line, deliberately strict
 
-## Directives
-
-The assistant can steer the routine by emitting one of these on its own line (leading whitespace allowed):
-
-| Directive | Effect |
-|---|---|
-| `/routine:stop` | End the active routine immediately |
-| `/routine:pause` | Pause without ending — Enter sends the next step, Esc ends |
-| `/routine:continue` | Explicit no-op; also unsets `paused` so it can resume an auto-mode routine |
-| `/routine:mode auto` | Switch to auto mode; unsets `paused` |
-| `/routine:mode manual` | Switch to manual mode |
-
-Matching (`internal/routines/directives.go`):
+Directives are matched with `internal/routines/directives.go`:
 
 ```go
 ^\s*/routine:(stop|pause|continue|mode\s+(auto|manual))\s*$
 ```
 
-Anchored with `^...$` and applied per line. Inline mentions (`as in /routine:stop`, backtick-wrapped tokens) deliberately do not match. Directives are kept verbatim in the rendered transcript — `applyDirectives` doesn't rewrite the assistant message.
+Anchored with `^...$` and applied per line, so inline mentions (`as in /routine:stop`,
+backtick-wrapped tokens) deliberately do *not* match — the assistant can talk *about* a directive
+without accidentally firing it. Directives are kept verbatim in the rendered transcript;
+`applyDirectives` doesn't rewrite the assistant message. And only assistant replies are scanned —
+user-typed `/routine:*` lines in the chat input are never parsed, so a user can't drive the
+controller by pasting a directive into the input.
 
-User-typed `/routine:*` lines in the chat input are not parsed. Only assistant replies are scanned.
+## Fixed 4-line step textareas
 
-## Logging
+Step textareas in the form are sized at a fixed 4 lines each rather than auto-fitting the
+available height. The previous "divide remaining space across all steps" heuristic squeezed every
+textarea down to a 1-line stub once step count grew, and the user couldn't see the content of any
+step. The scrollable viewport handles overflow now, so a fixed per-step size is friendlier to
+type into. The related `ensureFocusVisible`/`fieldLineStarts` scrolling exists for the same
+reason: without it, a routine with many steps used to push the help line off the terminal
+entirely.
 
-When the frontmatter sets `log: <path>`, `routines.Logger` opens the file (`O_APPEND | O_CREATE | O_WRONLY`, mode `0o600`) at routine start and closes it on `endRoutine`. Relative paths resolve against the lucinate working directory at start time, captured via `os.Getwd()`.
+## Collision avoidance on duplicate, and the name predicates
 
-Format:
+Routines are name-keyed — the directory under `~/.lucinate/routines/<name>/` *is* the identity,
+unlike cron jobs which carry a separate ID. So the duplicate flow can't just reuse a name: it
+builds `"Copy of " + name`, walking `(2)`, `(3)`, … to find the first slot that doesn't collide
+with an existing routine. Duplicate opens in create mode (`editingID` stays empty) so submission
+goes through the plain `routines.Save` path — no rename, no overwrite, no delete-of-original.
 
-```
---- routine: demo started 2026-05-09T22:30:00Z ---
-[2026-05-09T22:30:00Z] user: <step 1 text>
-[2026-05-09T22:30:05Z] assistant: <reply line 1>
-<reply line 2 — no per-line prefix>
-```
+The name validation is deliberately split into two predicates. `validName` (path safety only —
+rejects empty, `.`, `..`, leading-dot, and anything with `/`, `\`, or NUL) is what `Load` and
+`Delete` use, so existing on-disk directories — including any non-kebab names left over from
+earlier versions — keep working. `IsValidKebab` is the *form* rule, tighter (lowercase ASCII,
+digits, hyphens; no leading/trailing/consecutive hyphens), and only `Save` enforces it — so
+anything newly saved or renamed lands on disk with a typeable identifier, while legacy directories
+aren't retroactively locked out. `ToKebab` produces the best-effort suggestion the form offers
+when the user types something like `My Routine!`.
 
-Only the *first* line of a multi-line message gets the `[ts] role:` prefix; subsequent lines are written verbatim so log diffs read like the chat. The logger is best-effort — write errors are silently swallowed so a logging hiccup never breaks the running routine. `Open` returns `nil, nil` for an empty path so callers can invoke it unconditionally.
+## Why the controller lifecycle is shaped as it is
 
-## Manager view
+Step indexing is strictly monotonic: only `sendNextRoutineStep` increments `ar.sent`, once per
+call, and auto-advance is gated solely on `ar.sent < len(Steps)` plus the directive/pause flags.
+There is deliberately no path that decrements or skips — the invariant is what makes "spurious
+auto-advance" a filtering problem (see stale-event filtering above) rather than an indexing one.
 
-`/routines` opens `routinesModel` (`internal/tui/routines.go`), modelled on the cron browser. Four substates:
+Completion is checked *before* mode: when the answered step was the last,
+`maybeAdvanceRoutine()` calls `endRoutine("completed")` regardless of mode and returns nil, so
+manual and auto routines both end with the same notification and cleared `activeRoutine` on their
+final reply. Mode only decides what happens *mid*-routine.
 
-| Substate | Purpose |
-|---|---|
-| `routinesSubList` | List of routines (name + step count + mode chips) |
-| `routinesSubDetail` | Read-only view of a single routine — frontmatter, file path, every step rendered in order |
-| `routinesSubForm` | Create / edit / duplicate form |
-| `routinesSubConfirmDelete` | y/n prompt before `routines.Delete` fires |
+## Navigation gating: don't strand or leak the controller
 
-Key bindings follow the project-wide conventions documented in [key-conventions.md](key-conventions.md). The list view exposes `n` (new) and `d` (duplicate, gated on a non-empty list); the detail view exposes `e` (edit) and `x` (delete) — `x` rather than `d` so duplicate and delete stay distinct in the user's vocabulary, matching the cron browser.
+Only one routine runs at a time per session, and starting a second — or navigating away — routes
+through `gateNavigation()` when a routine is already active. The gate covers more than the obvious
+`/routine`/`/routines` case: `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, and
+`/connections` all strand or replace the chat model, and the active routine controller can't
+survive a chat-view reset. Silently dropping it would leak the open log file — which is the real
+reason the gate exists rather than just a courtesy prompt. On `y` the gate cancels any in-flight
+turn (`cancelTurn`) and ends the routine (`endRoutine`) before dispatching. `startRoutine` keeps a
+defensive `if m.activeRoutine != nil` guard, but in normal flow the gate runs first.
 
-The form has three textinputs (name, mode, log) plus a slice of `textarea.Model` for the steps — one per step. The focus index is a single int: `0..2` are the header fields, `3+i` is step `i`. Key bindings inside the form:
+## Notifications live outside the message list, on purpose
 
-| Key | Action |
-|---|---|
-| Tab / Shift+Tab | Cycle focus |
-| Ctrl+S (or Alt+S) | Save — Ctrl+S is the surfaced binding; Alt+S is kept as a fallback for terminals that intercept Ctrl+S as XOFF |
-| Alt+Up | Insert blank step above the focused step |
-| Alt+Down | Insert blank step below the focused step |
-| Alt+Delete (or Alt+Backspace) | Remove the focused step (y/n confirm) |
-| Esc | Cancel without saving |
-| Alt+Enter | Newline within a step textarea |
+Routine state changes and errors are ephemeral notifications, not chat rows (see the `chat-ux`
+spec, Notifications). They live outside `m.messages` specifically so a `historyRefreshMsg` — which
+the routine machinery fires on every `final` — doesn't wipe them. They clear when the user submits
+any non-empty input. The controller calls `m.notify` / `m.notifyError` directly; the legacy
+`appendSystemError` helper still exists but routes to `notifyError` under the hood for older
+callers.
 
-`insertStep(idx, value)` uses an overlap-safe `copy` (`memmove`) so shift-right insertion never duplicates content. `deleteStep(idx)` re-inserts a blank textarea when the slice would otherwise empty out, so the form always has at least one step to type into.
+## Small deliberate deviations
 
-### Duplicate
-
-Pressing `d` on the list view opens the form pre-populated from the highlighted routine, in **create mode** — `editingID` stays empty so submission goes through the plain `routines.Save` path with no rename, no overwrite, no delete-of-original. The cloned name is built by `duplicateRoutineName(name, existing)`:
-
-- `"" → ""` (passes through so the form-level "name is required" check fires).
-- Otherwise: `"Copy of " + name`, walking `(2)`, `(3)`, … to find the first slot that doesn't collide with an existing routine. Routines are name-keyed (the directory under `~/.lucinate/routines/<name>/` is the identity), so collision avoidance is required — unlike cron jobs which have a separate ID.
-
-`Frontmatter.Name` is set to the duplicated name so the `STEPS.md` metadata stays in sync with the directory identity. `Frontmatter.Log` is copied verbatim — if it's a relative path the user can change it in the form before saving so the duplicate doesn't share the original's log file.
-
-### Form layout
-
-The form's middle section (header inputs + step textareas) renders inside a scrollable `viewport.Model`; the title and the footer (error line + help line) stay pinned. `viewForm` records the line index where each focusable field starts as it builds the body content (`fieldLineStarts`), and `ensureFocusVisible` adjusts the viewport's `YOffset` so the focused field is fully on-screen — scrolling down when the user tabs past the bottom of the visible window, scrolling up when they shift-tab back. Without this, a routine with many steps used to push the help line off the terminal entirely.
-
-Step textareas are sized at a fixed 4 lines each rather than auto-fitting the available height: the previous "divide remaining space across all steps" heuristic squeezed every textarea down to a 1-line stub once step count grew, and the user couldn't see the content of any step. The viewport handles overflow now, so a fixed per-step size is friendlier to type into.
-
-### Submission
-
-Submission iterates `form.steps` in order, dropping blank ones, and goes through `routines.Save`. Editing with a renamed `name` writes the new directory and `Delete`s the old one. After save (or delete), the model emits `routinesChangedMsg` so the chat view refreshes its `m.routineNames` cache for `/routine <TAB>` completion.
-
-## Slash commands and gating
-
-Two entries in `slashCommands`:
-
-| Command | Behaviour |
-|---|---|
-| `/routine <name>` | Activate the named routine. Bare `/routine` is an error pointing at `/routines`. Tab completion uses `m.routineNames` populated by `loadRoutineNames()` at chat init and after any manager-view CRUD. |
-| `/routines` | Open the manager via `showRoutinesMsg{}` |
-
-Only one routine can run at a time per session. Both commands route through `gateNavigation()` (`routines_chat.go`) when a routine is already active:
-
-```
-Routine "demo" is active. Starting routine "other" will cancel it. Continue? (y/n)
-```
-
-The same gate covers the navigations that strand or replace the chat model — `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections` — for the same reason: the active routine controller can't survive a chat-view reset, and silently dropping it would leak the open log file. On `y`, the gate cancels any in-flight turn (`cancelTurn`) and ends the routine (`endRoutine`) before dispatching the navigation. On `n` or Esc the prompt clears and the routine continues.
-
-`startRoutine` itself still has a defensive `if m.activeRoutine != nil` guard, but in normal flow the gate runs first.
-
-## Notifications
-
-Routine state changes (started, paused, ended) and routine errors are surfaced as ephemeral notifications, not chat rows — see [chat-ux.md → Notifications](chat-ux.md#notifications). They live outside `m.messages` so a `historyRefreshMsg` doesn't wipe them, and they clear when the user submits any non-empty input. The routine controller calls `m.notify` / `m.notifyError` directly; the legacy `appendSystemError` helper still exists but routes to `notifyError` under the hood for older callers.
-
-## Status row
-
-When `m.activeRoutine != nil`, the chat View renders a single styled row immediately above the input box. While auto-advancing or mid-turn the trailing segment is a passive preview:
-
-```
-routine: demo — AUTO — sent: 5/10 — next: <preview>
-```
-
-When the routine is awaiting user input — manual mode, or auto with `paused` set, with no turn in flight and steps remaining — the trailing segment switches to a call-to-action so the user sees both what the next message is and that the routine is parked on them:
-
-```
-routine: demo — MANUAL — sent: 5/10 — ▶ Press Enter to send: <preview>
-```
-
-`AUTO`/`MANUAL` reflects the mode; `(paused)` is appended when `paused` is set. The row is coloured by mode — amber (`execClr`) for auto, cyan (`userClr`) for manual — so the driver is legible at a glance without the row competing with the purple chat header. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`; the preview length is computed from `m.width` so it grows with the terminal (floor 20 chars, fallback 40 when width is not yet known). `applyLayout()` (`completion.go`) subtracts one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
-
-## Key bindings
-
-| Key | Behaviour |
-|---|---|
-| Shift+Tab | Cycle mode (auto ↔ manual). No-op when no routine is active. Mirrors Claude Code's mode-cycle gesture. Yields to slash-menu cycling when the completion menu is active. |
-| Esc | When a routine is active: end the routine and (if streaming) cancel the in-flight turn. Otherwise behaves as before (`/cancel`-equivalent or transcript back). |
-| Enter (empty input) | When a routine is active and idle (manual or paused): send the next step. Otherwise no-op. |
-
-## Verification
-
-Unit tests:
-
-- `internal/routines/parse_test.go` — frontmatter parsing, default mode, blank-line preservation, format round-trip.
-- `internal/routines/directives_test.go` — own-line matching, inline-mention rejection, all five directive kinds.
-- `internal/routines/store_test.go` — disk round-trip, invalid-name rejection.
-- `internal/routines/log_test.go` — header + per-message timestamp shape, multi-line bodies, append across reopens, nil-receiver safety.
-- `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` / `TestHandleEvent_StaleDeltaFromOlderRunIgnored` / `TestFinalisedRunSet_*` — pin the bounded stale-run filter.
-- `internal/tui/events_test.go::TestHandleEvent_FinalRefreshesEvenWithQueuedMessages` / `TestHandleEvent_FinalRefreshesDuringRoutineAutoAdvance` — pin that the resync fires on every successful `final`, not just at queue/routine end.
-- `internal/tui/events_test.go::TestHandleEvent_FinalBumpsGen` / `TestHandleEvent_FinalEmptyAckDoesNotBumpGen` — pin the gen-bump semantics that anchor the merge boundary.
-- `internal/tui/events_test.go::TestMergeHistoryRefresh_PreservesLiveTail` / `TestMergeHistoryRefresh_NoLiveTail` — pin the merge contract the unconditional refresh depends on.
-- `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
-- `internal/tui/routines_test.go::TestRoutinesDuplicate_*` / `TestDuplicateRoutineName_*` / `TestRoutinesDetailKey_X_TriggersDelete` / `TestRoutinesDetailKey_D_NoLongerDeletes` — pin the duplicate flow, the collision-suffix algorithm, and the `d` → `x` delete remap.
-- `internal/tui/routines_chat_test.go::TestMaybeAdvanceRoutine_ManualCompletion` / `TestMaybeAdvanceRoutine_ManualMidStepIsNoOp` — pin that manual routines complete on their final reply and stay quiet between steps.
-
-Manual smoke:
-
-1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — ▶ Press Enter to send: …`.
-2. Press Enter on an empty input — step 1 dispatches.
-3. Step through to the end. After the final step's reply, a `Routine "demo" completed.` notification appears, the status row disappears, and the input returns to plain chat.
-4. Shift+Tab flips status to `AUTO`. Subsequent step finals auto-advance.
-5. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
-6. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
-7. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.
+- `x` deletes on the detail view, not `d` — `d` is duplicate on the list, and keeping the two
+  verbs distinct in the user's vocabulary (matching the cron browser) is worth the minor
+  departure from a "d for delete" habit.
+- `Alt+S` is kept as a save fallback alongside the surfaced `Ctrl+S`, because some terminals
+  intercept Ctrl+S as XOFF and would otherwise swallow the save.
+- `deleteStep` re-inserts a blank textarea when the slice would empty out, so the form always has
+  at least one step to type into rather than presenting an empty, un-focusable body.
+- `Frontmatter.Log` is copied verbatim on duplicate rather than cleared: a shared relative log
+  path is a hazard, but blanking it silently would be surprising, so we leave it visible in the
+  form for the user to change before saving.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,46 +1,62 @@
-# Sessions
+# Sessions — lessons and rationale
 
-## Lifecycle
+The behavioural contract for sessions lives in
+[`openspec/specs/sessions/spec.md`](../openspec/specs/sessions/spec.md) — the session
+lifecycle, the session browser, the compact and reset commands, and message queueing are all
+captured there as requirements and scenarios. This file keeps the hard-won lessons, pitfalls,
+and design rationale behind that flow: the "why it works this odd way" that the spec's
+requirements don't dwell on.
 
-A session is created when the user selects an agent in the agent picker (see [agents.md](agents.md)). `client.CreateSession(agentID, key)` is called and the returned `sessionKey` is passed to `newChatModel()`. The session key is deterministic for non-default agents (based on agent ID) so the same session is restored on restart.
+## Why session keys are deterministic
 
-The same default-key rule is reused by the one-shot CLI mode: `app.Send` (`lucinate send`) calls `CreateSession` with `MainKey` for the default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the same conversation as "open the picker, pick the agent, hit enter". See [one-shot.md](one-shot.md) for the full lifecycle.
+The session key is deterministic for non-default agents (based on agent ID) so the same session
+is restored on restart rather than spawning a fresh conversation each launch. The same
+default-key rule is reused by the one-shot CLI mode (`lucinate send`): it uses `MainKey` for the
+default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the
+same conversation as "open the picker, pick the agent, hit enter". Keeping both entry points on
+the same key rule is the whole point — otherwise a scripted send and an interactive pick would
+drift onto different conversations.
 
-`lucinate chat --session <key>` overrides this default at the picker's `CreateSession` site: `AppModel.initialSession` is consumed in the `viewSelect` block of `update`, beating both the literal `"main"` and `MainKey`. The override is one-shot — cleared once consumed so a follow-up agent pick on the same picker doesn't keep landing on the original key. See [chat-launch.md](chat-launch.md).
+The `lucinate chat --session <key>` override is deliberately **one-shot** — cleared once
+consumed in the `viewSelect` block so a follow-up agent pick on the same picker doesn't keep
+landing on the original key.
 
-On `chatModel.Init()`, two async commands run in parallel:
+## Why history and stats load in parallel
 
-- `loadHistory()` — fetches the last N messages from the gateway (`client.SessionHistory()`), strips `System:` lines (see [message-rendering.md](message-rendering.md#history-cleanup)), and populates the viewport.
-- `loadStats()` — fetches token usage and cost via `client.SessionUsage()` for the header bar.
+On `chatModel.Init()`, `loadHistory()` and `loadStats()` run as two async commands in parallel
+rather than in sequence — neither depends on the other, so serialising them would just add
+latency to the first paint.
 
-History depth (N) is configurable; see [chat-ux.md](chat-ux.md#history-depth).
+## Compact: server-side vs local streaming
 
-## Session browser
+The distinction that catches people out: on OpenClaw the gateway runs the compaction pass
+server-side, but on the OpenAI-compatible backend the pass runs **locally** (a streaming
+`POST /v1/chat/completions` against the agent's configured model). Same `/compact` command, two
+very different execution paths — worth remembering when a compaction behaves differently between
+backends.
 
-`/sessions` emits `showSessionsMsg{}`, which navigates to the sessions view (`sessionsModel` in `internal/tui/sessions.go`). The model calls `client.SessionsList(agentID)` and parses the response into `sessionItem` values grouped into two lists:
+## Reset is delete-then-recreate
 
-- **Conversations** — regular sessions.
-- **Scheduled** — sessions whose key contains `:cron:`, used by scheduled/automated agents.
+`/reset` doesn't clear a session in place; it calls `SessionDelete()` to permanently remove the
+session and then immediately creates a replacement via `CreateSession()`. The new session key
+comes back as `sessionClearedMsg{newSessionKey}` — the chat model reinitialises against a fresh
+key rather than reusing the old one.
 
-Both lists are sorted by `updatedAt` descending. Selecting a session returns `sessionSelectedMsg` and a new `chatModel` is constructed with the chosen key, loading its history.
+## Queueing gotcha: exec results also drain the queue
 
-## Compact and reset
+While a response is in flight, new input is appended to `m.pendingMessages` rather than sent, so
+fast typing doesn't drop messages. The non-obvious part is that local (`!`) and remote (`!!`)
+exec results **also** trigger `drainQueue()` — not just chat responses. If you change the exec
+flow, remember it shares the same drain path; miss that and queued messages silently stall after
+an exec.
 
-Both commands use the [confirmation pattern](commands.md#confirmation-pattern) before taking action.
+`lucinate chat <message>` pre-seeds the same queue and drains it from the `historyLoadedMsg`
+handler *after* the scrollback has rendered, so the launch message appears after the loaded
+history — matching what a human typing the same message would see, rather than jumping ahead of
+it.
 
-**`/compact`** calls `backend.SessionCompact()`, which summarises older messages in the session context to reduce token usage. On OpenClaw the gateway runs the pass server-side; on the OpenAI-compatible backend the pass runs locally (a streaming `POST /v1/chat/completions` against the agent's configured model — see [backend_openai.md](backend_openai.md#compaction)). While the pass is in flight the confirmation handler shows a pending `Compacting session…` system row with the streaming spinner attached (see [confirmation pattern](commands.md#confirmation-pattern)). On success the placeholder is replaced in place with `Session compacted.`; the smaller context is picked up on the next chat send.
+## Scheduled sessions sort separately
 
-**`/reset`** calls `backend.SessionDelete()` to permanently remove the session, then immediately creates a replacement via `backend.CreateSession()`. While the round-trip is in flight the chat view shows a pending `Clearing session…` system row with the spinner attached. On success the new session key is returned as `sessionClearedMsg{newSessionKey}` and the chat model reinitialises with an empty history; on error the placeholder is replaced in place with the error.
-
-## Message queueing
-
-While `m.sending == true` (a response is in flight), new user input is appended to `m.pendingMessages []string` rather than sent immediately. This prevents messages from being dropped when the user types quickly.
-
-After each response (`drainQueue()` in `chat.go`):
-
-1. If there are pending messages, the first one is dequeued and sent as if the user typed it fresh (including command detection, skill prepend, etc.).
-2. History is refreshed once the queue is fully drained.
-
-Local (`!`) and remote (`!!`) exec results also trigger queue draining. See [shell-execution.md](shell-execution.md) for the exec flow.
-
-`lucinate chat <message>` pre-seeds the same queue: `newChatModel` appends the supplied text to `pendingMessages` at construction time, and the `historyLoadedMsg` handler returns `m.drainQueue()` once the scrollback has rendered — so the user turn appears *after* the loaded history, matching what a human typing the same message would see. See [chat-launch.md](chat-launch.md).
+Sessions whose key contains `:cron:` are split into their own **Scheduled** list in the session
+browser, separate from regular **Conversations**. The `:cron:` marker in the key is what drives
+the grouping — there's no other flag distinguishing an automated session from a hand-started one.

--- a/docs/shell-execution.md
+++ b/docs/shell-execution.md
@@ -1,28 +1,42 @@
-# Shell execution
+# Shell execution — lessons and rationale
 
-Lucinate supports running shell commands directly from the chat input using a prefix convention:
+The behavioural contract for shell execution lives in
+[`openspec/specs/shell-execution/spec.md`](../openspec/specs/shell-execution/spec.md) — the
+prefix convention, local execution, remote two-phase-approval execution, and message queueing
+during execution are all captured there as requirements and scenarios. This file keeps the
+hard-won lessons, pitfalls, and design rationale behind that flow.
 
-| Prefix | Where it runs |
-|---|---|
-| `!<command>` | Local machine (user's shell) |
-| `!!<command>` | Gateway host (remote) |
+## Two-phase approval for remote exec is not one call
 
-Both are handled in `chat.go`'s `Update()` before messages are sent to the gateway.
+Remote `!!` execution deliberately splits into submit then approve rather than a single request.
+`client.ExecRequest` only lodges the request; the gateway may resolve it under its own exec
+policy or leave it open for the client to decide. The client auto-approves an unresolved request
+with `"allow-once"` — but the race here is the whole point of the design, and it bites two ways:
 
-## Local execution (`!`)
+- If the gateway's own policy has *already* resolved the approval, the follow-up `ExecResolve`
+  comes back with `"unknown or expired"`. That error is silently ignored on purpose — it means
+  the request already went through, not that anything failed. Treating it as an error would
+  reject perfectly good runs.
+- If the gateway denies (`Decision == "deny"`), the error is shown immediately rather than
+  waiting for the asynchronous `exec.finished` event — because no event is coming for a request
+  that never ran.
 
-Detected when the input starts with `!` but not `!!`. `localExecCommand()` in `commands.go` spawns `exec.Command("sh", "-c", command)` and captures combined stdout and stderr. The result is returned as `localExecFinishedMsg{output, exitCode, err}` and displayed as a system message. No gateway involvement; no approval required.
+## "running on gateway..." is a placeholder, not the result
 
-## Remote execution (`!!`)
+Remote output arrives asynchronously via the `exec.finished` event, well after the submit call
+returns. The "running on gateway..." system message is a placeholder that `handleEvent()` later
+replaces with the real output or error. If you change how system messages are keyed, keep this
+replacement working — otherwise you get a stuck "running on gateway..." line that never resolves.
 
-Detected when the input starts with `!!`. The stripped command is passed to `execCommand()` in `commands.go`, which implements a two-phase approval flow:
+## Local `!` has no gateway approval
 
-1. **Submit** — `client.ExecRequest(ctx, command, sessionKey)` is called. The gateway returns immediately with an `ExecApprovalRequestResult` containing `{ID, Status, Decision}`.
-2. **Approve** — If `Decision` is empty (not yet resolved by gateway policy), the client auto-approves via `client.ExecResolve(ctx, id, "allow-once")`. If the approval was already resolved (the gateway's own exec policy accepted it), the `"unknown or expired"` error is silently ignored.
-3. **Result** — Output arrives asynchronously via an `exec.finished` gateway event, processed in `handleEvent()` in `events.go`. The system message "running on gateway..." is replaced with the output or an error.
+Local execution runs straight through `sh -c` with no gateway involvement and no approval step.
+This is intentional — `!` is the user's own shell on their own machine — but it means the
+security model for `!` and `!!` is genuinely different: only remote exec passes through gateway
+policy. Don't assume approval semantics carry over from one to the other.
 
-If the gateway denies the request (`Decision == "deny"`), an error is shown immediately without waiting for the event.
+## Message queueing overlaps with exec
 
-## Message queueing during execution
-
-Both local and remote execution can overlap with in-flight chat messages. New user input while `m.sending == true` is held in `m.pendingMessages` and drained after the current exchange completes. See [sessions.md](sessions.md#message-queueing) for details.
+Both local and remote execution can overlap with in-flight chat messages; new input while
+`m.sending == true` is held in `m.pendingMessages` and drained afterwards. The rationale and
+details live in the `sessions` spec (message queueing).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,97 +1,65 @@
-# Agent Skills
+# Agent skills — lessons and rationale
 
-Agent skills are locally-stored prompt templates that users can inject into a chat session via slash commands (e.g. `/review`). They allow users to define reusable instructions without modifying gateway configuration. A skill can be invoked on its own (`/review`) or referenced mid-message (`use /review on the diff`) — see [Activation](#activation).
+The behavioural contract for agent skills lives in
+[`openspec/specs/skills/spec.md`](../openspec/specs/skills/spec.md) — the skill file format,
+startup discovery, catalog injection, activation and reference expansion, tab completion, and UI
+commands are all captured there as requirements and scenarios. This file keeps the hard-won
+lessons, pitfalls, and design rationale behind that flow: the "why it works this odd way" that
+the spec's requirements don't dwell on.
 
-## Skill file format
+## The agent only learns about skills once, on the first turn
 
-Each skill lives in its own directory and must contain a `SKILL.md` file with YAML frontmatter:
+The agent doesn't receive any skill information unless a message carries it. Rather than repeat
+the catalog on every message, the OpenClaw backend's `takePendingCatalog()`
+(`internal/backend/openclaw/openclaw.go`) prepends the listing to the **first user message** of
+each session and never again — a per-session flag, mutex-guarded against concurrent sends,
+prevents re-emission. The mutex isn't decoration: two sends racing on a fresh session would
+otherwise both see the flag unset and emit the catalog twice. The catalog lines ride the
+`System: ` prefix convention (see the `message-rendering` spec) so they render as system context
+rather than user prose.
 
-```
----
-name: review
-description: Perform a code review
----
+## Why activation rewrites the message instead of calling a command
 
-Please review the following code for correctness, style, and potential bugs. Be concise.
-```
+A `/review` token isn't dispatched as a command — `handleSlashCommand()` (`commands.go`) returns
+`(false, nil)` for any slash input whose first token names a known skill and lets it fall through
+to the normal send path. The rewriting happens in `expandSkillReferences(text, skills)`
+(`skills.go`), and its four rules exist because a skill reference can appear anywhere in free
+prose, not just at the start:
 
-Both `name` and `description` are required. The body is arbitrary markdown and is sent verbatim to the agent when the skill is activated.
+- Each unique matched skill produces one `<local-agent-skill name="...">…</local-agent-skill>`
+  block, ordered by first occurrence — so the agent sees the skill bodies inline rather than
+  having to fetch them.
+- Each `/skill-name` token in the prose is replaced with `the "<canonical-name>" skill above`.
+  The canonical name comes from the frontmatter regardless of how the user typed it, so
+  case-insensitive or shorthand references still point the agent at the right block.
+- Multiple distinct skills switch to a plural preamble and one envelope each — the agent needs to
+  know it has several to choose from.
+- A "bare" message — the whole trimmed input is a single `/skill-name` — collapses to `use the
+  "<name>" skill above immediately`, because there's no surrounding prose to weave the reference
+  into.
 
-## Discovery
+This is why the feature works mid-message (`use /review on the diff`) at all: activation is a
+text substitution over the message, not a command with its own send path.
 
-Skills are discovered at startup by `discoverSkills()` in `internal/tui/skills.go`. It scans these directories in order:
+## History strips the skill envelopes — and a known cosmetic divergence
 
-1. `<cwd>/.agents/skills/*/SKILL.md`
-2. `<cwd>/.agent/skills/*/SKILL.md`
-3. `~/.agents/skills/*/SKILL.md`
-4. `~/.agent/skills/*/SKILL.md`
+When restoring user messages from history, `stripLocalAgentSkillBlocks` (`history.go`) elides the
+preamble line and every `<local-agent-skill>...</local-agent-skill>` block, alongside the
+`System:` line strip used for the catalog — otherwise the machinery we injected would show up as
+if the user had typed it.
 
-CWD directories are scanned first — if two skills share the same `name`, the first one found wins. Symlinked skill directories are resolved via `os.Stat`.
+The known gotcha: the visible chat row shows the user-typed text live, but on history reload the
+rendered text reflects the post-substitution payload. The gateway has no record of the original
+prose, so there's nothing to restore it from. This is a cosmetic divergence only — the agent
+received the same thing either way.
 
-Discovery runs as a Bubble Tea command in `chatModel.Init()` and returns a `skillsDiscoveredMsg` which stores the skill list in `chatModel.skills`.
+## Discovery path ordering: CWD wins on purpose
 
-## Catalog injection
+`discoverSkills()` (`internal/tui/skills.go`) scans CWD paths (`.agents`/`.agent`) before home
+paths, and the first skill found for a given `name` wins. The ordering is deliberate: a
+project-local skill should be able to shadow a personal one of the same name, so per-project
+overrides beat your global defaults rather than the other way round. Symlinked skill directories
+are resolved via `os.Stat` so a linked skill folder is still picked up.
 
-The agent doesn't receive skill information unless it's explicitly included in a message. The chat layer passes the discovered skills through `ChatSendParams.Skills`; the OpenClaw backend's `takePendingCatalog()` (`internal/backend/openclaw/openclaw.go`) prepends a skill listing to the **first user message** of each session:
-
-```
-System: Available agent skills (activate with /skill-name):
-System:   - review: Perform a code review
-```
-
-Lines are prefixed with `System: ` using the convention described in [message-rendering.md](message-rendering.md). The catalog is sent only once per session — a per-session flag, mutex-guarded against concurrent sends, prevents re-emission. See [backend_openclaw.md](backend_openclaw.md) for the backend-side detail.
-
-## Activation
-
-A `/skill-name` token is recognised when it sits at the start of a message *or* mid-prose preceded by whitespace, with token characters `[A-Za-z0-9_-]`. Matching is case-insensitive.
-
-`handleSlashCommand()` (`commands.go`) returns `(false, nil)` for any `/`-prefixed input whose first token names a known skill, deferring to the regular Enter-handler send path. Unknown slashes that aren't built-ins still produce an error system message there.
-
-The send path runs `expandSkillReferences(text, skills)` (`skills.go`) before dispatching. When at least one matched skill is found it produces a payload of the form:
-
-```
-Please use the following skill:
-
-<local-agent-skill name="review">
-<skill body>
-</local-agent-skill>
-
-run the "review" skill above on the diff
-```
-
-Rules applied by `expandSkillReferences`:
-
-- Each unique matched skill produces one `<local-agent-skill name="...">…</local-agent-skill>` block. Order follows first-occurrence in the prose.
-- Each `/skill-name` token in the prose is replaced with `the "<canonical-name>" skill above`. The canonical name comes from the skill's frontmatter, regardless of how the user typed it.
-- Multiple distinct skills produce a plural preamble (`Please use the following skills:`) and one envelope per skill.
-- A "bare" message — the entire trimmed input is a single `/skill-name` — collapses the prose to `use the "<name>" skill above immediately`.
-
-The visible chat row shows the user-typed text. On history reload the rendered text reflects the post-substitution payload (the gateway has no record of the original prose) — this is a known cosmetic divergence.
-
-`stripLocalAgentSkillBlocks` (`history.go`) elides the preamble line and every `<local-agent-skill>...</local-agent-skill>` block when restoring user messages from history, alongside the `System:` line strip used for the catalog.
-
-### Tab completion
-
-Skill names participate in the same completion menu as built-in slash commands. `matchingSlashCommands(prefix)` (`completion.go`) returns every match for the current prefix — built-ins in curated order, then skills — and the menu rendered between the viewport and input lists them all. Tab extends the input to the longest common prefix; if multiple skills share a prefix, repeated Tab cycles them (Shift+Tab cycles back). Mid-message completion still works: `use /rev<TAB>` resolves the slash token under the cursor regardless of position. See [commands.md → Tab completion](commands.md#tab-completion) for the cycle/LCP machinery.
-
-Completion only fires when the cursor sits at the end of the slash token (next character is whitespace or end-of-buffer); inserting mid-token would clobber the trailing characters and `findSlashTokenAt` returns ok=false.
-
-## UI commands
-
-| Command | Behaviour |
-|---|---|
-| `/skills` | Lists all discovered skills with their descriptions |
-| `/<name>` | Activates the named skill (alone or with prose) |
-| `/help` | Mentions how many skills are loaded |
-
-The count of loaded skills also appears in the `/stats` table.
-
-## Adding a new skill
-
-Create a directory under one of the scanned paths:
-
-```
-~/.agents/skills/my-skill/SKILL.md
-```
-
-Skills are discovered once at startup — a restart is required to pick up new files.
+Discovery runs once at startup, so newly added skills need a restart to appear — there's no
+watcher.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,80 @@
+schema: spec-driven
+
+# Project context (shown to AI when creating artifacts).
+context: |
+  Project: lucinate — a terminal UI (TUI) chat client for backend agent runtimes,
+  written in Go and built on bubbletea (charmbracelet).
+
+  Tech stack:
+    - Go (module `lucinate`; single binary, version stamped from git tags)
+    - bubbletea / bubbles / lipgloss for the TUI
+    - `github.com/a3tai/openclaw-go` gateway SDK, consumed as a local `replace` (`../openclaw-go`)
+    - Build/test via Makefile (`make build`, `make test`, `make coverage`, `make fmt`)
+
+  Architecture:
+    - The TUI talks to backends through a uniform `backend.Backend` interface, so chat /
+      sessions / commands code paths are backend-agnostic. Optional capabilities are exposed
+      as sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`,
+      `UsageBackend`, `DeviceTokenAuth`, `APIKeyAuth`) that a backend may or may not implement.
+    - Three backends ship: OpenClaw (gateway over WebSocket), OpenAI-compatible
+      (`/v1/chat/completions` for Ollama, vLLM, LM Studio, OpenAI proper), and Hermes
+      (`/v1/responses` chaining, server-side state).
+    - Persisted state lives under `~/.lucinate/` (connections, secrets, identity, agents, config).
+    - Key packages: `internal/config`, `internal/backend` (+ `openclaw`, `openai` adapters),
+      `internal/client` (gateway SDK wrapper, WebSocket supervisor), `internal/tui` (views).
+
+  Naming conventions:
+    - This repo must contain NO "mobile", "ios", or "android" references in specs, code,
+      commits, or PRs. Refer to "native platforms" instead.
+    - British English spelling in prose (behaviour, colour, synchronise).
+    - Conventional-commit style for commits and branch names (feat/…, fix/…).
+    - Never edit CHANGELOG.md by hand — the release process owns it.
+
+  Keyboard conventions (cross-view; every new manager/picker/form should follow these so the
+  user's mental model carries between screens — these are descriptive of the code today, not
+  aspirational):
+    Action keys:
+      n=New, e=Edit, x=Delete (NOT d — d is Duplicate), d=Duplicate, r=Refresh (always
+      available), R=Retry (only after an error), t=Toggle, T=Transcript, !=Run now,
+      a=Toggle agent filter, c=Connections, s=Settings, k=View crons (agent picker, OpenClaw
+      only), Space=Toggle a boolean config item.
+    Rationale worth preserving:
+      - x for delete because d is reserved for duplicate; the two managers share a vocabulary.
+      - lowercase r = refresh, uppercase R = retry; never reverse (terminals that drop shift
+        would land on the wrong action). Where retry does not apply, only r is bound.
+      - ! for run-now (not R) because the case-sensitive r/R pair misfires on terminals that
+        drop shift on letters.
+      - In the agent picker, k is "View crons", a deliberate deviation from k/j list-nav; the
+        picker drops k from up-navigation rather than shadowing it (↑ still moves up).
+    Confirms: y/Y confirm a destructive action, n/N or Esc decline; a confirm is always its own
+      substate so the prompt UI replaces the help row before the user presses a key.
+    Navigation: Esc = back/cancel (always "step backwards"), Enter = select/submit,
+      Up/Down or k/j move in a list, Left/Right or h/l adjust numeric config items,
+      Tab/Shift+Tab cycle form focus.
+    Form keys: Alt+S = Save (Ctrl+S kept only as a defensive alias — many terminals treat
+      Ctrl+S as XOFF and never deliver it), Alt+Enter = newline in a multi-line field,
+      Enter = submit, Esc = cancel without saving.
+    Reserved keys (avoid for app actions — the terminal or readline layer consumes them):
+      Ctrl+S (XOFF), Ctrl+R (readline reverse-search), Ctrl+W (delete word), and Ctrl+<letter>
+      in general. Prefer Alt+<letter> for app-level shortcuts (e.g. Alt+M for routine mode).
+    Discovery: every manager view exposes its bindings via `Actions() []Action`; when adding a
+      binding, register it in `Actions()` for the substate AND wire it in `handleKey` so the
+      help line, action drawer, and key dispatch stay in sync (`TriggerAction(id)` lets a menu
+      invoke the same code path as the keystroke).
+
+  Testing:
+    - Add or update tests whenever behaviour changes; capture behaviour a user or caller
+      depends on, not coverage for its own sake. Run `make test` before committing.
+    - Levels: plain unit tests for pure logic; drive `Update` directly for model state
+      transitions; `teatest/v2` for rendered output; build-tag-guarded integration tests for
+      anything needing a real backend (`//go:build integration`, `integration_openai`).
+
+# Per-artifact rules (optional).
+rules:
+  proposal:
+    - Refer to the app as a "native platform" client where relevant; never say mobile/iOS/Android.
+    - Use British English spelling.
+  specs:
+    - State each requirement as one observable behaviour using SHALL/MUST (RFC 2119). Split
+      any requirement with "and also" clauses into separate requirements.
+    - Every requirement has at least one `#### Scenario:` with GIVEN/WHEN/THEN bullets.

--- a/openspec/specs/agents/spec.md
+++ b/openspec/specs/agents/spec.md
@@ -1,0 +1,365 @@
+# Agent Picker Specification
+
+## Purpose
+
+The agent picker (`selectModel` in `internal/tui/select.go`) is shown after a connection is
+established — either directly on startup when the connection is unambiguous, or after the user
+picks one from the connections picker (see the `connections` spec). It loads the list of
+configured agents from the active backend and either presents a selection UI or auto-selects
+when only one agent exists. This spec covers where agents come from, how the list is loaded,
+filtered, and navigated, the managed-mode and OpenClaw action affordances, auto-selection
+drivers, and the create, select, and delete flows.
+
+## Requirements
+
+### Requirement: Picker entry and managed-mode actions
+
+The agent picker SHALL be shown after a connection is established — either directly on startup
+when the connection is unambiguous, or after the user picks one from the connections picker (see
+the `connections` spec). In managed mode the picker SHALL surface a **Connections** action (key
+`c`) so the user can switch connection without first entering chat, and a **Settings** action
+(key `s`, gated on the same managed-mode flag) that emits `showConfigMsg{}` to open the settings
+screen. On OpenClaw connections the picker SHALL surface a **View crons** action (key `k`, gated
+on `backend.CronBackend`) that emits `showCronsMsg{filterAgentID: ""}` to open the cron browser
+across all agents — the one place to reach crons before entering a chat. `k` SHALL be dropped
+from the list's up-navigation to make room (`↑` still scrolls up); see the `key-conventions`
+spec.
+
+#### Scenario: Connections action in managed mode
+
+- **GIVEN** the picker is running in managed mode
+- **WHEN** the user presses `c`
+- **THEN** the connections picker is opened so the user can switch connection without first entering chat
+
+#### Scenario: Settings action in managed mode
+
+- **GIVEN** the picker is running in managed mode
+- **WHEN** the user presses `s`
+- **THEN** `showConfigMsg{}` is emitted to open the settings screen
+
+#### Scenario: View crons action on an OpenClaw connection
+
+- **GIVEN** an OpenClaw connection whose backend implements `backend.CronBackend`
+- **WHEN** the user presses `k`
+- **THEN** `showCronsMsg{filterAgentID: ""}` is emitted to open the cron browser across all agents
+- **AND** `k` is dropped from the list's up-navigation while `↑` still scrolls up
+
+### Requirement: Agent source per backend
+
+Agents SHALL come from the active backend (`backend.Backend.ListAgents`). For OpenClaw, that is
+the gateway's agent list. For OpenAI-compatible connections, agents are local — see the
+`connections` spec (OpenAI agent storage). For Hermes connections the list SHALL be one synthetic
+entry (the connected profile is the agent — see the `backend-hermes` spec, one-profile-one-agent)
+and the create-agent affordance SHALL be hidden via `Capabilities.AgentManagement`.
+
+#### Scenario: OpenClaw agents come from the gateway
+
+- **GIVEN** an OpenClaw connection
+- **WHEN** the picker lists agents
+- **THEN** the agents are the gateway's agent list via `backend.Backend.ListAgents`
+
+#### Scenario: Hermes shows a single synthetic agent
+
+- **GIVEN** a Hermes connection
+- **WHEN** the picker lists agents
+- **THEN** the list is one synthetic entry for the connected profile
+- **AND** the create-agent affordance is hidden via `Capabilities.AgentManagement`
+
+### Requirement: Loading agents
+
+The picker SHALL load agents via `loadAgents()`, which calls `client.ListAgents()` and returns an
+`agentsLoadedMsg`. Each agent SHALL be an `agentItem` wrapping a `protocol.AgentSummary`. The
+list SHALL be displayed using a Bubble Tea list component with a custom delegate that shows the
+agent name, falling back to ID if no name is set.
+
+#### Scenario: Agents loaded into the list
+
+- **WHEN** `loadAgents()` runs
+- **THEN** `client.ListAgents()` is called and an `agentsLoadedMsg` is returned
+- **AND** each agent is an `agentItem` wrapping a `protocol.AgentSummary` shown by name, falling back to ID when no name is set
+
+### Requirement: Fuzzy filtering with opt-in activation
+
+The picker SHALL enable the Bubble Tea list's built-in filtering with the same fuzzy matcher
+(`fuzzyFilter`) as the model picker (`internal/tui/models.go`). Pressing `/` SHALL open the
+filter, typing SHALL narrow it, and `esc` SHALL clear it. `agentItem.FilterValue()` SHALL
+concatenate the agent's name and ID so a query matches either — typing part of a display name or
+part of the raw agent ID both hit the same agent. Unlike the model picker, the agent picker SHALL
+start in plain list mode rather than dropping straight into filtering: the single-letter action
+shortcuts (`n` new, `d` delete, `c` connections) must stay reachable, so filtering is opt-in via
+`/`.
+
+The following behaviours SHALL hold:
+
+- **Keystroke routing.** While the filter input is focused (`list.FilterState() == list.Filtering`),
+  `handleKey` SHALL forward every key except `enter` to the list so characters that collide with
+  action shortcuts (e.g. `n`) type into the query instead of firing the action. Outside filtering,
+  the normal action dispatch applies.
+- **Enter selects from the filter.** `enter` SHALL pick the highlighted agent from any filter
+  state, so the user can type-to-narrow and pick in one keystroke rather than first applying the
+  filter (the bubbles default while typing). When the filter matches nothing, `enter` SHALL fall
+  through to the list.
+- **Input focus.** `selectModel.filtering()` SHALL report whether the filter is focused;
+  `app.go`'s `computeWantsInput()` consults it (alongside the create-agent form) so the app-level
+  `q`-to-quit shortcut and the embedder input-focus signal treat a typed `q` as filter text rather
+  than a quit request.
+- **Reset on re-entry.** The picker reuses one `selectModel` across navigation, so leaving for
+  another screen (config, connections, chat) and coming back would otherwise restore a stale
+  narrowed view. `AppModel.Update` SHALL call `selectModel.resetFilter()` on every transition
+  *into* `viewSelect`, clearing the query so the list reopens showing every agent. It SHALL be a
+  no-op when no filter was active.
+
+#### Scenario: Filter matches name or ID
+
+- **GIVEN** the filter is open
+- **WHEN** the user types part of a display name or part of the raw agent ID
+- **THEN** `agentItem.FilterValue()` concatenates name and ID so both queries hit the same agent
+
+#### Scenario: Filtering is opt-in
+
+- **GIVEN** the agent picker has just opened
+- **WHEN** no key has been pressed
+- **THEN** it is in plain list mode with the `n`, `d`, and `c` action shortcuts reachable, and filtering starts only after `/`
+
+#### Scenario: Colliding key typed while filtering
+
+- **GIVEN** the filter input is focused (`list.FilterState() == list.Filtering`)
+- **WHEN** the user presses a key such as `n`
+- **THEN** `handleKey` forwards it to the list so it types into the query instead of firing the action
+
+#### Scenario: Enter picks from an active filter
+
+- **GIVEN** the filter is active and narrows to at least one match
+- **WHEN** the user presses `enter`
+- **THEN** the highlighted agent is picked in one keystroke
+- **AND** when the filter matches nothing, `enter` falls through to the list
+
+#### Scenario: Typed q treated as filter text
+
+- **GIVEN** the filter input is focused
+- **WHEN** the user types `q`
+- **THEN** `computeWantsInput()` consults `selectModel.filtering()` so `q` is filter text, not a quit request
+
+#### Scenario: Filter reset on re-entry
+
+- **GIVEN** a narrowed filter was left active and the user navigated away to config, connections, or chat
+- **WHEN** the app transitions back into `viewSelect`
+- **THEN** `AppModel.Update` calls `selectModel.resetFilter()` so the list reopens showing every agent
+- **AND** it is a no-op when no filter was active
+
+### Requirement: Auto-selection of a single agent and after create
+
+If exactly one agent is returned, the picker SHALL select it automatically without user
+interaction and create a session immediately. The same auto-select SHALL fire after creating a
+new agent — the picker bypasses the list and proceeds straight to chat.
+
+#### Scenario: Single agent auto-selected
+
+- **GIVEN** exactly one agent is returned
+- **WHEN** the list loads
+- **THEN** that agent is selected automatically without user interaction and a session is created immediately
+
+#### Scenario: Auto-select after create
+
+- **GIVEN** a new agent was just created
+- **WHEN** the picker reloads
+- **THEN** it bypasses the list and proceeds straight to chat with the new agent
+
+### Requirement: Command-line agent auto-pick
+
+`lucinate chat --agent <name>` SHALL be a third auto-pick driver: `selectModel.autoPickName`
+runs an ID-then-case-insensitive-name match on the first `agentsLoadedMsg` and selects the
+matching agent. It SHALL run **before** the single-agent and post-create branches, so a `--agent`
+mismatch in a single-agent connection surfaces as an error banner on the picker rather than
+silently picking the only available agent. The override SHALL be one-shot: cleared on consume so
+a later `agentsLoadedMsg` (e.g. after a user-driven create) does not re-fire it. See the
+`chat-launch` spec for the full override-consumption story.
+
+#### Scenario: --agent selects a matching agent
+
+- **GIVEN** `lucinate chat --agent <name>` was invoked
+- **WHEN** the first `agentsLoadedMsg` arrives
+- **THEN** `selectModel.autoPickName` runs an ID-then-case-insensitive-name match and selects the matching agent, before the single-agent and post-create branches
+
+#### Scenario: --agent mismatch in a single-agent connection
+
+- **GIVEN** a single-agent connection and a `--agent` name that matches no agent
+- **WHEN** the picker resolves the auto-pick
+- **THEN** an error banner is shown on the picker rather than silently picking the only available agent
+
+#### Scenario: Override is one-shot
+
+- **GIVEN** the `--agent` override was consumed on the first `agentsLoadedMsg`
+- **WHEN** a later `agentsLoadedMsg` arrives (e.g. after a user-driven create)
+- **THEN** the override does not re-fire because it was cleared on consume
+
+### Requirement: Selecting an agent
+
+Pressing Enter on a highlighted agent SHALL call `client.CreateSession(agentID, key)`. On
+success, `sessionCreatedMsg` SHALL carry the new session key and the app SHALL transition to the
+chat view (`newChatModel(...)`). See the `sessions` spec for the session lifecycle from this
+point. The `/agent <name>` slash command SHALL bypass the picker entirely and reach the same
+`sessionCreatedMsg` path — see the `commands` spec (agent). From the chat input, `/agent `
+followed by Tab SHALL autocomplete against the cached agent list.
+
+#### Scenario: Enter creates a session
+
+- **GIVEN** an agent is highlighted
+- **WHEN** the user presses Enter
+- **THEN** `client.CreateSession(agentID, key)` is called and, on success, `sessionCreatedMsg` carries the new session key and the app transitions to the chat view via `newChatModel(...)`
+
+#### Scenario: /agent slash command bypasses the picker
+
+- **WHEN** the user runs `/agent <name>`
+- **THEN** the picker is bypassed entirely and the same `sessionCreatedMsg` path is reached
+
+#### Scenario: Tab autocompletes agent names
+
+- **GIVEN** the chat input contains `/agent ` followed by Tab
+- **THEN** the name is autocompleted against the cached agent list
+
+### Requirement: Creating an agent
+
+Pressing `n` in the picker SHALL switch to a creation form (`subStateCreate`). The form's shape
+SHALL be driven by the active backend's `Capabilities.AgentWorkspace` flag (see
+`backend.Capabilities`).
+
+**OpenClaw** (workspace-aware):
+
+- **Name** — must start with a lowercase letter and contain only alphanumeric characters and
+  hyphens. Validated on submit.
+- **Workspace** — a filesystem path that is auto-suggested but editable.
+
+On submit, `Backend.CreateAgent` SHALL be called with both fields. The gateway creates the agent
+and seeds an `IDENTITY.md` file in the workspace.
+
+**OpenAI-compatible** (local-agent backends):
+
+- **Name** — same validation rules as above.
+- The workspace field SHALL be hidden. On submit, the backend seeds `IDENTITY.md` and `SOUL.md`
+  with defaults under `~/.lucinate/agents/<connection>/<agent>/`. Users edit those files on disk to
+  customise the agent's identity and behaviour — see the `connections` spec (OpenAI agent storage).
+
+On success the agent list SHALL be reloaded and the new agent SHALL be auto-selected (see the
+auto-selection requirement). On failure the form SHALL stay open and the error SHALL be shown so
+the user can correct and retry.
+
+#### Scenario: OpenClaw create with workspace
+
+- **GIVEN** an OpenClaw connection and the create form (`subStateCreate`)
+- **WHEN** the user submits a valid name (starts with a lowercase letter, alphanumeric and hyphens only) and an auto-suggested but editable workspace path
+- **THEN** `Backend.CreateAgent` is called with both fields and the gateway seeds an `IDENTITY.md` file in the workspace
+
+#### Scenario: OpenAI-compatible create hides workspace
+
+- **GIVEN** an OpenAI-compatible connection where `Capabilities.AgentWorkspace` is not set
+- **WHEN** the create form is shown and a valid name submitted
+- **THEN** the workspace field is hidden and the backend seeds `IDENTITY.md` and `SOUL.md` with defaults under `~/.lucinate/agents/<connection>/<agent>/`
+
+#### Scenario: Create succeeds
+
+- **WHEN** agent creation succeeds
+- **THEN** the agent list is reloaded and the new agent is auto-selected
+
+#### Scenario: Create fails
+
+- **WHEN** agent creation fails
+- **THEN** the form stays open and the error is shown so the user can correct and retry
+
+### Requirement: Deleting an agent
+
+Pressing `d` on a highlighted agent SHALL enter `subStateConfirmDelete`. The substate SHALL be
+gated by the same `Capabilities.AgentManagement` flag as create — Hermes connections never expose
+it because profiles are server-managed. The view SHALL be deliberately loud: a red header with
+the agent's name, a bullet list of what's about to be removed (metadata, transcript, and on
+OpenClaw bindings), the local backup path, a `Delete files | Keep files` toggle, and a textinput
+labelled with the agent's display name.
+
+The following behaviours SHALL hold:
+
+- **Type-to-confirm.** `confirm-delete` SHALL only be emitted from `Actions()` when the typed name
+  matches the agent's display name (case-insensitive, whitespace-trimmed) and no request is in
+  flight. That presence-toggle is the disable mechanism for native-platform embedders — the
+  `Action` struct has no `Enabled` flag.
+- **Keep files toggle.** `tab` SHALL flip `m.keepFiles`, which becomes `!DeleteFiles` on the
+  `backend.DeleteAgentParams` sent to the backend. It SHALL default to **keep files**
+  (`keepFiles=true` → `DeleteFiles=false`), so a mistaken confirmation preserves the agent's file
+  content — the user has to toggle off to destroy it. The view's description line SHALL switch with
+  the toggle so the user can read what the current mode will do before pressing enter.
+- **Pending state is snapshotted** (`pendingDeleteID`, `pendingDeleteName`) at substate entry from
+  the passed `agentItem`, never re-read from `list.SelectedItem()` afterwards. A list re-render
+  mid-flight cannot resolve the destructive cmd to the wrong agent.
+- **Esc** SHALL trigger `cancel-delete` and clear all pending state. **Enter** without a matching
+  name SHALL be a no-op.
+- **Plain `d` is not bound** inside the substate because it's a printable character the user might
+  type as part of the agent name.
+
+`agentDeletedMsg` SHALL carry the result. On success the picker SHALL clear pending state and
+reload via `loadAgents()`. On error `pendingDeleteName` SHALL be preserved so the user can retry
+without retyping; `deleteErr` SHALL surface inline. Keystrokes SHALL be ignored while
+`m.deleting` is true — the network call has already left.
+
+The destructive vs preserve interpretation is per-backend:
+
+- **OpenClaw** — `Backend.DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`,
+  which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` to the gateway. The
+  pointer is always set explicitly — the gateway's implicit "preserve files" default never applies.
+- **OpenAI-compatible** — when `DeleteFiles=true` the agent directory is wiped via
+  `AgentStore.Delete` (`os.RemoveAll`); when false it's moved to `<root>/.archive/<id>-<unixts>/`
+  via `AgentStore.Archive` so IDENTITY.md, SOUL.md, and history.jsonl are recoverable on disk. See
+  the `backend-openai` spec (agent storage).
+- **Hermes** — `DeleteAgent` returns a clear error pointing at `hermes profile delete`. The UI gate
+  (AgentManagement=false) means the user shouldn't reach it; the reject is defensive.
+
+#### Scenario: Confirm-delete gated on typed name
+
+- **GIVEN** the `subStateConfirmDelete` view is showing
+- **WHEN** the typed name matches the agent's display name (case-insensitive, whitespace-trimmed) and no request is in flight
+- **THEN** `confirm-delete` is emitted from `Actions()`; otherwise the action is absent (the presence-toggle disable mechanism, since `Action` has no `Enabled` flag)
+
+#### Scenario: Keep-files default preserves content
+
+- **GIVEN** the confirm-delete view with its default toggle
+- **WHEN** the user confirms without toggling
+- **THEN** `keepFiles=true` → `DeleteFiles=false` so the agent's file content is preserved, and the user must press `tab` to toggle off to destroy it, with the description line switching to match
+
+#### Scenario: Pending agent snapshotted against re-render
+
+- **GIVEN** delete confirmation was entered from a passed `agentItem`
+- **WHEN** the list re-renders mid-flight
+- **THEN** `pendingDeleteID` and `pendingDeleteName` remain the snapshotted values, never re-read from `list.SelectedItem()`, so the destructive cmd cannot resolve to the wrong agent
+
+#### Scenario: Cancel and no-op enter
+
+- **WHEN** the user presses Esc
+- **THEN** `cancel-delete` fires and all pending state is cleared
+- **AND** pressing Enter without a matching name is a no-op, and plain `d` is not bound inside the substate
+
+#### Scenario: Delete succeeds
+
+- **WHEN** `agentDeletedMsg` reports success
+- **THEN** the picker clears pending state and reloads via `loadAgents()`
+
+#### Scenario: Delete fails
+
+- **WHEN** `agentDeletedMsg` reports an error
+- **THEN** `pendingDeleteName` is preserved for retry without retyping and `deleteErr` surfaces inline, with keystrokes ignored while `m.deleting` is true
+
+#### Scenario: OpenClaw delete sets the files pointer explicitly
+
+- **GIVEN** an OpenClaw connection
+- **WHEN** an agent is deleted
+- **THEN** `Backend.DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)` sending `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}`, with the pointer always set so the gateway's implicit preserve-files default never applies
+
+#### Scenario: OpenAI-compatible archive vs wipe
+
+- **GIVEN** an OpenAI-compatible connection
+- **WHEN** an agent is deleted with `DeleteFiles=true`
+- **THEN** the agent directory is wiped via `AgentStore.Delete` (`os.RemoveAll`)
+- **AND** when `DeleteFiles=false` it is moved to `<root>/.archive/<id>-<unixts>/` via `AgentStore.Archive` so IDENTITY.md, SOUL.md, and history.jsonl are recoverable on disk
+
+#### Scenario: Hermes delete is defensively rejected
+
+- **GIVEN** a Hermes connection where the UI gate `AgentManagement=false` should keep the user away
+- **WHEN** `DeleteAgent` is nonetheless reached
+- **THEN** it returns a clear error pointing at `hermes profile delete`

--- a/openspec/specs/authentication/spec.md
+++ b/openspec/specs/authentication/spec.md
@@ -1,0 +1,265 @@
+# Authentication Specification
+
+## Purpose
+
+Authenticate lucinate to its backends. For OpenClaw connections this is device
+pairing — no usernames or passwords: each device holds a persistent Ed25519 keypair
+and an administrator approves it on the gateway. The OpenAI-compatible and Hermes
+backends instead use a simpler bearer-token (API key) model (see the `connections` and
+`backend-hermes` specs). This spec covers the OpenClaw device-pairing flow, identity and
+token storage, interactive auth recovery, automatic reconnection, and operator scopes.
+
+## Requirements
+
+### Requirement: OpenClaw device-pairing authentication model
+
+For OpenClaw connections the system SHALL authenticate by device pairing rather than
+usernames or passwords. Each device generates a persistent Ed25519 keypair that acts as a
+stable device identity across restarts, and an administrator approves that device on the
+gateway before it can operate. Bootstrap tokens were removed in v0.10.2; device pairing is
+the only setup path.
+
+#### Scenario: No password prompt
+- **WHEN** a user connects to an OpenClaw gateway
+- **THEN** the system authenticates using the device's Ed25519 identity and (once issued) a device token
+- **AND** never prompts for a username or password
+
+### Requirement: Gateway URL configuration and WebSocket derivation
+
+The system SHALL accept an OpenClaw gateway URL from the connections picker (the default UX)
+or from the `OPENCLAW_GATEWAY_URL` environment variable (auto-added on first run), which may
+be set in the shell or in a `.env` file in the working directory. The system SHALL derive the
+WebSocket endpoint automatically by replacing `https://` with `wss://` (or `http://` with
+`ws://`) and appending `/ws`. Both values are held in `internal/config/config.go` as
+`Config.GatewayURL` and `Config.WSURL`. Resolution order is covered by the `connections` spec.
+
+#### Scenario: WebSocket endpoint derived from an HTTPS gateway URL
+- **GIVEN** `OPENCLAW_GATEWAY_URL=https://your-gateway-host`
+- **WHEN** the client prepares to connect
+- **THEN** `Config.WSURL` is `wss://your-gateway-host/ws`
+
+#### Scenario: WebSocket endpoint derived from an HTTP gateway URL
+- **GIVEN** a gateway URL beginning `http://`
+- **WHEN** the client prepares to connect
+- **THEN** the scheme becomes `ws://` and `/ws` is appended
+
+### Requirement: Per-endpoint device identity generation and storage
+
+On first run the system SHALL create an Ed25519 keypair via `identity.Store.LoadOrGenerate()`
+under `~/.lucinate/identity/<endpoint>/`, where `<endpoint>` is derived from the gateway URL's
+host and port (e.g. `gateway.example.com` or `localhost_8789`). Each gateway endpoint SHALL get
+its own keypair and device token, so switching `OPENCLAW_GATEWAY_URL` does not overwrite
+existing credentials. The keypair SHALL be reused across restarts as a stable device identity.
+
+#### Scenario: Keypair generated on first run
+- **GIVEN** no identity exists for the target endpoint
+- **WHEN** the client starts
+- **THEN** `LoadOrGenerate()` creates an Ed25519 keypair under `~/.lucinate/identity/<endpoint>/`
+
+#### Scenario: Switching gateways preserves existing credentials
+- **GIVEN** an existing keypair and device token for endpoint A
+- **WHEN** `OPENCLAW_GATEWAY_URL` is changed to endpoint B
+- **THEN** endpoint B gets its own keypair and token
+- **AND** endpoint A's credentials are left intact
+
+### Requirement: First-run pairing flow
+
+On first connection with a device that has no token, the system SHALL guide the user through
+gateway approval and obtain a device token without requiring a process restart. The flow is:
+
+1. Running `lucinate` connects to the gateway with the device identity but no token; the
+   gateway responds `NOT_PAIRED` and registers a pending pairing request.
+2. The connecting view enters its `subStatePairingRequired` modal (`internal/tui/connecting.go`)
+   with on-screen instructions. On the gateway host an administrator approves the device with
+   `openclaw device list --pending` then `openclaw device approve <device-id>`.
+3. The user presses Enter in the modal. `authResolvedMsg{}` triggers `retryConnect`
+   (`internal/tui/app.go`), which re-invokes `Connect` on the same backend. The gateway accepts
+   the connection and issues a fresh device token in `hello.Auth.DeviceToken`, which
+   `client.dial` persists via `store.SaveDeviceToken`.
+4. `dial` closes the bootstrap connection and re-dials with the freshly-issued token (see the
+   re-dial requirement). The TUI advances to the agent picker with no process restart.
+
+The token save SHALL be non-fatal — if it fails, a warning is logged but the session continues.
+
+#### Scenario: Unpaired device on first connect
+- **GIVEN** a device with no stored token
+- **WHEN** it connects to the gateway
+- **THEN** the gateway responds `NOT_PAIRED` and registers a pending pairing request
+- **AND** the connecting view shows the `subStatePairingRequired` modal with approval instructions
+
+#### Scenario: Retry after administrator approval
+- **GIVEN** the pairing-required modal is showing and an administrator has run `openclaw device approve <device-id>`
+- **WHEN** the user presses Enter
+- **THEN** `authResolvedMsg{}` triggers `retryConnect`, the gateway issues a token in `hello.Auth.DeviceToken`, and it is persisted via `store.SaveDeviceToken`
+- **AND** the TUI advances to the agent picker without a restart
+
+#### Scenario: Token save fails
+- **WHEN** persisting the newly issued device token fails
+- **THEN** a warning is logged
+- **AND** the session continues
+
+### Requirement: Token re-dial after first-time pairing
+
+When the bootstrap connect for a freshly approved device presented an empty token (it
+authenticated by Ed25519 device-key signature alone) AND the gateway returned a non-empty
+`hello.Auth.DeviceToken`, the system SHALL persist that token, close the bootstrap
+`gateway.Client`, and dial a second time so the surviving connection carries the issued token.
+This is required because the OpenClaw protocol expects scoped operations to run on a connection
+that authenticated *with* the token at connect time; reusing the bootstrap connection for scoped
+RPCs leaves `sessions.create` silently stalled. On subsequent launches (token already on disk →
+bootstrap presents it → gateway returns no new one) the second dial SHALL be skipped. Both
+branches are pinned by tests in `internal/client/dial_test.go`. The TUI also wraps
+`CreateSession` (`internal/tui/app.go`) in a per-call `context.WithTimeout` derived as `2×` the
+configured connect timeout, so any future stall in this region surfaces as a UI error in the
+agent picker rather than freezing the view.
+
+#### Scenario: Second dial after first pairing
+- **GIVEN** `dial` presented an empty token AND the gateway returned a non-empty `hello.Auth.DeviceToken`
+- **WHEN** the handshake completes
+- **THEN** the token is persisted, the bootstrap `gateway.Client` is closed, and a second dial is made carrying the issued token
+
+#### Scenario: No re-dial on subsequent launches
+- **GIVEN** a device token already on disk that the bootstrap presents at connect
+- **WHEN** the gateway returns no new token
+- **THEN** the second dial is skipped
+
+#### Scenario: Session creation stall surfaces as a UI error
+- **WHEN** `CreateSession` does not return within `2×` the configured connect timeout
+- **THEN** the agent picker shows a UI error rather than freezing
+
+### Requirement: Subsequent-run authentication
+
+On runs after the first pairing, the system SHALL authenticate using the stored identity and
+token without re-pairing:
+
+1. Load `OPENCLAW_GATEWAY_URL` from the environment, or use a saved connection from
+   `~/.lucinate/connections.json`.
+2. Load the Ed25519 identity and stored device token from `~/.lucinate/identity/<endpoint>/`.
+3. Open a WebSocket connection with the identity and token; the gateway SDK
+   (`github.com/a3tai/openclaw-go`) attaches the token to all API calls.
+4. On a successful `Hello` handshake, save any refreshed token back to disk; no second dial is
+   needed because the connection already authenticated with a token.
+5. Proceed to the agent picker.
+
+If the token is expired or revoked, the gateway SHALL reject the connection and the connecting
+view SHALL open the appropriate auth-recovery modal.
+
+#### Scenario: Valid stored token
+- **GIVEN** a stored Ed25519 identity and valid device token for the endpoint
+- **WHEN** the client connects
+- **THEN** the `Hello` handshake succeeds, any refreshed token is saved, and the TUI proceeds to the agent picker
+
+#### Scenario: Expired or revoked token
+- **GIVEN** a stored token that the gateway no longer accepts
+- **WHEN** the client connects
+- **THEN** the gateway rejects the connection and the connecting view opens the matching auth-recovery modal
+
+### Requirement: Interactive auth recovery on connect
+
+When `Connect` fails with a recognised auth error, `runConnect` (`internal/tui/app.go`) SHALL
+classify it via the `isNotPairedErr` / `isTokenMismatchErr` / `isTokenMissingErr` / `isAPIKeyErr`
+predicates and `handleConnectResult` SHALL open the matching modal sub-state in
+`internal/tui/connecting.go`. All four flows happen inside the running TUI as modal text inputs,
+not stdin; cancellation routes back to the connections picker and the active backend is closed
+before the next pick. The four cases:
+
+- **Not paired** (`NOT_PAIRED`) — pairing-required modal: instructions to run
+  `openclaw device approve` on the gateway host, then Enter to retry.
+- **Token mismatch** (`gateway token mismatch`) — the stored device token is no longer valid for
+  this gateway (e.g. the device was removed and re-added). The modal offers three choices, each
+  routed through the `DeviceTokenAuth` sub-interface on the live backend: (1) clear the stored
+  token and retry pairing (`ClearToken`, default); (2) reset the device identity entirely (new
+  keypair) and retry pairing (`ResetIdentity`); (3) cancel back to the connections picker.
+- **Token missing** (`gateway token missing`) — text prompt for a pre-shared token; submission
+  stores it via `DeviceTokenAuth.StoreToken` and the connect is retried.
+- **API key required** (HTTP 401/403 from any `/v1` request on OpenAI-compat or Hermes
+  connections) — text prompt for an API key; submission stores it via `APIKeyAuth.StoreAPIKey`.
+
+#### Scenario: Token mismatch offers three choices
+- **GIVEN** a connect fails with `gateway token mismatch`
+- **WHEN** `handleConnectResult` opens the modal
+- **THEN** the user is offered clear-token-and-retry (default), reset-identity-and-retry, and cancel — each routed through the `DeviceTokenAuth` sub-interface
+
+#### Scenario: API key prompt on 401/403
+- **GIVEN** an OpenAI-compat or Hermes `/v1` request returns HTTP 401 or 403
+- **WHEN** the connect result is handled
+- **THEN** a modal text input prompts for an API key and stores it via `APIKeyAuth.StoreAPIKey` before retrying
+
+#### Scenario: Cancelling recovery
+- **WHEN** the user cancels any auth-recovery modal
+- **THEN** the active backend is closed and control returns to the connections picker
+
+### Requirement: Automatic reconnection after disconnection
+
+Once the TUI is running, a supervisor in `internal/client/supervisor.go` SHALL watch the gateway
+connection (`Client.Done()`) and reconnect automatically if it drops (e.g. when the gateway is
+restarted). Reconnection SHALL follow the backoff schedule 1s, 2s, 4s, 8s, 15s, then 30s for
+every subsequent attempt, with each attempt's connect timeout taken from
+`prefs.ConnectTimeoutSeconds` (default 15s). The supervisor SHALL push `tui.ConnStateMsg` into the
+bubbletea program so the chat header shows `⚠ disconnected`, `⟳ reconnecting (attempt N)`, or
+`✖ auth failed`, and SHALL add a one-line system message to the chat scrollback on disconnect and
+on recovery. If a reply was streaming when the connection dropped, the placeholder SHALL be
+cleared so the input is usable again (the gateway has no resume protocol; the partial reply is
+abandoned). If the gateway rejects the device token mid-session (`gateway token mismatch` /
+`token missing`), the supervisor SHALL stop retrying and advise switching connections via
+`/connections`, because the auth-recovery modal lives on the connect path, not the reconnect path.
+
+#### Scenario: Transient drop reconnects with backoff
+- **GIVEN** the gateway connection drops
+- **WHEN** the supervisor detects `Client.Done()`
+- **THEN** it retries on the schedule 1s, 2s, 4s, 8s, 15s, then 30s and surfaces `⟳ reconnecting (attempt N)` in the header
+
+#### Scenario: Stream interrupted by a drop
+- **GIVEN** a reply is streaming when the connection drops
+- **WHEN** the disconnect is handled
+- **THEN** the streaming placeholder is cleared and the input becomes usable again
+
+#### Scenario: Auth failure mid-session stops retrying
+- **GIVEN** the gateway rejects the device token mid-session with `gateway token mismatch` or `token missing`
+- **WHEN** the supervisor observes it
+- **THEN** it stops retrying, shows `✖ auth failed`, and advises switching connections via `/connections`
+
+### Requirement: Operator scopes and override
+
+The client SHALL connect requesting operator-level scopes `ScopeOperatorRead`,
+`ScopeOperatorWrite`, `ScopeOperatorAdmin`, and `ScopeOperatorApprovals` (the default in
+`internal/client/client.go`), which are required for session management, exec approval, and agent
+administration. The gateway grants the intersection of the requested scopes and those the device
+token actually carries, so the effective set can be narrower. The `OPENCLAW_OPERATOR_SCOPES`
+environment variable (comma-separated, e.g. `operator.read,operator.write,operator.approvals`)
+SHALL override the default requested set — useful when a pairing only carries a subset, since
+requesting scopes beyond what the pairing grants is rejected as a scope mismatch. Because
+`config.Load()` reads `.env` from the working directory, a stray `OPENCLAW_OPERATOR_SCOPES` in a
+`.env` silently bounds scopes for every connection regardless of the selected gateway; admin-only
+client operations SHALL fail fast with a message pointing here (e.g. `missing scope:
+operator.admin`) rather than surfacing the raw gateway error.
+
+#### Scenario: Default scope request
+- **WHEN** the client connects without `OPENCLAW_OPERATOR_SCOPES` set
+- **THEN** it requests operator read, write, admin, and approvals scopes and receives the intersection the token carries
+
+#### Scenario: Bounding the requested scopes
+- **GIVEN** a pairing that carries only a subset of the default scopes
+- **WHEN** `OPENCLAW_OPERATOR_SCOPES` is set to that subset
+- **THEN** the connection is accepted without the admin-only operations, instead of being rejected as a scope mismatch
+
+#### Scenario: Stray scopes override diagnosed
+- **GIVEN** a stray `OPENCLAW_OPERATOR_SCOPES` in a working-directory `.env`
+- **WHEN** an admin-only operation such as creating an agent is attempted
+- **THEN** it fails fast with `missing scope: operator.admin` and a message pointing to the scopes configuration
+
+### Requirement: Credential and state file storage
+
+The system SHALL store credentials and related state under `~/.lucinate/` at the following paths:
+
+| Path | Contents |
+|---|---|
+| `~/.lucinate/identity/<endpoint>/` | Ed25519 keypair and device token (per gateway endpoint) |
+| `~/.lucinate/secrets/secrets.json` | OpenAI-compat and Hermes API keys, keyed by connection ID (mode 0600) |
+| `~/.lucinate/connections.json` | Saved connection records |
+| `~/.lucinate/hermes/<conn-id>/` | Per-connection Hermes state: `last_response_id` pointer + capped prompts log |
+| `~/.lucinate/config.json` | UI preferences — not authentication-related |
+
+#### Scenario: API key secrets file permissions
+- **WHEN** an OpenAI-compat or Hermes API key is stored
+- **THEN** it is written to `~/.lucinate/secrets/secrets.json` keyed by connection ID with file mode 0600

--- a/openspec/specs/backend-hermes/spec.md
+++ b/openspec/specs/backend-hermes/spec.md
@@ -1,0 +1,174 @@
+# Hermes Backend Specification
+
+## Purpose
+
+The Hermes backend (`internal/backend/hermes`) talks to a [Nous Research Hermes Agent](https://github.com/nousresearch/hermes-agent) profile via its OpenAI-compatible HTTP server (`/v1/...`). Unlike the OpenAI-compat backend (which treats the remote as a stateless `/v1/chat/completions` sink and keeps client-side identity and history), Hermes is **stateful server-side** — each profile owns its own SOUL, sessions, memories, and runs an API server on its own port — so this backend stays thin and lets the server be the source of truth. It is a sibling of the OpenAI backend, not a subclass; it plugs into the cross-backend connection lifecycle described by the `connections` spec.
+
+## Requirements
+
+### Requirement: Backend structure and shared primitives
+
+The Hermes backend SHALL be a sibling of the OpenAI backend, not a subclass. Both SHALL use the shared HTTP / SSE / event-emission primitives in `internal/backend/httpcommon` (request builder with bearer auth, SSE scanner, `protocol.Event` emitter). Beyond those shared primitives the two backends SHALL remain independent: the wire shape, agent model, and history strategy all differ. Because Hermes is stateful server-side (each profile owns its own SOUL, sessions, memories, and runs an API server on its own port), this backend SHALL stay thin and let the server be the source of truth, in contrast to the OpenAI-compat backend which treats the remote as a stateless `/v1/chat/completions` sink and keeps client-side identity and history. The cross-backend connection lifecycle this plugs into is covered by the `connections` spec.
+
+#### Scenario: Shared HTTP primitives reused, independent wire shape
+- **GIVEN** the Hermes and OpenAI backends both live under `internal/backend`
+- **WHEN** the Hermes backend makes requests and emits events
+- **THEN** it uses the shared `internal/backend/httpcommon` request builder with bearer auth, SSE scanner, and `protocol.Event` emitter
+- **AND** its wire shape, agent model, and history strategy remain independent of the OpenAI backend rather than inherited from it
+
+### Requirement: Capabilities reporting
+
+`Backend.Capabilities()` SHALL report the following capability set:
+
+- `AuthRecovery: AuthRecoveryAPIKey` — bearer-token auth-recovery modal, same as OpenAI.
+- `AgentManagement: false` — Hermes profiles are configured server-side (`hermes profile create` / `hermes profile delete` on the host), so the TUI's "new agent" and "delete agent" affordances are both hidden. `CreateAgent` and `DeleteAgent` SHALL both return clear errors if ever called regardless.
+- `GatewayStatus: true` — `/status` reports endpoint, auth, model, and (when present) the active `lastResponseID` thread.
+- Everything else SHALL be off — `/compact`, `/think`, `/stats`, `/crons`, and `!!` SHALL render a "not available on this connection" system message.
+
+#### Scenario: Agent management is disabled
+- **GIVEN** a connected Hermes backend
+- **WHEN** the TUI reads `Backend.Capabilities()`
+- **THEN** `AgentManagement` is `false` and the "new agent" and "delete agent" affordances are hidden
+- **AND** `CreateAgent` and `DeleteAgent` return clear errors if called regardless
+
+#### Scenario: Unsupported commands are rejected with a message
+- **WHEN** the user invokes `/compact`, `/think`, `/stats`, `/crons`, or `!!` on a Hermes connection
+- **THEN** a "not available on this connection" system message is rendered
+
+#### Scenario: Auth recovery uses the API-key modal
+- **WHEN** capabilities are reported
+- **THEN** `AuthRecovery` is `AuthRecoveryAPIKey`, driving the bearer-token auth-recovery modal, same as OpenAI
+
+### Requirement: Status payload
+
+`/status` on a Hermes connection SHALL return a `BackendStatus` carrying:
+
+- `Type: "hermes"`, the API base URL, and the auth mode (`"API key"` or `"anonymous"`).
+- The discovered or configured default model — `opts.DefaultModel` SHALL win over the model cached during connect via `profileModel`.
+- `Thread` populated when `lastResponseID` is set, so the user can see whether the next turn will chain onto an existing server-side conversation or start fresh.
+
+The renderer SHALL omit the OpenClaw-specific gateway block entirely for Hermes — see the per-section gating in `internal/tui/commands.go` (`formatBackendStatus`).
+
+#### Scenario: Status reports type, endpoint, auth, and model
+- **WHEN** the user runs `/status` on a Hermes connection
+- **THEN** the `BackendStatus` reports `Type: "hermes"`, the API base URL, and the auth mode (`"API key"` or `"anonymous"`)
+- **AND** the model is the discovered or configured default, with `opts.DefaultModel` taking precedence over the `profileModel` cached during connect
+
+#### Scenario: Thread shown when a chain is active
+- **GIVEN** `lastResponseID` is set for the connection
+- **WHEN** `/status` renders
+- **THEN** `Thread` is populated so the user can see the next turn will chain onto an existing server-side conversation
+- **AND** the OpenClaw-specific gateway block is omitted from the rendering via the per-section gating in `formatBackendStatus`
+
+### Requirement: One profile, one agent
+
+`ListAgents` SHALL return a single synthetic entry (ID `hermes`) representing the connected Hermes profile. The display name SHALL be the model surfaced by `GET /v1/models` — Hermes advertises the profile's pinned upstream model there. `CreateAgent` and `DeleteAgent` SHALL both be rejected with clear errors pointing the user at `hermes profile create` / `hermes profile delete` on the host.
+
+`SessionsList` SHALL return one session keyed off the same synthetic ID. `CreateSession` SHALL be a no-op that round-trips the agent ID. There SHALL be no concept of multi-agent or multi-session within a single Hermes connection — to talk to a different personality, the user configures a different Hermes profile (which runs on its own port) and adds it as a separate connection.
+
+#### Scenario: Single synthetic agent listed
+- **WHEN** `ListAgents` is called on a Hermes connection
+- **THEN** it returns a single synthetic entry with ID `hermes`
+- **AND** the display name is the model surfaced by `GET /v1/models`
+
+#### Scenario: Agent creation and deletion rejected
+- **WHEN** `CreateAgent` or `DeleteAgent` is called
+- **THEN** it is rejected with a clear error pointing the user at `hermes profile create` / `hermes profile delete` on the host
+
+#### Scenario: Single session, no-op create
+- **WHEN** `SessionsList` is called
+- **THEN** it returns one session keyed off the synthetic `hermes` ID
+- **AND** `CreateSession` is a no-op that round-trips the agent ID
+
+### Requirement: Chat over `/v1/responses` with response-ID chaining
+
+`ChatSend` SHALL post to `/v1/responses` with `stream: true` and SHALL chain via `previous_response_id` rather than a named conversation. Two reasons:
+
+- Hermes maintains conversation continuity server-side from the chained ID, so history is not resent on every turn.
+- Pinning a named conversation per connection meant `/reset` wiped the local last-response pointer but left Hermes' server-side thread alive, so the next chat continued the old conversation. Chaining via `previous_response_id` makes `SessionDelete` actually start a fresh chain. (Regression test: `TestSessionDelete_NextChatStartsFreshChain` in `backend_test.go`.)
+
+The streaming SSE SHALL emit typed events — `response.created`, `response.output_text.delta`, `response.completed` — which the backend dispatches on the `type` field in each `data:` payload. Deltas SHALL accumulate into a string and surface as `protocol.ChatEvent` (state=delta) just like the OpenAI backend; `response.completed` SHALL produce a final event and persist the new response ID.
+
+`ChatAbort` SHALL cancel the streaming request context. The Runs API (`POST /v1/runs/{id}/stop`) exists for tool-heavy turns but SHALL NOT be used in V1 — closing the SSE connection is enough for plain chat.
+
+#### Scenario: Streaming chat chains on the previous response
+- **WHEN** `ChatSend` is invoked
+- **THEN** it posts to `/v1/responses` with `stream: true` and chains via `previous_response_id` rather than a named conversation
+- **AND** history is not resent on each turn because Hermes maintains continuity server-side from the chained ID
+
+#### Scenario: Typed SSE events dispatched
+- **GIVEN** a streaming `/v1/responses` request
+- **WHEN** `data:` payloads arrive
+- **THEN** the backend dispatches on the `type` field for `response.created`, `response.output_text.delta`, and `response.completed`
+- **AND** deltas accumulate into a string and surface as `protocol.ChatEvent` (state=delta), while `response.completed` produces a final event and persists the new response ID
+
+#### Scenario: Reset starts a fresh chain
+- **GIVEN** a connection with an active response chain
+- **WHEN** `SessionDelete` (`/reset`) runs
+- **THEN** the next chat starts a fresh chain because continuity is keyed on `previous_response_id`, not a named conversation
+- **AND** this is pinned by `TestSessionDelete_NextChatStartsFreshChain` in `backend_test.go`
+
+#### Scenario: Abort cancels the stream
+- **WHEN** `ChatAbort` is called during a plain chat turn
+- **THEN** the streaming request context is cancelled and closing the SSE connection is sufficient, without using the `POST /v1/runs/{id}/stop` Runs API in V1
+
+### Requirement: Local per-connection state files
+
+Two small files per connection SHALL live under `~/.lucinate/hermes/<connection-id>/`:
+
+| File                | Purpose                                                                            |
+|---------------------|------------------------------------------------------------------------------------|
+| `last_response_id`  | The most recent response ID, used to chain `previous_response_id` on the next turn |
+| `prompts.jsonl`     | Append-only log of `{response_id, prompt, time}` entries, capped at 100            |
+
+Both files SHALL be mode `0600` and the directory SHALL be `0700`. They SHALL be cleared by `SessionDelete` (`/reset`).
+
+The prompts log SHALL exist because `GET /v1/responses/{id}` on Hermes returns only the assistant output — the user input field is omitted. Without a client-side mirror, the history-walk reconstruction would be assistant-only. The 100-entry cap SHALL match Hermes' server-side LRU cap on stored responses, so the two stay in rough sync.
+
+#### Scenario: State files created with restrictive permissions
+- **WHEN** the Hermes backend persists per-connection state
+- **THEN** `last_response_id` and `prompts.jsonl` are written under `~/.lucinate/hermes/<connection-id>/` with file mode `0600` and directory mode `0700`
+
+#### Scenario: Reset clears local state
+- **WHEN** `SessionDelete` (`/reset`) runs
+- **THEN** both `last_response_id` and `prompts.jsonl` are cleared
+
+#### Scenario: Prompts log mirrors user input
+- **GIVEN** `GET /v1/responses/{id}` returns only assistant output with the user input field omitted
+- **WHEN** a turn completes
+- **THEN** the `{response_id, prompt, time}` entry is appended to `prompts.jsonl`, capped at 100 entries to match Hermes' server-side LRU cap on stored responses
+
+### Requirement: History via walk-back
+
+Hermes has no list-by-conversation endpoint (`GET /v1/conversations/<name>/responses` 404s). To populate the chat scrollback, `ChatHistory` SHALL walk the chain backwards from the stored last-response ID via repeated `GET /v1/responses/{id}`, following `previous_response_id`. The walk SHALL be capped at **3 hops** in `historyWalkLimit` because each hop is a separate round-trip and first-load latency adds up; the chat view does not need a deep transcript on connect.
+
+Each hop SHALL yield the assistant's output text from the server, paired with the user prompt looked up from the local prompts log. Both SHALL be emitted in chronological order (user → assistant per turn) so the chat view renders a normal transcript.
+
+#### Scenario: Scrollback reconstructed by walking the chain
+- **GIVEN** no list-by-conversation endpoint exists (`GET /v1/conversations/<name>/responses` 404s)
+- **WHEN** `ChatHistory` populates the chat scrollback
+- **THEN** it walks the chain backwards from the stored last-response ID via repeated `GET /v1/responses/{id}`, following `previous_response_id`, capped at 3 hops in `historyWalkLimit`
+
+#### Scenario: Each hop pairs assistant output with the stored prompt
+- **WHEN** a history hop is processed
+- **THEN** the assistant's output text from the server is paired with the user prompt looked up from the local prompts log
+- **AND** both are emitted in chronological order (user → assistant per turn) so the chat view renders a normal transcript
+
+### Requirement: Connect and API-key authentication
+
+`Connect(ctx)` SHALL issue `GET /v1/models`, caching the discovered profile name as the synthetic agent's display model. A 401/403 SHALL surface as the canonical `api key required` error so the connecting view routes it to the API-key modal — the same flow as OpenAI.
+
+The Hermes API server requires `API_SERVER_KEY` to be set on the server side; the client SHALL send `Authorization: Bearer <key>`. The auth modal SHALL call `StoreAPIKey`, which updates the in-memory key on the live backend and (via the `secretAwareHermesBackend` shim in `app/factory.go`) persists it to `~/.lucinate/secrets/secrets.json`.
+
+#### Scenario: Connect discovers the profile model
+- **WHEN** `Connect(ctx)` runs
+- **THEN** it issues `GET /v1/models` and caches the discovered profile name as the synthetic agent's display model
+
+#### Scenario: Unauthorised connect routes to the API-key modal
+- **GIVEN** the Hermes API server requires `API_SERVER_KEY` and the client sends `Authorization: Bearer <key>`
+- **WHEN** a request returns HTTP 401 or 403
+- **THEN** it surfaces as the canonical `api key required` error and the connecting view routes it to the API-key modal, the same flow as OpenAI
+
+#### Scenario: API key stored and persisted
+- **WHEN** the user submits a key in the auth modal
+- **THEN** `StoreAPIKey` updates the in-memory key on the live backend and persists it to `~/.lucinate/secrets/secrets.json` via the `secretAwareHermesBackend` shim in `app/factory.go`

--- a/openspec/specs/backend-openai/spec.md
+++ b/openspec/specs/backend-openai/spec.md
@@ -1,0 +1,301 @@
+# OpenAI-Compatible Backend Specification
+
+## Purpose
+
+The OpenAI-compat backend (`internal/backend/openai`) lets lucinate talk to any HTTP server that implements `/v1/chat/completions` and `/v1/models` — Ollama, vLLM, LM Studio, llamafile, OpenAI proper, and so on. Because those servers have no concept of agents, lucinate maintains agent state on disk locally. This spec covers the backend's declared capabilities, status payload, connect and auth behaviour, local agent storage, session and history handling, skill-catalogue injection, streaming, and local compaction. The cross-backend connection lifecycle this plugs into is covered by the `connections` spec, where the Ollama preset (an opinionated OpenAI preset) is also documented.
+
+## Requirements
+
+### Requirement: Declared backend capabilities
+
+`Backend.Capabilities()` SHALL report `AuthRecovery: AuthRecoveryAPIKey`, `AgentManagement: true`, `SessionCompact: true` (the local summarisation pass — see the compaction requirement), and `GatewayStatus: true` (`/status` — see the status-payload requirement). Everything else SHALL be off — `/think`, `/stats`, and `!!` SHALL render a "not available on this connection" system message.
+
+#### Scenario: Unsupported command on this connection
+
+- **GIVEN** a connection served by the OpenAI-compat backend
+- **WHEN** the user issues `/think`, `/stats`, or `!!`
+- **THEN** the backend renders a "not available on this connection" system message
+
+#### Scenario: Capabilities that are enabled
+
+- **WHEN** `Backend.Capabilities()` is queried
+- **THEN** it reports `AuthRecovery: AuthRecoveryAPIKey`, `AgentManagement: true`, `SessionCompact: true`, and `GatewayStatus: true`
+
+### Requirement: Status payload
+
+`/status` SHALL return a `BackendStatus` carrying:
+
+- `Type: "openai"`, the configured `BaseURL`, the auth mode (`"API key"` or `"anonymous"`), and the configured `DefaultModel`.
+- `AgentCount` — the number of agent directories under the connection's store root.
+- `History` — the active agent's `history.jsonl` size and newline-counted message count. Files larger than `historyCountMaxBytes` (1 MiB) SHALL skip the count and the renderer SHALL fall back to size-only so an interactive command never blocks on a huge transcript.
+
+The `BackendStatus` SHALL carry no `Gateway` block — that section is OpenClaw-specific and stays nil here.
+
+#### Scenario: Status for a connection with an API key
+
+- **WHEN** the user issues `/status` on an OpenAI-compat connection configured with an API key
+- **THEN** the returned `BackendStatus` reports `Type: "openai"`, the configured `BaseURL`, auth mode `"API key"`, the configured `DefaultModel`, the agent count under the store root, and the active agent's history size and message count
+- **AND** the `Gateway` block is nil
+
+#### Scenario: Huge transcript skips the message count
+
+- **GIVEN** the active agent's `history.jsonl` is larger than `historyCountMaxBytes` (1 MiB)
+- **WHEN** `/status` builds the `History` section
+- **THEN** it skips the newline count and the renderer falls back to size-only so the command never blocks
+
+### Requirement: `/think` is currently a no-op
+
+`/think` SHALL report `Thinking: false` so it is gated off, even though several OpenAI-compatible providers expose reasoning controls in their own request shapes (OpenAI's `reasoning.effort`, Ollama's `think` flag on reasoning models, DeepSeek's `<think>` tags, Anthropic-via-proxy's `thinking` block). Wiring `/think` to translate into the active provider's reasoning shape is a known gap — tracked in [#80](https://github.com/lucinate-ai/lucinate/issues/80).
+
+#### Scenario: Thinking reported as disabled
+
+- **WHEN** capabilities are reported for the OpenAI-compat backend
+- **THEN** `/think` reports `Thinking: false` and is gated off
+
+### Requirement: Connect and auth
+
+`Connect(ctx)` SHALL issue `GET /v1/models`. A 401 or 403 SHALL be surfaced as the canonical `api key required` error so the connecting view routes it to the API-key modal. Any other ≥400 response SHALL surface as `connect: HTTP <code>: <body>`.
+
+The API key SHALL be sent as `Authorization: Bearer <key>` when present and omitted otherwise (some endpoints — Ollama, vLLM without auth — accept anonymous requests). The auth modal SHALL call `StoreAPIKey`, which updates the in-memory key on the live backend and (via the `secretAwareOpenAIBackend` shim in `app/factory.go`) writes through to `~/.lucinate/secrets/secrets.json` so the next launch reuses it without re-prompting.
+
+#### Scenario: Successful connect probes the models endpoint
+
+- **WHEN** `Connect(ctx)` runs
+- **THEN** it issues `GET /v1/models`
+
+#### Scenario: 401 or 403 routes to the API-key modal
+
+- **GIVEN** the server returns HTTP 401 or 403 from `GET /v1/models`
+- **WHEN** the connect result is handled
+- **THEN** it is surfaced as the canonical `api key required` error and the connecting view opens the API-key modal
+
+#### Scenario: Other error responses surface with code and body
+
+- **GIVEN** the server returns a ≥400 response other than 401/403
+- **WHEN** the connect result is handled
+- **THEN** it surfaces as `connect: HTTP <code>: <body>`
+
+#### Scenario: API key sent as a bearer token when present
+
+- **GIVEN** an API key is configured
+- **WHEN** the backend makes a request
+- **THEN** it sends `Authorization: Bearer <key>`
+- **AND** when no key is configured, the header is omitted so anonymous endpoints (Ollama, vLLM without auth) still work
+
+#### Scenario: Stored key persists across launches
+
+- **WHEN** the auth modal calls `StoreAPIKey`
+- **THEN** the in-memory key on the live backend is updated
+- **AND** via the `secretAwareOpenAIBackend` shim in `app/factory.go` it is written through to `~/.lucinate/secrets/secrets.json` so the next launch reuses it without re-prompting
+
+### Requirement: Agent storage layout
+
+Each agent SHALL own a directory under `~/.lucinate/agents/<connection-id>/<agent-id>/` containing:
+
+| File            | Purpose                                                       |
+|-----------------|---------------------------------------------------------------|
+| `agent.json`    | Metadata: id, name, default model, created/updated timestamps |
+| `IDENTITY.md`   | Who the agent is — markdown, user-editable                    |
+| `SOUL.md`       | Tone / values / working style — markdown, user-editable       |
+| `history.jsonl` | Append-only transcript, one JSON message per line             |
+
+All files SHALL be mode `0600` and the agent directory SHALL be `0700`. `agent.json` SHALL be rewritten via tempfile + rename so a crash mid-write can't truncate the metadata.
+
+The agent ID SHALL be derived from the user-supplied name via `slugify` (lowercase, alphanumerics and hyphens only) — the ID is also the session key, so it has to round-trip through gateway-protocol fields without escaping.
+
+A sibling `~/.lucinate/agents/<connection-id>/.archive/` directory SHALL hold agents the user deleted with the "Keep files" option set (see the delete-vs-archive requirement).
+
+#### Scenario: Agent directory created with restrictive permissions
+
+- **WHEN** an agent is created
+- **THEN** its directory `~/.lucinate/agents/<connection-id>/<agent-id>/` is mode `0700` and contains `agent.json`, `IDENTITY.md`, `SOUL.md`, and `history.jsonl`, each mode `0600`
+
+#### Scenario: Metadata write is crash-safe
+
+- **WHEN** `agent.json` is written
+- **THEN** it is rewritten via tempfile + rename so a crash mid-write cannot truncate the metadata
+
+#### Scenario: Agent ID slugified from name
+
+- **GIVEN** a user-supplied agent name
+- **WHEN** the agent ID is derived
+- **THEN** `slugify` produces a lowercase, alphanumeric-and-hyphen-only ID that also serves as the session key and round-trips through gateway-protocol fields without escaping
+
+### Requirement: IDENTITY.md and SOUL.md seeding
+
+On create, the form SHALL seed both files with placeholders the user can edit on disk later:
+
+- `DefaultIdentity(name)` SHALL interpolate the agent's chosen name as the `Name:` header so the model addresses itself by the right label from turn one.
+- `DefaultSoul` SHALL be a static template covering tone and working style.
+
+Users SHALL be able to edit either file between sessions without going through the TUI — `SystemPrompt(agentID)` reloads from disk on every chat send.
+
+#### Scenario: Files seeded on create
+
+- **WHEN** an agent is created
+- **THEN** `IDENTITY.md` is seeded via `DefaultIdentity(name)` with the agent's chosen name as the `Name:` header
+- **AND** `SOUL.md` is seeded from the static `DefaultSoul` template
+
+#### Scenario: Edits picked up on next send
+
+- **GIVEN** a user has edited `IDENTITY.md` or `SOUL.md` on disk between sessions
+- **WHEN** the next chat send occurs
+- **THEN** `SystemPrompt(agentID)` reloads the files from disk
+
+### Requirement: System prompt composition
+
+`AgentStore.SystemPrompt(agentID)` SHALL read IDENTITY.md and SOUL.md and concatenate them under `# Identity` / `# Soul` headers. All four cases SHALL be handled:
+
+- Both present → `# Identity\n\n…\n\n# Soul\n\n…`
+- Identity only → `# Identity\n\n…`
+- Soul only → `# Soul\n\n…`
+- Neither → empty string (model gets no preamble)
+
+#### Scenario: Both files present
+
+- **GIVEN** both IDENTITY.md and SOUL.md have content
+- **WHEN** `SystemPrompt(agentID)` runs
+- **THEN** it returns `# Identity\n\n…\n\n# Soul\n\n…`
+
+#### Scenario: Only one file present
+
+- **GIVEN** only IDENTITY.md (or only SOUL.md) has content
+- **WHEN** `SystemPrompt(agentID)` runs
+- **THEN** it returns just `# Identity\n\n…` (or just `# Soul\n\n…`)
+
+#### Scenario: Neither file present
+
+- **GIVEN** neither IDENTITY.md nor SOUL.md has content
+- **WHEN** `SystemPrompt(agentID)` runs
+- **THEN** it returns an empty string and the model gets no preamble
+
+### Requirement: Delete vs archive
+
+`Backend.DeleteAgent(ctx, params)` SHALL dispatch on `params.DeleteFiles` (the user's keep-vs-delete-files toggle on the picker — see the deleting-an-agent behaviour in the `agents` spec):
+
+- `DeleteFiles=true` → `AgentStore.Delete` (`os.RemoveAll(AgentDir(id))`). The on-disk content is gone.
+- `DeleteFiles=false` → `AgentStore.Archive` renames the agent dir to `<root>/.archive/<id>-<unixts>/`. IDENTITY.md, SOUL.md, history.jsonl, and agent.json all survive verbatim so the user can recover them by hand.
+
+`AgentStore.List` SHALL filter by parsable `agent.json` at the top of each direct child of the picker root, so the `.archive` directory is naturally skipped (it has no `agent.json` of its own and `LoadMeta` returns an error). No special-case is needed.
+
+`DeleteAgent` SHALL call `LoadMeta` first to surface a "not found" error rather than silently succeeding on a stale agent ID — important because the UI presence-toggles its `confirm-delete` action on `nameMatches()`, which can theoretically pass while the underlying agent has already vanished.
+
+#### Scenario: Delete with files removed
+
+- **GIVEN** `params.DeleteFiles=true`
+- **WHEN** `DeleteAgent` runs
+- **THEN** `AgentStore.Delete` runs `os.RemoveAll(AgentDir(id))` and the on-disk content is gone
+
+#### Scenario: Delete keeping files archives the directory
+
+- **GIVEN** `params.DeleteFiles=false`
+- **WHEN** `DeleteAgent` runs
+- **THEN** `AgentStore.Archive` renames the agent dir to `<root>/.archive/<id>-<unixts>/` with IDENTITY.md, SOUL.md, history.jsonl, and agent.json surviving verbatim for manual recovery
+
+#### Scenario: Archive directory skipped by the picker
+
+- **WHEN** `AgentStore.List` enumerates the picker root
+- **THEN** it filters by parsable `agent.json` at the top of each direct child, so `.archive` (which has no `agent.json` and makes `LoadMeta` error) is naturally skipped without a special case
+
+#### Scenario: Deleting a stale agent ID fails loudly
+
+- **GIVEN** an agent ID that no longer exists on disk but passes the UI's `nameMatches()` presence toggle for `confirm-delete`
+- **WHEN** `DeleteAgent` runs
+- **THEN** its up-front `LoadMeta` call surfaces a "not found" error rather than silently succeeding
+
+### Requirement: Sessions and history
+
+Agent ≡ session, 1:1 — there SHALL be no session browser sub-list because there is nothing for it to list. `CreateSession` SHALL return the agent ID as the session key. `/reset` SHALL call `SessionDelete`, which clears `history.jsonl` (the agent metadata stays).
+
+`AppendMessage` SHALL write one JSON-encoded `Message` line per call and touch `UpdatedAt` so `List()` orders recent agents first. `LoadHistory(limit)` SHALL return up to `limit` most recent messages; `limit <= 0` returns the full transcript.
+
+#### Scenario: Session key is the agent ID
+
+- **WHEN** `CreateSession` runs
+- **THEN** it returns the agent ID as the session key
+- **AND** there is no session browser sub-list
+
+#### Scenario: Reset clears history but keeps metadata
+
+- **WHEN** the user issues `/reset`
+- **THEN** `SessionDelete` clears `history.jsonl` while the agent metadata stays
+
+#### Scenario: Appending a message reorders the agent list
+
+- **WHEN** `AppendMessage` is called
+- **THEN** it writes one JSON-encoded `Message` line and touches `UpdatedAt` so `List()` orders recent agents first
+
+#### Scenario: History limit honoured
+
+- **WHEN** `LoadHistory(limit)` is called
+- **THEN** it returns up to `limit` most recent messages, or the full transcript when `limit <= 0`
+
+### Requirement: Skill catalog injection
+
+The chat layer SHALL pass the active skill catalog through `ChatSendParams.Skills`. The backend SHALL prepend a `System: Available agent skills (activate with /skill-name): …` block to the first turn of each session, then set `catalogSent[sessionKey] = true` so subsequent turns omit it. The check-and-mark SHALL be mutex-guarded against concurrent sends.
+
+#### Scenario: Catalogue prepended on the first turn only
+
+- **GIVEN** a new session whose `catalogSent[sessionKey]` is unset
+- **WHEN** the first turn is sent with `ChatSendParams.Skills` populated
+- **THEN** the backend prepends a `System: Available agent skills (activate with /skill-name): …` block and sets `catalogSent[sessionKey] = true`
+- **AND** subsequent turns omit the block
+
+#### Scenario: Concurrent sends are serialised
+
+- **WHEN** two sends race on the same session
+- **THEN** the check-and-mark of `catalogSent` is mutex-guarded so the catalogue block is injected once
+
+### Requirement: Streaming chat send and abort
+
+`ChatSend` SHALL issue `POST /v1/chat/completions` with `stream: true` and parse the SSE response line-by-line, emitting `protocol.ChatEvent` for each `delta.content` chunk and a final event when `[DONE]` arrives. `ChatAbort` SHALL cancel the stored `context.CancelFunc` for the run, which terminates the in-flight HTTP request.
+
+#### Scenario: Streamed deltas emitted as chat events
+
+- **WHEN** `ChatSend` runs
+- **THEN** it issues `POST /v1/chat/completions` with `stream: true`, emits a `protocol.ChatEvent` for each `delta.content` chunk, and emits a final event when `[DONE]` arrives
+
+#### Scenario: Abort terminates the in-flight request
+
+- **WHEN** `ChatAbort` is called for a run
+- **THEN** it cancels the stored `context.CancelFunc`, terminating the in-flight HTTP request
+
+### Requirement: Local compaction
+
+`/compact` SHALL run locally — there is no gateway-side compactor, so `SessionCompact` SHALL issue a streaming `POST /v1/chat/completions` against the agent's configured model with a summarisation prompt and the older portion of the transcript as context. Deltas SHALL be accumulated into a string without touching the events channel, so the compaction is invisible to the chat view. The accumulated text SHALL be written back to `history.jsonl` as a single `role: "system"` message with `Summary: true`, followed by the most recent `compactKeepTail` messages preserved verbatim. `compactMinHistory` SHALL gate the no-op-when-too-small case (returns success without a network round-trip).
+
+Streaming (rather than non-streaming) is intentional: some Ollama setups, particularly with reasoning-capable models, return an empty `message.content` on the non-streaming path while the streamed `delta.content` deltas produce the actual answer. Reusing the streaming code path means /compact works across the same compatibility matrix the regular chat send already covers.
+
+The `Summary` flag is what distinguishes a compact-produced digest from the legacy "skip stored system messages" defence in `runStream`: messages with `Summary: true` SHALL be forwarded on every turn after compaction, while any other `role: "system"` line in `history.jsonl` is still ignored. `ChatHistory` SHALL mirror the same rule so the digest renders in the chat view rather than vanishing on history refresh.
+
+A previously-compacted session that gets compacted again SHALL fold the existing summary into the new one — `renderTranscriptForCompact` includes prior summaries under a `summary:` label so multiple compactions don't lose detail accumulated across earlier passes.
+
+The transcript SHALL be dumped as labelled text inside a single `role: user` message, not forwarded as the literal user/assistant message sequence. Forwarding raw turns ends the request on `role: assistant` — and OpenAI-compatible servers (Ollama, vLLM, llama.cpp) interpret that as "the conversation is complete" and respond with empty content, defeating the summarisation. Wrapping the transcript in a user turn lets the model treat it as input data and produce the summary as a normal reply.
+
+#### Scenario: Compaction runs locally and stores a summary
+
+- **WHEN** the user issues `/compact` on a session with enough history
+- **THEN** `SessionCompact` issues a streaming `POST /v1/chat/completions` against the agent's configured model with a summarisation prompt and the older transcript, accumulates the deltas into a string without touching the events channel, and writes the result back to `history.jsonl` as a single `role: "system"` message with `Summary: true`, followed by the most recent `compactKeepTail` messages preserved verbatim
+
+#### Scenario: Too-small history is a no-op
+
+- **GIVEN** a transcript below `compactMinHistory`
+- **WHEN** `/compact` runs
+- **THEN** it returns success without a network round-trip
+
+#### Scenario: Summary digest survives history refresh
+
+- **GIVEN** a stored `role: "system"` message with `Summary: true`
+- **WHEN** turns are sent and history is refreshed
+- **THEN** `runStream` and `ChatHistory` forward the `Summary: true` message on every turn while still ignoring any other `role: "system"` line, so the digest renders in the chat view rather than vanishing
+
+#### Scenario: Re-compacting folds in prior summaries
+
+- **GIVEN** a session that was already compacted
+- **WHEN** it is compacted again
+- **THEN** `renderTranscriptForCompact` includes prior summaries under a `summary:` label so detail accumulated across earlier passes is not lost
+
+#### Scenario: Transcript wrapped in a user turn
+
+- **WHEN** the transcript is sent for summarisation
+- **THEN** it is dumped as labelled text inside a single `role: user` message rather than the literal user/assistant sequence, so OpenAI-compatible servers (Ollama, vLLM, llama.cpp) do not see the request end on `role: assistant` and respond with empty content

--- a/openspec/specs/backend-openclaw/spec.md
+++ b/openspec/specs/backend-openclaw/spec.md
@@ -1,0 +1,140 @@
+# OpenClaw Backend Specification
+
+## Purpose
+
+The OpenClaw backend (`internal/backend/openclaw`) is a thin adapter over `*client.Client` from the existing OpenClaw SDK. Every TUI call site that used to hold a `*client.Client` now holds a `backend.Backend`; the OpenClaw concrete type is recovered via type assertion at the few sites that still need gateway-only affordances. This spec covers the backend's declared capabilities, its connect and auth pass-throughs, the agent and session model, skill-catalogue injection, the pass-through method surface, and the cross-backend status payload. See the `connections` spec for the cross-backend connection lifecycle and the `authentication` spec for device pairing.
+
+## Requirements
+
+### Requirement: Full capability surface
+
+`Backend.Capabilities()` SHALL report the full surface — every optional sub-interface SHALL be implemented. The capabilities and their use sites are:
+
+| Capability        | Use site                                  |
+|-------------------|-------------------------------------------|
+| `GatewayStatus`   | `/status`                                 |
+| `RemoteExec`      | `!!` — see the `shell-execution` spec     |
+| `SessionCompact`  | `/compact`                                |
+| `Thinking`        | `/think`                                  |
+| `SessionUsage`    | `/stats`                                  |
+| `Cron`            | `/crons` — see the `crons` spec           |
+| `AuthRecovery`    | `AuthRecoveryDeviceToken` — see the connect-and-auth requirement |
+| `AgentWorkspace`  | Workspace field on the create-agent form  |
+
+#### Scenario: Every optional sub-interface is implemented
+
+- **WHEN** `Backend.Capabilities()` is queried
+- **THEN** it reports `GatewayStatus`, `RemoteExec`, `SessionCompact`, `Thinking`, `SessionUsage`, `Cron`, `AuthRecovery`, and `AgentWorkspace`
+- **AND** each maps to its use site (`/status`, `!!`, `/compact`, `/think`, `/stats`, `/crons`, `AuthRecoveryDeviceToken`, and the create-agent form's workspace field)
+
+### Requirement: Connect and auth pass-through with modal auth recovery
+
+`Connect`, `Close`, `Events`, and `Supervise` SHALL be pass-throughs to the underlying client. The TUI's connecting view SHALL route auth failures into modal sub-states:
+
+- `NOT_PAIRED` → pairing-required modal: instructions to approve the device on the gateway host, then Enter to retry.
+- `gateway token mismatch` → device-token modal: clear / reset identity / cancel. `ClearToken` and `ResetIdentity` come from the `DeviceTokenAuth` sub-interface.
+- `gateway token missing` → device-token text prompt; submission stores via `StoreToken`.
+
+Tokens and the Ed25519 device identity SHALL live under `~/.lucinate/identity/<endpoint>/`, isolated per gateway endpoint. The first successful connect after a fresh approval SHALL re-dial transparently so the surviving connection authenticates with the issued token — see the `authentication` spec for the full pairing flow and the re-dial rationale.
+
+#### Scenario: Auth failures route into modal sub-states
+
+- **GIVEN** a connect attempt fails with a recognised auth error
+- **WHEN** the connecting view handles it
+- **THEN** `NOT_PAIRED` opens the pairing-required modal, `gateway token mismatch` opens the device-token modal (clear / reset identity / cancel via `DeviceTokenAuth`'s `ClearToken` and `ResetIdentity`), and `gateway token missing` opens a text prompt that stores the token via `StoreToken`
+
+#### Scenario: Transparent re-dial after fresh approval
+
+- **GIVEN** a device has just been approved on the gateway host
+- **WHEN** the first successful connect completes
+- **THEN** the backend re-dials transparently so the surviving connection authenticates with the issued token stored under `~/.lucinate/identity/<endpoint>/`
+
+### Requirement: Agent and session model owned by the gateway
+
+Agents SHALL be owned by the gateway. `ListAgents` and `CreateAgent` (with name + workspace) SHALL call straight through. Sessions SHALL be created server-side and identified by the gateway-issued session key. The gateway SHALL seed an `IDENTITY.md` file in the agent's workspace on creation; lucinate SHALL NOT author it.
+
+`DeleteAgent` SHALL forward to `Client.DeleteAgent(ctx, agentID, deleteFiles)`, which sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` over the wire. The `*bool` SHALL always be populated explicitly from the picker's keep-vs-delete-files toggle (see the `agents` spec, deleting-an-agent) — the gateway's implicit "preserve files" default MUST never apply. When `deleteFiles=false` the gateway SHALL drop bindings but leave the agent's workspace files in place; when true the workspace SHALL be wiped along with the bindings.
+
+#### Scenario: Agents and sessions call through to the gateway
+
+- **WHEN** `ListAgents` or `CreateAgent` (name + workspace) is invoked
+- **THEN** it calls straight through to the gateway, which owns the agents
+- **AND** sessions are created server-side and identified by the gateway-issued session key
+- **AND** the gateway seeds `IDENTITY.md` in the agent's workspace, which lucinate does not author
+
+#### Scenario: Delete agent always sends an explicit files flag
+
+- **GIVEN** the picker's keep-vs-delete-files toggle
+- **WHEN** `DeleteAgent` forwards to `Client.DeleteAgent(ctx, agentID, deleteFiles)`
+- **THEN** it sends `protocol.AgentsDeleteParams{AgentID, DeleteFiles: &flag}` with the `*bool` populated explicitly, so the gateway's implicit "preserve files" default never applies
+
+#### Scenario: Delete with files preserved versus wiped
+
+- **WHEN** `deleteFiles=false`
+- **THEN** the gateway drops bindings but leaves the agent's workspace files in place
+- **AND** **WHEN** `deleteFiles=true`, the workspace is wiped along with the bindings
+
+### Requirement: Skill catalogue injection on the first turn
+
+The chat layer SHALL pass the active skill catalogue through `ChatSendParams.Skills`. The backend SHALL prepend a `System:`-prefixed block — `Available agent skills (activate with /skill-name): …` — to the first turn of each session via `takePendingCatalog(sessionKey, skills)`. After the first turn, `catalogSent[sessionKey] = true` and subsequent sends SHALL omit the block.
+
+The check-and-mark SHALL be mutex-guarded so two concurrent sends on the same session cannot both emit the catalogue. Every line of the block SHALL be prefixed with `System:` so the gateway's prompt assembler can identify it as a session-level system block (retained server-side across turns) and so `stripSystemLines` on the client side hides it from the visible transcript on history refresh.
+
+#### Scenario: Catalogue prepended once per session
+
+- **GIVEN** a session's first turn with an active skill catalogue passed via `ChatSendParams.Skills`
+- **WHEN** the send is processed
+- **THEN** the backend prepends the `System:`-prefixed `Available agent skills (activate with /skill-name): …` block via `takePendingCatalog(sessionKey, skills)`
+- **AND** sets `catalogSent[sessionKey] = true` so subsequent sends omit the block
+
+#### Scenario: Concurrent sends cannot double-emit the catalogue
+
+- **GIVEN** two concurrent sends on the same session
+- **WHEN** the mutex-guarded check-and-mark runs
+- **THEN** at most one send emits the catalogue block
+
+#### Scenario: System-prefixed lines retained server-side and hidden client-side
+
+- **GIVEN** every line of the catalogue block is prefixed with `System:`
+- **WHEN** the gateway's prompt assembler processes it
+- **THEN** it treats the block as a session-level system block retained server-side across turns
+- **AND** `stripSystemLines` on the client side hides it from the visible transcript on history refresh
+
+### Requirement: Pass-through method surface
+
+`SessionsList`, `CreateSession`, `SessionDelete`, `ChatSend`, `ChatAbort`, `ChatHistory`, `ModelsList`, `SessionPatchModel`, and the capability-specific methods (`ExecRequest`, `ExecResolve`, `SessionCompact`, `SessionPatchThinking`, `SessionUsage`, `CronsList`, `CronRuns`, `CronAdd`, `CronUpdate`, `CronUpdateRaw`, `CronRemove`, `CronRun`) SHALL all forward to the underlying client unchanged. The adapter exists to satisfy the `backend.Backend` interface, not to add behaviour.
+
+#### Scenario: Methods forward unchanged
+
+- **WHEN** any of `SessionsList`, `CreateSession`, `SessionDelete`, `ChatSend`, `ChatAbort`, `ChatHistory`, `ModelsList`, `SessionPatchModel`, `ExecRequest`, `ExecResolve`, `SessionCompact`, `SessionPatchThinking`, `SessionUsage`, `CronsList`, `CronRuns`, `CronAdd`, `CronUpdate`, `CronUpdateRaw`, `CronRemove`, or `CronRun` is called
+- **THEN** it forwards to the underlying client unchanged, adding no behaviour
+
+### Requirement: Cross-backend status payload
+
+`Status(ctx, agentID, sessionKey)` SHALL assemble the cross-backend `BackendStatus` from a single gateway `/health` round-trip plus accessors on `*client.Client`:
+
+- Common header — `Type: "openclaw"`, the gateway WebSocket URL, and `"device token"` / `"anonymous"` derived from whether a token is loaded for this endpoint.
+- `Gateway` block — the health snapshot (sessions, agents, channels), the gateway version and uptime from the connect handshake, and the negotiated protocol version bounded by `protocol.MinProtocolVersion` and `protocol.ProtocolVersion` (the same pair advertised in `ConnectParams.MinProtocol`/`MaxProtocol`, so the displayed range matches what the handshake actually negotiated against).
+
+If the health fetch fails, `Status` SHALL still return a populated payload with `Gateway.Health = nil` and SHALL surface the error to the caller; the TUI SHALL render the body and the error as separate system messages rather than swallowing either.
+
+`agentID` and `sessionKey` SHALL be ignored — OpenClaw's per-session state lives on the gateway and is already reflected in the health snapshot.
+
+#### Scenario: Status assembled from a single health round-trip
+
+- **WHEN** `Status(ctx, agentID, sessionKey)` is called
+- **THEN** it assembles `BackendStatus` from one gateway `/health` round-trip plus `*client.Client` accessors
+- **AND** the common header carries `Type: "openclaw"`, the gateway WebSocket URL, and `"device token"` or `"anonymous"` per whether a token is loaded for this endpoint
+- **AND** the `Gateway` block carries the health snapshot (sessions, agents, channels), the gateway version and uptime from the connect handshake, and the protocol version bounded by `protocol.MinProtocolVersion` and `protocol.ProtocolVersion` (matching `ConnectParams.MinProtocol`/`MaxProtocol`)
+
+#### Scenario: Health fetch failure still returns a payload
+
+- **WHEN** the `/health` fetch fails
+- **THEN** `Status` returns a populated payload with `Gateway.Health = nil` and surfaces the error to the caller
+- **AND** the TUI renders the body and the error as separate system messages rather than swallowing either
+
+#### Scenario: Agent and session identifiers are ignored
+
+- **GIVEN** `agentID` and `sessionKey` arguments
+- **WHEN** `Status` runs
+- **THEN** both are ignored, because OpenClaw's per-session state lives on the gateway and is already reflected in the health snapshot

--- a/openspec/specs/chat-launch/spec.md
+++ b/openspec/specs/chat-launch/spec.md
@@ -1,0 +1,183 @@
+# Pre-Navigated Launch Specification
+
+## Purpose
+
+`lucinate chat` is a TUI entry point that accepts the same `--connection` / `--agent` / `--session` overrides as `lucinate send`, but instead of dispatching one turn and exiting it launches the regular interactive program with each override consumed at the transition that would otherwise have prompted the user. An optional positional message is auto-submitted as the first turn once the session's history loads. The user-facing CLI shape lives in the project README (the "skip the pickers" section); this spec covers the override plumbing and the seams the TUI uses to consume them safely.
+
+## Requirements
+
+### Requirement: Separate `chat` subcommand distinct from `send`
+
+The system SHALL provide `lucinate chat` as a separate subcommand from `lucinate send` because the two are distinct lifecycles. `send` is a non-TUI lifecycle (connect → resolve → ChatSend → drain → exit). `chat` is the regular TUI lifecycle with the picker steps short-circuited. Both SHALL share connection / agent resolution helpers (`resolveSendConnection`, `resolveSendAgent` in `app/send.go`) but otherwise have nothing in common — `chat` does not call `ChatSend` itself, never owns a `replyCollector`, and never needs `--detach`. Auth-recovery modals, supervisor reconnect, `/connections`, and every other TUI affordance SHALL keep working unchanged.
+
+#### Scenario: chat launches the interactive TUI, not a one-shot turn
+- **WHEN** a user runs `lucinate chat` with `--connection` / `--agent` / `--session` overrides
+- **THEN** the regular interactive TUI program launches with each override consumed at the transition that would otherwise have prompted the user
+- **AND** the command does not call `ChatSend`, own a `replyCollector`, or require `--detach`
+
+#### Scenario: TUI affordances keep working under chat
+- **GIVEN** a session launched via `lucinate chat`
+- **WHEN** the user encounters auth-recovery modals, supervisor reconnect, or invokes `/connections`
+- **THEN** those affordances work unchanged, exactly as under a bare `lucinate` invocation
+
+### Requirement: `app.Chat` pre-flight lifecycle
+
+`app.Chat` (`app/chat.go`) SHALL be a thin pre-flight stage that performs three steps:
+
+1. **Resolve the connection.** When `--connection` is set, `resolveSendConnection` matches by ID then case-insensitive Name; a miss is a clean error that distinguishes the empty-store first-run case from a typo against a populated store. When `--connection` is unset, `config.ResolveEntryConnection()` runs — the same env-var / default-id / single-entry decision tree the bare `lucinate` invocation uses, including the `ShowPicker` outcome that lands the user on the connections picker.
+2. **Pack the overrides into `RunOptions`.** `InitialAgent`, `InitialSession`, `InitialMessage` go onto `RunOptions`; the existing `Initial *config.Connection` carries the resolved connection (or nil for the picker). Agent and session strings are trimmed; the message is taken verbatim so leading whitespace inside a quoted argument is preserved.
+3. **Hand off to `Run`.** From here it is the regular TUI. The TUI consumes each override at a defined transition — the resolution logic that would otherwise have prompted runs, then the override is cleared.
+
+`Chat` SHALL NOT connect, list agents, or create a session itself. It SHALL defer all three to the TUI so a typo in `--agent` lands on the existing picker (with an error banner) rather than failing before the user can recover.
+
+#### Scenario: Connection resolved by explicit override
+- **GIVEN** `--connection` is set
+- **WHEN** `app.Chat` resolves it
+- **THEN** `resolveSendConnection` matches by ID then case-insensitive Name
+- **AND** a miss is a clean error that distinguishes the empty-store first-run case from a typo against a populated store
+
+#### Scenario: Connection resolved when override is unset
+- **GIVEN** `--connection` is unset
+- **WHEN** `app.Chat` resolves the connection
+- **THEN** `config.ResolveEntryConnection()` runs the same env-var / default-id / single-entry decision tree the bare `lucinate` invocation uses
+- **AND** a `ShowPicker` outcome lands the user on the connections picker
+
+#### Scenario: Overrides packed and handed to the TUI
+- **WHEN** `app.Chat` packs overrides into `RunOptions`
+- **THEN** `InitialAgent`, `InitialSession`, and `InitialMessage` are set, agent and session strings are trimmed, and the message is taken verbatim so leading whitespace inside a quoted argument is preserved
+- **AND** `Initial *config.Connection` carries the resolved connection or nil for the picker
+- **AND** control hands off to `Run` for the regular TUI
+
+#### Scenario: Chat defers connect, list, and create to the TUI
+- **GIVEN** a typo in `--agent`
+- **WHEN** `app.Chat` runs
+- **THEN** it does not connect, list agents, or create a session itself
+- **AND** the typo lands on the existing picker with an error banner rather than failing before the user can recover
+
+### Requirement: Override consumption at three transition points
+
+The three overrides SHALL live on `AppModel` in `internal/tui/app.go` and be consumed at three different transition points, as follows:
+
+| Override | Consumed at | Picker behaviour |
+|---|---|---|
+| `initialAgent` | `handleConnectResult` success branch — passed into `newSelectModel` as `autoPickName`. | The picker's `agentsLoadedMsg` handler (in `internal/tui/select.go`) runs ID-then-case-insensitive-name resolution **before** the existing single-agent auto-pick and post-create branches. A match sets `m.selected = true`; a miss sets `m.err = fmt.Errorf("agent %q not found", query)`. Either way the field is cleared so a second `agentsLoadedMsg` (e.g. after a user-driven agent create) doesn't re-fire. |
+| `initialSession` | `viewSelect` block of `update` — used to override `createKey` before `CreateSession` is invoked. | Beats both `"main"` and the connection's default-agent `MainKey`. Cleared on consume. |
+| `initialMessage` | `sessionCreatedMsg` handler — passed into `newChatModel` as a trailing arg, which appends it to `pendingMessages`. | The chat view's `historyLoadedMsg` handler returns `m.drainQueue()` when `pendingMessages` is non-empty and `!m.sending`, so the user turn lands *after* the history scrollback — matching what a human typing would see. |
+
+#### Scenario: Initial agent consumed at connect success
+- **GIVEN** `initialAgent` is set
+- **WHEN** the `handleConnectResult` success branch runs
+- **THEN** it is passed into `newSelectModel` as `autoPickName`, the `agentsLoadedMsg` handler runs ID-then-case-insensitive-name resolution before the single-agent auto-pick and post-create branches, a match sets `m.selected = true` and a miss sets `m.err = fmt.Errorf("agent %q not found", query)`
+- **AND** the field is cleared so a second `agentsLoadedMsg` doesn't re-fire
+
+#### Scenario: Initial session overrides the create key
+- **GIVEN** `initialSession` is set
+- **WHEN** the `viewSelect` block of `update` runs before `CreateSession` is invoked
+- **THEN** it overrides `createKey`, beating both `"main"` and the connection's default-agent `MainKey`
+- **AND** it is cleared on consume
+
+#### Scenario: Initial message auto-submitted after history
+- **GIVEN** `initialMessage` is set
+- **WHEN** the `sessionCreatedMsg` handler passes it into `newChatModel` as a trailing arg, which appends it to `pendingMessages`
+- **THEN** the chat view's `historyLoadedMsg` handler returns `m.drainQueue()` when `pendingMessages` is non-empty and `!m.sending`, so the user turn lands after the history scrollback matching what a human typing would see
+
+### Requirement: Auto-pick miss beats single-agent auto-pick
+
+The single-agent auto-pick at `select.go` SHALL run only when `autoPickName` was unset on entry. `--agent foo` against a single-agent connection where foo doesn't match MUST surface the error rather than silently picking the wrong agent. This precedence ordering is the design's load-bearing detail; `TestSelectModel_AutoPickName_MissBeatsSingleAgentAutoPick` (`internal/tui/select_test.go`) guards it.
+
+#### Scenario: Non-matching agent on a single-agent connection surfaces an error
+- **GIVEN** a single-agent connection and `--agent foo` where foo doesn't match
+- **WHEN** the picker resolves the agent
+- **THEN** the miss surfaces the error rather than silently picking the single available agent (the single-agent auto-pick only runs when `autoPickName` was unset on entry)
+
+### Requirement: Stale-override clearing on scope change
+
+Because agent IDs and session keys aren't portable across connections, the system SHALL clear all three overrides at the points where the user is signalling a scope change. If the user backs out of a connection the original invocation targeted, applying the original `--agent` against the new connection's agent list would either error spuriously or silently match the wrong agent. The `AppModel.update` method SHALL clear all three overrides at these points:
+
+- **`authResolvedMsg{cancelled:true}`** — user aborted the auth modal, returns to the connections picker.
+- **`handleConnectResult` unrecoverable-error branch** — connect failed in a way that bounces back to the connections picker with an error banner.
+- **`showConnectionsMsg`** — user invoked `/connections` mid-chat to switch connection.
+
+Successful `authResolvedMsg` retries (token resolved, `cancelled` false) SHALL leave the overrides set: the user just resolved the auth they originally intended to use, so the auto-pick should still fire. `handleConnectResult` success SHALL NOT clear the overrides — it consumes `initialAgent` (passing it into `newSelectModel`), but `initialSession` and `initialMessage` ride through to their later consumption points.
+
+#### Scenario: Overrides cleared when the user signals a scope change
+- **WHEN** `authResolvedMsg{cancelled:true}` fires, or the `handleConnectResult` unrecoverable-error branch runs, or `showConnectionsMsg` fires
+- **THEN** `AppModel.update` clears all three overrides
+
+#### Scenario: Successful auth retry keeps overrides
+- **GIVEN** a successful `authResolvedMsg` retry with token resolved and `cancelled` false
+- **WHEN** it is handled
+- **THEN** the overrides are left set so the auto-pick still fires
+
+#### Scenario: Connect success rides session and message overrides through
+- **WHEN** `handleConnectResult` succeeds
+- **THEN** it consumes `initialAgent` by passing it into `newSelectModel` but does not clear the overrides
+- **AND** `initialSession` and `initialMessage` ride through to their later consumption points
+
+### Requirement: Embedding `app.Chat` from Go via `ChatOptions`
+
+The system SHALL expose `ChatOptions` as the embedder seam for calling `app.Chat` from Go:
+
+```go
+err := app.Chat(ctx, app.ChatOptions{
+    Connection:       "my-con",   // empty → ResolveEntryConnection
+    Agent:            "main",
+    Session:          "",          // empty → main-session default
+    Message:          "hello",
+    BackendFactory:   nil,         // nil → DefaultBackendFactory
+    ConnectionsStore: nil,         // nil → LoadConnections()
+})
+```
+
+`resolveChatRunOptions` (the unexported core that builds `RunOptions` without spinning up Bubble Tea) SHALL be what the unit tests in `app/chat_test.go` exercise. Embedders that want to layer additional `RunOptions` fields (`HideInputArea`, `OnActionsChanged`, …) SHALL call `Chat`'s peer logic themselves rather than relying on internals — those callbacks are TUI-host concerns that don't belong in `ChatOptions`. The function SHALL be a single-shot launcher: there is no resume surface and no incremental progress callback — once the TUI is running, embedders interact with it through the `app.Program` API the bare invocation uses.
+
+#### Scenario: Embedder defaults resolved from empty fields
+- **GIVEN** an embedder calls `app.Chat` with an empty `Connection`, empty `Session`, nil `BackendFactory`, and nil `ConnectionsStore`
+- **THEN** `Connection` falls back to `ResolveEntryConnection`, `Session` falls back to the main-session default, `BackendFactory` falls back to `DefaultBackendFactory`, and `ConnectionsStore` falls back to `LoadConnections()`
+
+#### Scenario: RunOptions built without Bubble Tea for tests
+- **WHEN** the unit tests in `app/chat_test.go` run
+- **THEN** they exercise `resolveChatRunOptions`, the unexported core that builds `RunOptions` without spinning up Bubble Tea
+
+#### Scenario: Single-shot launcher with no resume surface
+- **WHEN** an embedder calls `app.Chat`
+- **THEN** it is a single-shot launcher with no resume surface and no incremental progress callback
+- **AND** once the TUI is running, embedders interact with it through the `app.Program` API the bare invocation uses
+
+### Requirement: No pre-flight agent or session validation
+
+The system SHALL NOT perform pre-flight agent / session validation; the TUI SHALL be the validator. A typo in `--agent` lands on the picker with an error banner; a typo in `--session` reaches the backend's `CreateSession`, which decides whether to create-or-resume. Surfacing those errors before the TUI starts would mean a Connect + ListAgents round-trip from `Chat` itself, duplicating the picker's existing error path.
+
+#### Scenario: Agent typo validated by the TUI
+- **GIVEN** a typo in `--agent`
+- **WHEN** the TUI runs
+- **THEN** the invocation lands on the picker with an error banner rather than being validated before the TUI starts
+
+#### Scenario: Session typo reaches CreateSession
+- **GIVEN** a typo in `--session`
+- **WHEN** the TUI runs
+- **THEN** it reaches the backend's `CreateSession`, which decides whether to create-or-resume
+
+### Requirement: Single first-turn message, not multi-turn pre-seeding
+
+The system SHALL treat `--message` as a single first-turn override, not a script. Chains of turns belong on the TUI side (the user types follow-ups) or the `send` side (one turn per invocation, optionally `--detach`'d).
+
+#### Scenario: Message is a single first turn
+- **WHEN** `--message` is provided
+- **THEN** it is auto-submitted as a single first turn, not a script of multiple turns
+- **AND** multi-turn chains belong on the TUI side (user follow-ups) or the `send` side (one turn per invocation, optionally `--detach`'d)
+
+### Requirement: No slash-command parsing on auto-submit
+
+The auto-submitted message SHALL drain through `drainQueue`, not the textarea's Enter handler. `drainQueue` recognises `!` and `!!` exec prefixes and does skill-reference expansion, but it SHALL NOT dispatch slash commands. A message of `/sessions` is sent to the agent as the literal string `/sessions`, not routed to the sessions browser. Scripted workflows that want slash-command effects SHALL call the corresponding RPC directly — the same advice as `send`.
+
+#### Scenario: Slash command sent as a literal string
+- **GIVEN** an auto-submitted message of `/sessions`
+- **WHEN** it drains through `drainQueue`
+- **THEN** it is sent to the agent as the literal string `/sessions`, not routed to the sessions browser
+- **AND** `drainQueue` still recognises `!` and `!!` exec prefixes and does skill-reference expansion
+
+#### Scenario: Scripted slash-command effects use RPC directly
+- **GIVEN** a scripted workflow that wants slash-command effects
+- **WHEN** it needs those effects on auto-submit
+- **THEN** it calls the corresponding RPC directly, the same advice as `send`

--- a/openspec/specs/chat-ux/spec.md
+++ b/openspec/specs/chat-ux/spec.md
@@ -1,0 +1,399 @@
+# Chat UX Specification
+
+## Purpose
+
+Define the interactive chat surface of lucinate: how the input box interprets key bindings, how sent messages stream back with animated feedback, how the header bar reports agent, model, context usage, connection and update state, how the view regions are stacked and how ephemeral notifications, routine status, and tool activity are surfaced. It also covers message recall, extended-thinking levels, history depth and mid-turn resync, connect timeout, and the mouse-driven scrolling and selection model. This is a faithful reformat of the chat-ux maintainer doc.
+
+## Requirements
+
+### Requirement: Input key bindings
+
+The chat input box SHALL interpret the following key bindings:
+
+| Key | Action |
+|---|---|
+| Enter | Send message — or, on empty input with an active routine, advance the routine (see the `routines` spec) |
+| Alt+Enter | Insert newline |
+| Ctrl+W | Delete word backward |
+| Up arrow (empty input) | Recall the last queued message for editing, or start a bash-style walk back through previously sent messages |
+| Down arrow (while walking) | Walk forward again; at the newest entry, clear the input |
+| Tab | Open slash menu, extend to longest common prefix, then cycle |
+| Shift+Tab | While slash-menu is cycling: cycle backward through candidates. Otherwise, with an active routine: cycle the routine's mode (auto ↔ manual) |
+| Page Up / Page Down | Scroll message history |
+| Mouse wheel | Scroll message history — see the "Scrolling, selection, and the mouse" requirement |
+| Mouse click-drag | Select transcript text; copies to the clipboard on release |
+| Esc | Cancel in-progress response — or, with an active routine, end the routine and (if streaming) cancel the turn |
+
+Alt+Enter SHALL be configured via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")` in `chat.go`. Shift+Enter SHALL NOT be supported — `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input.
+
+#### Scenario: Newline binding uses Alt+Enter, not Shift+Enter
+- **GIVEN** the chat input box is focused
+- **WHEN** the user presses Alt+Enter
+- **THEN** a newline is inserted via `ta.KeyMap.InsertNewline.SetKeys("alt+enter")`
+- **AND** Shift+Enter is not supported because `ReportAllKeysAsEscapeCodes` is disabled to preserve shifted punctuation input
+
+#### Scenario: Esc cancels the in-progress response
+- **GIVEN** a response is in progress
+- **WHEN** the user presses Esc
+- **THEN** the in-progress response is cancelled
+- **AND** with an active routine, Esc instead ends the routine and (if streaming) cancels the turn
+
+### Requirement: Message recall
+
+When the textarea is empty and the user presses Up arrow, the system SHALL pop the last entry in `m.pendingMessages` and insert it into the textarea with the cursor at the end, so that a recently queued message can be edited and resent without retyping it.
+
+With no queued messages, Up SHALL start a bash-style walk back through previously submitted user messages (`historyBrowseIndex` / `historyBrowseValue` in `chat.go`): repeated Up steps older, Down steps newer, and reaching the newest entry clears the input. The walk SHALL end as soon as the recalled text is edited — Up/Down then revert to ordinary cursor movement within multi-line content. Because mouse capture is on by default, the terminal never synthesises arrow keys from the wheel, so scrolling cannot accidentally trigger a walk (see the "Scrolling, selection, and the mouse" requirement).
+
+#### Scenario: Recall the last queued message
+- **GIVEN** the textarea is empty and `m.pendingMessages` has at least one entry
+- **WHEN** the user presses Up arrow
+- **THEN** the last entry in `m.pendingMessages` is popped and inserted into the textarea with the cursor at the end
+
+#### Scenario: Bash-style walk through submitted messages
+- **GIVEN** the textarea is empty and there are no queued messages
+- **WHEN** the user presses Up arrow
+- **THEN** a walk back through previously submitted user messages begins using `historyBrowseIndex` / `historyBrowseValue`
+- **AND** repeated Up steps older, Down steps newer, and reaching the newest entry clears the input
+
+#### Scenario: Editing ends the walk
+- **GIVEN** the user is walking through previously submitted messages
+- **WHEN** the recalled text is edited
+- **THEN** the walk ends and Up/Down revert to ordinary cursor movement within multi-line content
+
+### Requirement: Streaming animation
+
+When a message is sent, the system SHALL immediately append an assistant message with `streaming: true` to the display so there is always visible feedback. A braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) SHALL animate at 120 ms intervals via `spinnerTickCmd()`; each frame increments `m.spinnerFrame` and re-renders the last message line.
+
+As delta events arrive from the gateway, the message content SHALL be built up in place. When the final event arrives, `streaming` SHALL be set to false and the spinner SHALL stop. If the final event arrives before any delta (empty response), the placeholder SHALL be removed from the display entirely.
+
+The same spinner SHALL also decorate pending system rows (`chatMessage.pending`) — the in-flight placeholders posted by `/compact` and `/reset` after confirmation. `hasStreamingMessage()` SHALL treat any pending system row as a reason to keep ticking, and the result handler SHALL swap the placeholder for the outcome via `replacePendingSystem` so the spinner is replaced in place rather than appended after. The confirmation-pattern wiring is captured in the `commands` spec, and the rendering side is captured in the `message-rendering` spec.
+
+#### Scenario: Placeholder appears immediately on send
+- **WHEN** a message is sent
+- **THEN** an assistant message with `streaming: true` is appended immediately
+- **AND** the braille spinner `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏` animates at 120 ms intervals via `spinnerTickCmd()`, incrementing `m.spinnerFrame` and re-rendering the last message line
+
+#### Scenario: Deltas build content, final stops the spinner
+- **GIVEN** a streaming assistant message
+- **WHEN** delta events arrive and then the final event arrives
+- **THEN** the content is built up in place, `streaming` is set to false, and the spinner stops
+
+#### Scenario: Empty response removes the placeholder
+- **GIVEN** a streaming placeholder is shown
+- **WHEN** the final event arrives before any delta
+- **THEN** the placeholder is removed from the display entirely
+
+#### Scenario: Pending system row keeps the spinner ticking
+- **GIVEN** a pending system row from `/compact` or `/reset` (`chatMessage.pending`)
+- **WHEN** `hasStreamingMessage()` is evaluated
+- **THEN** it treats the pending row as a reason to keep ticking, and `replacePendingSystem` swaps the placeholder for the outcome in place
+
+### Requirement: Thinking levels
+
+The gateway SHALL support extended thinking for supported models. The level SHALL be stored in `m.thinkingLevel` and displayed in the header bar when set and not `"off"`. Valid levels SHALL be: `off`, `minimal`, `low`, `medium`, `high`.
+
+`/think` (no argument) SHALL show the current level. `/think <level>` SHALL validate the input and call `client.SessionPatchThinking(sessionKey, level)` (command dispatch is captured in the `commands` spec). The spinner SHALL also appear while the model is thinking before any response deltas arrive, giving immediate feedback after sending.
+
+#### Scenario: Show the current thinking level
+- **WHEN** the user runs `/think` with no argument
+- **THEN** the current level is shown
+
+#### Scenario: Set a valid thinking level
+- **WHEN** the user runs `/think <level>` with one of `off`, `minimal`, `low`, `medium`, `high`
+- **THEN** the input is validated and `client.SessionPatchThinking(sessionKey, level)` is called
+- **AND** the level is displayed in the header bar when set and not `"off"`
+
+#### Scenario: Spinner during thinking
+- **GIVEN** a message has been sent and the model is thinking
+- **WHEN** no response deltas have yet arrived
+- **THEN** the spinner appears to give immediate feedback
+
+### Requirement: Header bar layout
+
+The header line SHALL show:
+
+- **Left:** agent name · model ID (last path component) · thinking level (if set and not `off`) · connection status (only when not connected) · update-available badge (only when `prefs.UpdateChecksEnabled()` and the startup check found a newer release)
+- **Right:** context usage (`tokens: 65k/1.0m (7%)  $0.42`) when the gateway has reported a context window for the active session; otherwise the legacy `tokens: 125.5K (2.3K cached)  $0.42` shape.
+
+The renderer SHALL cap the percentage at 999% so a runaway numerator never widens the header past three digits.
+
+#### Scenario: Right-hand context usage shape
+- **GIVEN** the gateway has reported a context window for the active session
+- **WHEN** the header is rendered
+- **THEN** the right side shows `tokens: 65k/1.0m (7%)  $0.42`
+- **AND** otherwise it shows the legacy `tokens: 125.5K (2.3K cached)  $0.42` shape
+
+#### Scenario: Percentage capped at 999%
+- **WHEN** a runaway numerator would push the percentage past three digits
+- **THEN** the renderer caps the displayed percentage at 999%
+
+### Requirement: Header context-usage and cost loading
+
+Two independent loads SHALL feed the right-hand side of the header:
+
+- `loadContextUsage()` SHALL populate `m.promptTokens` and `m.contextWindow`. It calls `SessionsList(agentID)`, finds the entry whose `key` matches `m.sessionKey`, and reads `totalTokens` (numerator — a per-turn prompt-token snapshot of `input + cacheRead + cacheWrite`, intentionally excluding output) and `contextTokens` (denominator), falling back to `defaults.contextTokens` when the entry omits the window. This is what makes the percentage scoped to the *current session*; the older approach of calling `SessionUsage("")` returned gateway-wide aggregates and pegged the value at 999%. The cmd SHALL refresh on chat init, on every `historyRefreshMsg` (so the percentage tracks turn-by-turn), and on `modelSwitchedMsg` (a new model can change the window). The handler SHALL discard results whose `sessionKey` no longer matches `m.sessionKey` so a navigated-away-and-back race cannot apply a stale snapshot.
+- `loadStats()` SHALL continue to call `client.SessionUsage()` for the cumulative cost figure shown on the right of the header (and for the `/stats` table). The percentage display SHALL fall back to its token+cache layout when `loadContextUsage` has not produced a window yet.
+
+#### Scenario: Session-scoped context usage
+- **WHEN** `loadContextUsage()` runs
+- **THEN** it calls `SessionsList(agentID)`, matches the entry whose `key` is `m.sessionKey`, and reads `totalTokens` (numerator, `input + cacheRead + cacheWrite`, excluding output) and `contextTokens` (denominator)
+- **AND** falls back to `defaults.contextTokens` when the entry omits the window
+
+#### Scenario: Refresh triggers
+- **WHEN** chat init, a `historyRefreshMsg`, or a `modelSwitchedMsg` occurs
+- **THEN** `loadContextUsage()` refreshes so the percentage tracks turn-by-turn and picks up a new model's window
+
+#### Scenario: Stale snapshot discarded
+- **GIVEN** the user navigated away and back
+- **WHEN** a context-usage result arrives whose `sessionKey` no longer matches `m.sessionKey`
+- **THEN** the handler discards it
+
+#### Scenario: Cost figure and fallback layout
+- **WHEN** `loadStats()` runs
+- **THEN** it calls `client.SessionUsage()` for the cumulative cost figure (also used by the `/stats` table)
+- **AND** the percentage display falls back to its token+cache layout when `loadContextUsage` has not produced a window yet
+
+### Requirement: Per-agent header colour override
+
+The header background SHALL default to the accent purple but MAY be overridden per agent with `/header <hex>` (see the `commands` spec). The override SHALL be stored against the agent ID under `prefs.Agents[agentID].HeaderColor`; the renderer SHALL call `prefs.HeaderColorFor(m.agentID)` each frame and apply the colour to both `headerStyle` and the warn-badge background. Switching to another agent SHALL pick up that agent's own colour (or the default).
+
+#### Scenario: Override the header colour for an agent
+- **WHEN** the user runs `/header <hex>`
+- **THEN** the colour is stored under `prefs.Agents[agentID].HeaderColor`
+- **AND** the renderer applies `prefs.HeaderColorFor(m.agentID)` each frame to both `headerStyle` and the warn-badge background
+
+#### Scenario: Switching agents picks up per-agent colour
+- **WHEN** the user switches to another agent
+- **THEN** the header uses that agent's own colour, or the default if none is set
+
+### Requirement: Connection-status badge
+
+The connection-status badge SHALL be rendered in the error colour and SHALL appear only when the gateway connection is degraded:
+
+| Badge | Meaning |
+|---|---|
+| `⚠ disconnected` | The supervisor has just observed the WebSocket close; reconnect not yet attempted. |
+| `⟳ reconnecting` (or `attempt N`) | A reconnect attempt is in progress. The attempt counter is shown from the second attempt onwards. |
+| `✖ auth failed` | The gateway rejected the device token mid-session. The supervisor has stopped retrying — open `/connections` and re-pick the same connection so the connecting view's auth-recovery modal can prompt for a fix. |
+
+A matching one-line system message SHALL also be added to the chat scrollback on disconnect (`Lost gateway connection — attempting to reconnect…`) and on recovery (`Reconnected to gateway.`) so the event is visible even after the badge clears. The full lifecycle is captured in the `authentication` spec.
+
+#### Scenario: Disconnected badge on WebSocket close
+- **WHEN** the supervisor observes the WebSocket close before a reconnect attempt
+- **THEN** the header shows `⚠ disconnected` in the error colour
+
+#### Scenario: Reconnecting badge with attempt counter
+- **GIVEN** a reconnect attempt is in progress
+- **WHEN** the header renders
+- **THEN** it shows `⟳ reconnecting` (with `attempt N` from the second attempt onwards)
+
+#### Scenario: Auth-failed badge stops retrying
+- **GIVEN** the gateway rejected the device token mid-session
+- **WHEN** the header renders
+- **THEN** it shows `✖ auth failed` and the supervisor has stopped retrying
+- **AND** the user must open `/connections` and re-pick the same connection so the auth-recovery modal can prompt for a fix
+
+#### Scenario: Scrollback notes on disconnect and recovery
+- **WHEN** the connection drops and later recovers
+- **THEN** a one-line system message `Lost gateway connection — attempting to reconnect…` is added on disconnect and `Reconnected to gateway.` on recovery, visible even after the badge clears
+
+### Requirement: Update-available badge
+
+A second header badge — `↑ vX.Y.Z`, rendered in the same warn style as `⚠ disconnected` — SHALL appear when the daily startup update check finds a newer release. The check SHALL be owned by `internal/update`: a single `GET https://lucinate.ai/latest.json` with a 5-second timeout, fired once per day from `AppModel.Init()`. If anything goes wrong (offline, captive portal, malformed manifest, non-stable build), `update.Check` SHALL return `nil, nil` — no badge, no error.
+
+The badge SHALL be suppressed once the user has seen it: `prefs.LatestSeenVersion` records the manifest version on every successful check, and the badge SHALL appear only when the manifest moves *past* that version. The whole feature MAY be toggled off via the `Check for updates on startup` row in `/settings`, or set `LUCINATE_DISABLE_UPDATE_CHECK=1` for an unconditional opt-out (useful in CI). The manifest URL itself MAY be overridden via `LUCINATE_UPDATE_MANIFEST_URL` for local testing.
+
+#### Scenario: Badge appears for a newer release
+- **GIVEN** update checks are enabled
+- **WHEN** the daily `GET https://lucinate.ai/latest.json` (5-second timeout, once per day from `AppModel.Init()`) finds a version past `prefs.LatestSeenVersion`
+- **THEN** the `↑ vX.Y.Z` badge appears in the warn style
+
+#### Scenario: Check failure is silent
+- **WHEN** the check hits an error (offline, captive portal, malformed manifest, non-stable build)
+- **THEN** `update.Check` returns `nil, nil` with no badge and no error
+
+#### Scenario: Opting out of the update check
+- **WHEN** the `Check for updates on startup` row in `/settings` is off, or `LUCINATE_DISABLE_UPDATE_CHECK=1` is set
+- **THEN** the update check is disabled
+- **AND** `LUCINATE_UPDATE_MANIFEST_URL` may override the manifest URL for local testing
+
+### Requirement: View region order
+
+`chatModel.View()` (`internal/tui/chat.go`) SHALL assemble the chat view top→bottom in this fixed order. Every region between the header and the input SHALL reserve conversation-viewport height via `applyLayout`, and each SHALL render only when it has content:
+
+1. **Header** — the status bar (connection, agent, model, token/cost).
+2. **Info notifications** — informational one-shots such as `copied … to clipboard`, pinned just below the header.
+3. **Conversation viewport** — the scrollable transcript.
+4. **Completion menu** — slash-command / mention candidates, while active.
+5. **Routine status row** — when a routine is active.
+6. **Tool-activity strip** — what the agent is running this turn (collapses to a summary when idle).
+7. **Queued-message footer** — messages typed while a turn streams, awaiting dispatch.
+8. **Error notifications** — error one-shots; the bottommost region above the input.
+9. **Input box.**
+10. **Help line.**
+
+Informational and error notifications SHALL be deliberately split to opposite ends. An informational confirmation reads naturally at the top beside the status bar, while an error surfaces at the bottom next to the input, where the user will act on it. Both SHALL be drawn from the same `chatModel.notifications` store, filtered on the `isError` flag by `renderInfoNotifications` / `renderErrorNotifications`.
+
+#### Scenario: Fixed top-to-bottom region order
+- **WHEN** `chatModel.View()` assembles the chat view
+- **THEN** regions render in order: header, info notifications, conversation viewport, completion menu, routine status row, tool-activity strip, queued-message footer, error notifications, input box, help line
+- **AND** each region between header and input reserves viewport height via `applyLayout` and renders only when it has content
+
+#### Scenario: Notifications split to opposite ends
+- **GIVEN** the shared `chatModel.notifications` store filtered on `isError`
+- **WHEN** notifications render
+- **THEN** informational rows pin to the top just below the header via `renderInfoNotifications` and error rows drop to the bottommost region above the input via `renderErrorNotifications`
+
+### Requirement: Notifications
+
+Ephemeral state messages — confirmation prompts, cancel acks, routine state changes (see the `routines` spec) — SHALL render as one or more width-padded rows, styled with `statusStyle` (or `errorStyle` for is-error rows). They SHALL be split by kind: informational rows pin to the top just below the header, and error rows drop to the bottommost region below the queued-message footer (see the "View region order" requirement for how they sit relative to the other regions).
+
+The store SHALL be `chatModel.notifications []notification` (`internal/tui/notifications.go`). Notifications SHALL live outside `m.messages`, so they survive `historyRefreshMsg` and never reach the gateway. They SHALL be cleared at the top of the Enter handler whenever the user submits a non-empty input, and on the empty-Enter routine-advance path — the assumption is that any state worth showing in a notification has been read or no longer applies once the user takes their next action.
+
+`m.notify(text)`, `m.notifyError(text)`, and `m.clearNotifications()` SHALL be the only entry points; each SHALL call `applyLayout()` so the conversation viewport reflows when notifications appear or disappear. Empty text SHALL be dropped silently so callers can `notify(maybeFmt(...))` without a guard.
+
+This replaced the older pattern of appending `chatMessage{role:"system"}` rows for transient state. Persistent client-side rows (the inline `! cmd` / `!! cmd` shell-execution scrollback, gateway connect/disconnect notes, the `/help` / `/stats` / `/skills` info dumps) still go in `m.messages` because their value is in being scrollable history, not in a one-shot read.
+
+#### Scenario: Notifications survive history refresh
+- **GIVEN** notifications live in `chatModel.notifications` outside `m.messages`
+- **WHEN** a `historyRefreshMsg` lands
+- **THEN** notifications survive and never reach the gateway
+
+#### Scenario: Notifications cleared on next action
+- **WHEN** the user submits a non-empty input, or takes the empty-Enter routine-advance path
+- **THEN** notifications are cleared at the top of the Enter handler
+
+#### Scenario: Only entry points, reflow, empty dropped
+- **WHEN** `m.notify(text)`, `m.notifyError(text)`, or `m.clearNotifications()` is called
+- **THEN** each calls `applyLayout()` so the viewport reflows
+- **AND** empty text is dropped silently so callers can `notify(maybeFmt(...))` without a guard
+
+#### Scenario: Persistent rows still use the message list
+- **WHEN** an inline `! cmd` / `!! cmd` shell-execution row, a gateway connect/disconnect note, or a `/help` / `/stats` / `/skills` info dump is produced
+- **THEN** it goes in `m.messages` because its value is in being scrollable history, not a one-shot read
+
+### Requirement: Routine status row
+
+When `m.activeRoutine != nil`, a single styled row SHALL render immediately above the input box:
+
+```
+routine: demo — AUTO — sent: 5/10 — next: <40-char preview>
+```
+
+`AUTO`/`MANUAL` SHALL reflect the controller's mode; `(paused)` SHALL be appended when `paused` is set. The row SHALL be sourced by `routineStatusLine()` and styled by `routineStatusStyle` in `routines_chat.go`. `applyLayout()` SHALL subtract one from the viewport height when a routine is active, mirroring the notification-row accounting. The full controller surface is captured in the `routines` spec.
+
+#### Scenario: Routine status row rendered above the input
+- **GIVEN** `m.activeRoutine != nil`
+- **WHEN** the chat view renders
+- **THEN** a single styled row like `routine: demo — AUTO — sent: 5/10 — next: <40-char preview>` renders immediately above the input box, sourced by `routineStatusLine()` and styled by `routineStatusStyle`
+- **AND** `AUTO`/`MANUAL` reflects the controller's mode and `(paused)` is appended when `paused` is set
+- **AND** `applyLayout()` subtracts one from the viewport height while a routine is active
+
+### Requirement: Tool activity strip
+
+When the agent invokes a tool, it SHALL appear in an ephemeral strip above the input (not in the scrollback) — name, one-line argument summary, and a state glyph that animates while running and resolves to ✓ or ✖. Once the turn finishes the strip SHALL collapse to a one-line summary (`✓ called search ×3, read ×2`) that clears when the next turn begins. Lucinate SHALL opt into the `tool-events` capability on connect; backends without tool events (e.g. the OpenAI-compatible adapter) simply never emit them. Tool output bodies are not yet expandable — the rendering contract and the open follow-up for an expand/collapse affordance are captured in the `message-rendering` spec.
+
+#### Scenario: Tool invocation shows in the strip
+- **WHEN** the agent invokes a tool
+- **THEN** an ephemeral strip above the input (not the scrollback) shows the name, a one-line argument summary, and a state glyph that animates while running and resolves to ✓ or ✖
+
+#### Scenario: Strip collapses after the turn
+- **WHEN** the turn finishes
+- **THEN** the strip collapses to a one-line summary such as `✓ called search ×3, read ×2`
+- **AND** the summary clears when the next turn begins
+
+#### Scenario: Backends without tool events
+- **GIVEN** a backend without tool events (e.g. the OpenAI-compatible adapter)
+- **WHEN** the agent runs
+- **THEN** no tool events are emitted even though lucinate opts into the `tool-events` capability on connect
+
+### Requirement: History depth
+
+The number of messages loaded from the gateway on session init SHALL be configurable. The default SHALL be 50. It MAY be changed via `/settings` ("History limit") in steps of 10 (range 10–500). The value SHALL be stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit.
+
+When restored history is non-empty, a dimmed separator row SHALL be rendered above the new turn, labelled with the relative time of the most recent restored message (`Resumed from 2h ago`, `…`). The label SHALL come from `formatSeparatorLabel` (`render.go`), driven by the `timestampMs` field on the synthetic separator `chatMessage` (the role is captured in the `message-rendering` spec). How history loading fits into the session lifecycle is captured in the `sessions` spec.
+
+#### Scenario: Configurable history limit
+- **WHEN** the user changes "History limit" in `/settings`
+- **THEN** the value (default 50, range 10–500 in steps of 10) is stored in `prefs.HistoryLimit` and passed to `loadHistory()` as the fetch limit
+
+#### Scenario: Resumed-from separator on non-empty history
+- **GIVEN** restored history is non-empty
+- **WHEN** the chat view renders
+- **THEN** a dimmed separator row appears above the new turn labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`), from `formatSeparatorLabel` driven by the `timestampMs` field on the synthetic separator `chatMessage`
+
+### Requirement: Mid-turn history resync
+
+After a turn finalises, the chat view SHALL fetch `chat.history` from the gateway and merge it into `m.messages`. The merge SHALL NOT be a wholesale replacement — that would wipe live state (the next routine step's placeholder, a system row the user just took an action on). (Tool activity lives outside `m.messages`, so it is untouched by the merge.)
+
+The mechanism SHALL be a generation counter:
+
+- `chatModel.gen` is a monotonically increasing `uint64` (starts at 1).
+- Every `appendMessage(...)` stamps the current `m.gen` onto the row.
+- A successful `final` (or `error`/`aborted`) calls `bumpGen()`, which captures the current value as the "boundary" and then advances the counter. The boundary is what the just-issued `refreshHistoryAt(boundary)` carries.
+- When the resulting `historyRefreshMsg` lands, `mergeHistoryRefresh(server, boundary)` keeps every existing row with `gen > boundary` (the live tail — appended by the post-bump `drainQueue` / `maybeAdvanceRoutine` / recovery path) and prepends the server-fetched canonical state.
+
+Practical consequences:
+
+- Rows imported from `chat.history` carry `gen=0` (the chatMessage zero value), so any subsequent refresh treats them as history-side and replaces them cleanly.
+- Tool activity is not part of `m.messages` at all (it lives in `chatModel.activeTools`, rendered in the tool-activity strip), so the merge neither preserves nor wipes it — it is reset per turn independently.
+- Empty `final` acks (the gateway ping that arrives before any real content) intentionally do NOT bump the gen, because no turn has actually completed.
+
+Tests SHALL pin the contract: `TestMergeHistoryRefresh_PreservesLiveTail`, `TestMergeHistoryRefresh_NoLiveTail`, `TestHandleEvent_FinalBumpsGen`, `TestHandleEvent_FinalEmptyAckDoesNotBumpGen`.
+
+#### Scenario: Merge preserves the live tail
+- **GIVEN** a successful `final` called `bumpGen()` capturing a boundary and `refreshHistoryAt(boundary)` was issued
+- **WHEN** the `historyRefreshMsg` lands
+- **THEN** `mergeHistoryRefresh(server, boundary)` keeps every existing row with `gen > boundary` (the live tail) and prepends the server-fetched canonical state, rather than doing a wholesale replacement
+
+#### Scenario: Imported history rows are replaced cleanly
+- **GIVEN** rows imported from `chat.history` carry `gen=0`
+- **WHEN** a subsequent refresh runs
+- **THEN** they are treated as history-side and replaced cleanly
+
+#### Scenario: Empty final ack does not bump gen
+- **WHEN** an empty `final` ack (the gateway ping before any real content) arrives
+- **THEN** the gen is not bumped because no turn has actually completed
+
+#### Scenario: Tool activity untouched by the merge
+- **GIVEN** tool activity lives in `chatModel.activeTools`, outside `m.messages`
+- **WHEN** the history merge runs
+- **THEN** the merge neither preserves nor wipes tool activity; it is reset per turn independently
+
+### Requirement: Connect timeout
+
+Each (re)connect attempt SHALL have a per-attempt deadline applied to the WebSocket / HTTP handshake. The default SHALL be 15 seconds; the range SHALL be 5–300 seconds via `/settings` ("Connect timeout"). The configured value SHALL be loaded by `app.DefaultBackendFactory` (`app/factory.go`) for every backend dispatch, so the same setting governs the initial connect and the supervisor's reconnect attempts. It SHOULD be bumped when targeting a slow local LLM that cold-starts on first request.
+
+#### Scenario: Per-attempt handshake deadline
+- **WHEN** a connect or reconnect attempt runs
+- **THEN** a per-attempt deadline (default 15s, range 5–300s via `/settings` "Connect timeout") applies to the WebSocket / HTTP handshake, loaded by `app.DefaultBackendFactory` for every backend dispatch so it governs both the initial connect and the supervisor's reconnect attempts
+
+### Requirement: Scrolling, selection, and the mouse
+
+The message history SHALL be a Bubble Tea viewport. Mouse capture (SGR cell-motion tracking) SHALL be on by default, which makes the three core interactions coexist cleanly:
+
+- **Wheel / trackpad scrolls the history.** Wheel events SHALL be forwarded to the viewport directly. Because tracking is on, the terminal never translates the wheel into arrow keys, so scrolling cannot collide with input recall. If the user has scrolled up, new streaming output SHALL NOT yank them back down; new messages SHALL re-anchor to the bottom only when already there (`GotoBottom()` after each update).
+- **Click-drag selects and copies.** Dragging over the transcript SHALL draw a reverse-video highlight; on release the selected text SHALL be copied to the clipboard (both OSC 52 through the terminal and the OS clipboard directly), with a "Copied …" confirmation row. This SHALL be implemented in `internal/tui/selection.go`. Selections SHALL be char-precise, span multiple lines, auto-scroll when dragged past the viewport edge, and strip styling from the copied text.
+- **Up/Down remain input recall.** The bash-style walk through previously submitted messages (and queued-message editing) SHALL own the arrow keys exclusively; scrolling never reaches them.
+
+Page Up/Down SHALL still scroll a page at a time. `/mouse off` SHALL opt out of capture, handing click-drag back to the terminal's native selection at the cost of wheel scrolling (the previous default behaviour); `/mouse on` SHALL restore the default.
+
+#### Scenario: Wheel scrolls without hijacking recall
+- **GIVEN** mouse capture (SGR cell-motion tracking) is on by default
+- **WHEN** the user scrolls with the wheel or trackpad
+- **THEN** wheel events are forwarded to the viewport directly and the terminal never translates them into arrow keys, so scrolling cannot collide with input recall
+
+#### Scenario: Scrolled-up view is not yanked down
+- **GIVEN** the user has scrolled up
+- **WHEN** new streaming output arrives
+- **THEN** the view is not yanked to the bottom; new messages re-anchor to the bottom only when already there (`GotoBottom()` after each update)
+
+#### Scenario: Click-drag selects and copies
+- **WHEN** the user drags over the transcript and releases
+- **THEN** a reverse-video highlight is drawn and the selected text is copied to the clipboard via OSC 52 and the OS clipboard directly, with a "Copied …" confirmation row
+- **AND** selections are char-precise, span multiple lines, auto-scroll past the viewport edge, and strip styling from the copied text, as implemented in `internal/tui/selection.go`
+
+#### Scenario: Toggling mouse capture
+- **WHEN** the user runs `/mouse off`
+- **THEN** capture is opted out, handing click-drag back to the terminal's native selection at the cost of wheel scrolling
+- **AND** `/mouse on` restores the default; Page Up/Down still scroll a page at a time

--- a/openspec/specs/commands/spec.md
+++ b/openspec/specs/commands/spec.md
@@ -1,0 +1,453 @@
+# Slash Commands Specification
+
+## Purpose
+
+Slash commands are local TUI commands that begin with `/`. They are intercepted by
+`handleSlashCommand()` in `internal/tui/commands.go` before any message is sent to the
+gateway, so they run entirely on the client and never reach the backend when handled.
+This spec covers command dispatch, the full set of built-in commands and their individual
+behaviours, tab completion, the yes/no confirmation pattern, and the routine-active
+navigation gate.
+
+## Requirements
+
+### Requirement: Slash command interception and dispatch
+
+The system SHALL intercept input that begins with `/` via `handleSlashCommand()` in
+`internal/tui/commands.go` before any message is sent to the gateway. The function SHALL
+return `(handled bool, cmd tea.Cmd)` — when `handled` is true the input SHALL be consumed
+locally and never forwarded to the backend.
+
+Input that starts with `/` and contains no spaces SHALL be matched case-insensitively
+against a `switch` statement of built-in commands. Commands that accept an argument (e.g.
+`/agent foo`, `/model sonnet`, `/think high`) SHALL be matched by prefix check after the
+switch.
+
+Slash input that is not a built-in SHALL be checked against the loaded skill names: if the
+first token (`/foo` from `/foo bar`) matches a skill, `handleSlashCommand` SHALL return
+`(false, nil)` and let the regular send path expand it via `expandSkillReferences` (see the
+`skills` spec). If it matches neither a built-in nor a skill, an error system message SHALL
+be shown.
+
+#### Scenario: Built-in command consumed locally
+- **WHEN** the user submits a built-in slash command such as `/clear`
+- **THEN** `handleSlashCommand()` returns `handled = true` and the input is consumed locally
+- **AND** it is never forwarded to the gateway
+
+#### Scenario: Command with an argument matched by prefix
+- **WHEN** the user submits `/model sonnet`
+- **THEN** the case-insensitive switch does not match the whole token, so the argument-bearing prefix check matches `/model ` and handles it
+
+#### Scenario: Slash input matching a loaded skill
+- **GIVEN** a loaded skill named `foo`
+- **WHEN** the user submits `/foo bar`
+- **THEN** `handleSlashCommand` returns `(false, nil)`
+- **AND** the regular send path expands it via `expandSkillReferences`
+
+#### Scenario: Slash input matching neither built-in nor skill
+- **WHEN** the user submits a slash token that matches no built-in and no skill
+- **THEN** an error system message is shown
+
+### Requirement: Built-in slash command catalogue
+
+The system SHALL provide the following built-in slash commands. Backend-only commands
+(marked **OpenClaw only**) SHALL render a "not available on this connection" system message
+on connections that do not support them (see the `connections` spec — capability negotiation).
+
+| Command | What it does |
+|---|---|
+| `/agent` | Return to the agent picker (alias for `/agents`) |
+| `/agent <name>` | Switch to a named agent without going through the picker |
+| `/agents` | Return to the agent picker by emitting `goBackMsg{}` |
+| `/cancel` | Cancel the in-progress response (also triggered by Escape) — see the `chat-ux` spec |
+| `/clear` | Wipe `m.messages` from the local display (does not affect gateway history) |
+| `/compact` | Compact the session context — see the `sessions` spec |
+| `/config` | Backward-compatible alias for `/settings` |
+| `/connections` | Open the connections picker mid-session, tearing down the active backend — see the `connections` spec |
+| `/crons` | Open the cron browser filtered to the current agent — see the `crons` spec — **OpenClaw only** |
+| `/crons all` | Open the cron browser unfiltered (jobs across all agents) — **OpenClaw only** |
+| `/cron <name>` | Resolve a named cron job and run it immediately after a y/n confirmation — **OpenClaw only** |
+| `/exit`, `/quit` | Exit via `tea.Quit` |
+| `/export` | Write the current session's canonical history to a transcript file |
+| `/export all` | Same as `/export` |
+| `/export routine` | Convert the session's user prompts into routine steps and open the form prepopulated |
+| `/header` | Show the chat header background colour for the current agent |
+| `/header <hex>` | Set the chat header background for the current agent to a hex colour (e.g. `#4FC3F7`, `#F0C`); persisted per agent across runs |
+| `/header reset` | Restore the default header colour for the current agent (also accepts `default` or `off`) |
+| `/help`, `/commands` | Print static help text; appends skill count if any are loaded |
+| `/model` | Report the model in use for the current session |
+| `/model <name>` | Switch model |
+| `/models` | Open the model picker (filter as you type) |
+| `/mouse` | Report the current mouse-capture state |
+| `/mouse on` | Enable mouse capture (the default): wheel scrolls history, click-drag selects and copies — see the `chat-ux` spec |
+| `/mouse off` | Disable capture, handing click-drag back to the terminal's native selection (wheel scrolling stops) |
+| `/mouse toggle` | Flip the capture state |
+| `/record` | Show whether transcript capture is on, and where it's writing |
+| `/record on` | Begin streaming canonical conversation messages to a transcript file |
+| `/record off` | Stop the active recording and report the file path |
+| `/reset` | Delete the session and start fresh — see the `sessions` spec |
+| `/routine <name>` | Activate a stored routine in the current session — see the `routines` spec |
+| `/routines` | Open the routines manager (list/view/edit/delete) — see the `routines` spec |
+| `/sessions` | Open the session browser — see the `sessions` spec |
+| `/settings` | Open the settings view by emitting `showConfigMsg{}` (alias: `/config`) |
+| `/skills` | List discovered skills — see the `skills` spec |
+| `/stats` | Show a token usage and cost table for the current session — **OpenClaw only** |
+| `/status` | Show backend status — common header (type, endpoint, auth, default model) plus backend-specific blocks: OpenClaw gateway health / versions / agents / channels, OpenAI agent count + current `history.jsonl` stats, Hermes thread state |
+| `/think` | Show the current thinking level — **OpenClaw only** |
+| `/think <level>` | Set the thinking level — see the `chat-ux` spec — **OpenClaw only** |
+
+#### Scenario: Backend-only command on an unsupported connection
+- **GIVEN** a connection that does not support cron jobs
+- **WHEN** the user submits `/crons`, `/cron <name>`, `/stats`, or `/think`
+- **THEN** a "not available on this connection" system message is rendered
+
+#### Scenario: Alias resolves to canonical command
+- **WHEN** the user submits `/config`
+- **THEN** it behaves identically to `/settings`, emitting `showConfigMsg{}`
+
+### Requirement: /agent switches to or returns from a named agent
+
+`handleAgentCommand()` SHALL cover both `/agent` shapes. With no argument it SHALL emit
+`goBackMsg{}`, returning to the agent picker just like `/agents`. With a name it SHALL call
+`client.ListAgents()`, fuzzy-match case-insensitively against agent names and IDs (exact
+match first, then substring), then call `client.CreateSession(agentID, "main")` and emit the
+same `sessionCreatedMsg` the picker selection path uses — so the chat view rebuild is
+identical to picking from the list. Lookup failures (no match, or backend error) SHALL be
+rendered inline as a system message via `agentSwitchFailedMsg` rather than bouncing the user
+back to the picker.
+
+#### Scenario: Bare /agent returns to the picker
+- **WHEN** the user submits `/agent` with no argument
+- **THEN** `goBackMsg{}` is emitted and the agent picker is shown, identical to `/agents`
+
+#### Scenario: /agent with a name switches agent in place
+- **WHEN** the user submits `/agent <name>`
+- **THEN** `client.ListAgents()` is called, the name is fuzzy-matched (exact first, then substring) against agent names and IDs, `client.CreateSession(agentID, "main")` runs, and `sessionCreatedMsg` rebuilds the chat view identically to a picker selection
+
+#### Scenario: /agent lookup fails
+- **WHEN** `/agent <name>` finds no match or the backend errors
+- **THEN** `agentSwitchFailedMsg` renders the failure inline as a system message
+- **AND** the user is not bounced back to the picker
+
+### Requirement: /model reports and switches the session model
+
+`handleModelCommand()` SHALL report the current model for the active session when called
+with no argument (falling back to `gateway default` when `m.modelID` is empty), pointing the
+user at `/models` and `/model <name>` to change it. With a name it SHALL call
+`client.ModelsList()` to retrieve available models from the gateway, fuzzy-match against
+model IDs and names (exact match first, then substring), then call
+`client.SessionPatchModel(sessionKey, modelRef)` and update `m.modelID` in the header.
+`/models` (plural) SHALL open the picker via `showModelPickerMsg`.
+
+Both switch paths — the `/model <name>` command and the `/models` picker — SHALL patch with
+the **qualified `<provider>/<id>` reference** produced by `qualifiedModelRef()`
+(`internal/tui/models.go`), not the bare id. `models.list` reports a provider-local id (e.g.
+`deepseek/deepseek-v4-pro`) alongside a separate `provider` field (e.g. `openrouter`), but
+`sessions.patch` — like the agent's configured `model.primary` — validates against the
+fully-qualified form (`openrouter/deepseek/deepseek-v4-pro`). Sending the bare id makes the
+gateway reject the switch with `INVALID_REQUEST: model not allowed: <id>`. Backends that
+leave `provider` empty (openai, hermes) SHALL keep the bare id unchanged.
+
+#### Scenario: Bare /model reports the current model
+- **WHEN** the user submits `/model` with no argument
+- **THEN** the current session model is reported (or `gateway default` when `m.modelID` is empty) and the user is pointed at `/models` and `/model <name>`
+
+#### Scenario: /model switches with a qualified reference
+- **WHEN** the user submits `/model <name>`
+- **THEN** `client.ModelsList()` is called, the name is fuzzy-matched (exact first, then substring) against model IDs and names, and `client.SessionPatchModel` is called with the qualified `<provider>/<id>` reference from `qualifiedModelRef()`
+- **AND** `m.modelID` in the header is updated
+
+#### Scenario: Provider-empty backend keeps the bare id
+- **GIVEN** an openai or hermes backend that leaves `provider` empty
+- **WHEN** the model reference is qualified
+- **THEN** the bare id is kept unchanged
+
+### Requirement: /cron resolves and runs a named cron job
+
+`handleCronCommand()` SHALL be gated on `backend.CronBackend` (OpenClaw only); on other
+connections it SHALL report "not available". It SHALL require a name argument — bare `/cron`
+SHALL error and point at `/crons` (the plural browser is matched by the switch first, so a
+`/cron ` prefix never swallows it).
+
+Because names live on the gateway, resolution SHALL be asynchronous: the handler SHALL return
+a command that calls `CronsList` and dispatches a `cronResolveMsg` carrying the query and the
+matched jobs. `matchCronJobs()` SHALL be tiered — exact (case-insensitive) `Name`, then exact
+`ID`, then substring on either — and SHALL return every job in the winning tier because cron
+job names are **not unique**. `chatModel.Update` SHALL turn the result into one of: an error
+row (list failed or no match), an ambiguity row listing each candidate's name, `id`, and
+schedule (re-run `/cron <id>` — IDs are unique — to disambiguate), or, for a single match, a
+`pendingConfirmation` (see the confirmation pattern requirement). The confirm prompt SHALL
+show the schedule and next run and end in `(y/n)`; on `y` the action SHALL call
+`CronRun(id, force=true)` — run now regardless of schedule, matching the crons browser's
+"Run now" — and report the outcome via `chatCronRanMsg` → `replacePendingSystem`.
+
+#### Scenario: Bare /cron errors
+- **WHEN** the user submits `/cron` with no argument
+- **THEN** it errors and points at `/crons`
+
+#### Scenario: Ambiguous cron name
+- **GIVEN** multiple cron jobs match the query in the winning tier
+- **WHEN** `matchCronJobs()` returns more than one job
+- **THEN** an ambiguity row lists each candidate's name, `id`, and schedule, advising the user to re-run `/cron <id>` (IDs are unique) to disambiguate
+
+#### Scenario: Single cron match confirmed and run
+- **GIVEN** exactly one cron job matches
+- **WHEN** the user answers `y` to the `(y/n)` confirmation showing the schedule and next run
+- **THEN** `CronRun(id, force=true)` runs the job now regardless of schedule and reports the outcome via `chatCronRanMsg` → `replacePendingSystem`
+
+### Requirement: /stats renders a usage and cost table
+
+Stats SHALL be loaded asynchronously via `client.SessionUsage()` on chat init and after each
+message exchange. `/stats` SHALL format `m.stats` through `formatStatsTable()` in
+`internal/tui/render.go`, which produces a text table of input/output/cache tokens and cost
+breakdown.
+
+#### Scenario: /stats formats loaded usage
+- **GIVEN** `m.stats` has been populated via `client.SessionUsage()`
+- **WHEN** the user submits `/stats`
+- **THEN** `formatStatsTable()` renders a text table of input/output/cache tokens and cost breakdown
+
+### Requirement: /header sets a per-agent chat header colour
+
+`handleHeaderCommand()` SHALL parse the argument, run it through
+`config.NormalizeHexColor()` (accepts `#RRGGBB`, `#RGB`, with or without the leading `#`),
+then write the canonical `#RRGGBB` value via `prefs.SetHeaderColor(agentID, hex)`, persist
+with `config.SavePreferences()`, and emit `prefsUpdatedMsg` so `AppModel.prefs` and
+`chatModel.prefs` stay in sync. The chat view's `View()` SHALL call
+`m.prefs.HeaderColorFor(m.agentID)` each render and override `headerStyle.Background()` (and
+the update-available warn-badge background, which sits inside the header) when a value is set
+for the current agent. Bare `/header` SHALL report the current agent's value; `/header reset`
+(also `default`, `off`) SHALL clear it.
+
+The colour SHALL be scoped per agent — switching to another agent shows that agent's own
+colour (or the built-in default). Per-agent overrides SHALL be stored under a nested `agents`
+sub-object in `config.json`, keyed by agent ID, so future per-agent settings can sit
+alongside `headerColor` without growing the file horizontally. When the active agent has no
+ID (e.g. an unbound chat), `/header` SHALL report an error rather than falling back to a
+global setting.
+
+#### Scenario: Setting a header colour
+- **WHEN** the user submits `/header #4FC3F7`
+- **THEN** the value is normalised via `config.NormalizeHexColor()`, written via `prefs.SetHeaderColor(agentID, hex)`, persisted with `config.SavePreferences()`, and `prefsUpdatedMsg` keeps the models in sync
+
+#### Scenario: Per-agent scoping
+- **GIVEN** a header colour set for agent A
+- **WHEN** the user switches to agent B
+- **THEN** agent B shows its own colour or the built-in default, and agent A's stored colour is untouched
+
+#### Scenario: Reset clears the override
+- **WHEN** the user submits `/header reset` (or `default` or `off`)
+- **THEN** the current agent's header colour override is cleared
+
+#### Scenario: Header on an agent with no ID
+- **GIVEN** an unbound chat where the active agent has no ID
+- **WHEN** the user submits `/header`
+- **THEN** an error is reported rather than falling back to a global setting
+
+### Requirement: /record and /export persist canonical chat history
+
+Both `/record` and `/export` SHALL persist the session's canonical chat history to a Markdown
+file under `<dataDir>/transcripts/`. `/record on` SHALL stream new turns as they finalise;
+`/export [all]` SHALL dump the current state in one shot; `/export routine` SHALL skip the
+file write and open the routines manager prefilled with the session's user prompts. The
+canonical-history tap, dedup signature, file layout, and lifecycle are documented in the
+`export-and-recording` spec.
+
+#### Scenario: Recording streams finalised turns
+- **WHEN** the user submits `/record on`
+- **THEN** new turns are streamed to a Markdown transcript under `<dataDir>/transcripts/` as they finalise
+- **AND** `/record off` stops the active recording and reports the file path
+
+#### Scenario: Export dumps current state
+- **WHEN** the user submits `/export` or `/export all`
+- **THEN** the current canonical history is written in one shot to a Markdown file under `<dataDir>/transcripts/`
+
+#### Scenario: Export routine skips the file write
+- **WHEN** the user submits `/export routine`
+- **THEN** no transcript file is written and the routines manager opens prefilled with the session's user prompts
+
+### Requirement: Tab completion menu
+
+A live menu (rendered between the conversation viewport and the input) SHALL appear as soon
+as the cursor sits at the end of a completable token with at least one matching candidate.
+Three sources SHALL feed the same menu and the same Tab/Shift+Tab semantics:
+
+- **Slash commands and skills** — `matchingSlashCommands(prefix)` (`completion.go`) returns
+  built-ins from the static `slashCommands` slice in their curated order, followed by skill
+  names. Source detection: `findSlashTokenAt(value, cursorByte)`.
+- **Agent names** — the argument of `/agent <name>`. `matchingAgentNames(prefix)` returns
+  every loaded agent whose lowercased form has the prefix as a prefix, preserving each
+  agent's original casing. Source detection: `findAgentArgAt(value, cursorByte)`, which
+  treats the entire tail of the line after `/agent ` as the token (so names with spaces
+  complete in one shot).
+- **Cron names** — the argument of `/cron <name>`. `matchingCronNames(prefix)` mirrors the
+  agent source over `m.cronNames`, which `loadCronNames()` populates on init from `CronsList`
+  (a no-op on non-OpenClaw connections). Source detection: `findCronArgAt(value, cursorByte)`
+  (line begins with `/cron ` — the trailing space excludes `/crons`). The snapshot may go
+  slightly stale mid-session; `/cron <name>` always re-lists to resolve the actual run.
+
+`completionAtCursor()` SHALL resolve the active source — slash commands take priority — and
+return a `completionContext{start, cursorByte, prefix, candidates}`. The Tab handler SHALL
+dispatch a single `handleCompletionTab(ctx)` over this context, applying bash-style
+menu-complete semantics:
+
+- One match → full completion in place.
+- Multiple matches with a longest common prefix beyond what the user typed → the input is
+  extended up to that LCP. `longestCommonPrefixFold(strs)` computes a case-insensitive LCP
+  using the first candidate's casing — agent names like `Main` and `Mail` collapse to `Mai`,
+  slash candidates (already lowercase) behave identically to the byte-wise variant.
+- Multiple matches at the LCP → enter cycle mode. The first Tab snapshots the candidate list
+  into `m.completion.cycleCandidates`, sets `cycleIndex = 0`, and replaces the input with the
+  first candidate. Subsequent Tab presses advance the index modulo the snapshot length;
+  Shift+Tab decrements with the same wraparound. The snapshot persists across presses because
+  Tab returns early before `refreshCompletionMenu` runs.
+
+Any non-Tab keystroke SHALL route through `refreshCompletionMenu`, which clears `cycling` and
+recomputes `candidates` from the current textarea contents via `completionAtCursor()`. The
+menu SHALL auto-hide when no source applies (whitespace breaks a slash token, cursor leaves
+end-of-line in the agent-arg context, the input is cleared, or the message is sent —
+`Reset()` calls in the Enter handler explicitly invoke `refreshCompletionMenu` so the menu
+doesn't outlive the input).
+
+The curated order in `slashCommands` (e.g. `/agents` before `/agent`, `/model` before
+`/models`) now only breaks ties for the inline ghost-hint and the legacy
+`completeSlashCommand` callers — Tab uses LCP, so the order no longer steers it.
+`setTextareaToValueWithCursor` SHALL perform the in-place replacement and reposition the
+cursor at the end of the inserted text.
+
+#### Scenario: Single candidate completes in place
+- **GIVEN** the cursor is at the end of a completable token with exactly one matching candidate
+- **WHEN** the user presses Tab
+- **THEN** the token is fully completed in place
+
+#### Scenario: Multiple candidates extend to the LCP
+- **GIVEN** multiple matches with a longest common prefix beyond what the user typed
+- **WHEN** the user presses Tab
+- **THEN** the input is extended up to the case-insensitive LCP computed by `longestCommonPrefixFold`
+
+#### Scenario: Cycling at the LCP
+- **GIVEN** multiple matches already at the LCP
+- **WHEN** the user presses Tab repeatedly
+- **THEN** the candidate list is snapshotted and each Tab advances the index modulo the snapshot length, with Shift+Tab decrementing under the same wraparound
+
+#### Scenario: Menu auto-hides when no source applies
+- **WHEN** whitespace breaks a slash token, the cursor leaves end-of-line in the agent-arg context, the input is cleared, or the message is sent
+- **THEN** `refreshCompletionMenu` recomputes candidates and the menu hides
+
+### Requirement: Inline ghost-hint fallback
+
+`slashCommandHint` and `agentNameHint` SHALL drive a single-line greyed-out hint in the help
+bar as a fallback for short terminals where the menu cannot render. With the menu visible,
+the help line SHALL switch to `Tab: extend · Shift+Tab: back · N matches`.
+
+#### Scenario: Ghost hint on a short terminal
+- **GIVEN** a terminal too short for the completion menu to render
+- **WHEN** a completable token is typed
+- **THEN** `slashCommandHint` / `agentNameHint` render a single-line greyed-out hint in the help bar
+
+#### Scenario: Help line with menu visible
+- **WHEN** the completion menu is visible
+- **THEN** the help line shows `Tab: extend · Shift+Tab: back · N matches`
+
+### Requirement: Completion menu layout
+
+`chatModel.baseViewportHeight` SHALL record the viewport height with the menu hidden;
+`applyLayout()` SHALL shrink the viewport by `menuRowsToRender()` whenever menu state changes,
+so the conversation pane reflows cleanly. The menu SHALL suppress itself entirely when the
+baseline cannot leave at least `completionMenuViewportFloor` rows for the conversation — Tab
+still does LCP extension on the underlying state. Candidate counts above
+`completionMenuMaxRows` SHALL collapse the tail into a `+N more` line.
+
+#### Scenario: Viewport reflows around the menu
+- **WHEN** menu state changes
+- **THEN** `applyLayout()` shrinks the viewport by `menuRowsToRender()` so the conversation pane reflows cleanly
+
+#### Scenario: Menu suppressed when the conversation would be starved
+- **GIVEN** the baseline cannot leave at least `completionMenuViewportFloor` rows for the conversation
+- **WHEN** completion is triggered
+- **THEN** the menu suppresses itself entirely while Tab still performs LCP extension on the underlying state
+
+#### Scenario: Long candidate list collapses
+- **GIVEN** more candidates than `completionMenuMaxRows`
+- **WHEN** the menu renders
+- **THEN** the tail collapses into a `+N more` line
+
+### Requirement: Agent name completion source
+
+The chat model SHALL fetch the agent list once on init via `loadAgentNames()` and store
+display names in `m.agentNames`; completion SHALL silently degrade to a no-op when the list
+has not loaded yet or the backend errored (`matchingAgentNames` returns nil, so
+`completionAtCursor` reports an empty candidate list and the menu stays hidden).
+`findAgentArgAt` SHALL recognise the argument context only when the cursor sits at
+end-of-line and the line begins with `/agent ` (single space). An empty prefix SHALL match
+every agent — Tab on `/agent ` opens the menu listing the full roster, with the LCP/cycle
+flow taking over from there.
+
+#### Scenario: Agent list not loaded
+- **GIVEN** the agent list has not loaded or the backend errored
+- **WHEN** the user attempts agent-name completion
+- **THEN** `matchingAgentNames` returns nil, the candidate list is empty, and the menu stays hidden
+
+#### Scenario: Empty prefix lists the full roster
+- **WHEN** the user presses Tab on `/agent ` (single trailing space, cursor at end-of-line)
+- **THEN** the menu lists every loaded agent and the LCP/cycle flow takes over
+
+### Requirement: Yes/no confirmation pattern
+
+Commands that need a yes/no (`/compact`, `/reset`, `/cron <name>`) SHALL use a two-step
+confirmation. On first invocation a `pendingConfirmation` struct SHALL be stored on the model
+containing the prompt string, an optional `runningStatus` line, and an action closure. The
+prompt SHALL be appended to the chat scrollback as a system row tagged `confirmPrompt: true`.
+On the next Enter keypress, if the input is `y` or `yes` the closure SHALL be executed;
+anything else SHALL cancel — and either way `removeConfirmPrompt()` SHALL drop the tagged
+prompt row (a brief `Confirmed.`/`Cancelled.` notification reports which) so the `(y/n)`
+question does not linger once answered. This prevents accidental data loss.
+
+When `runningStatus` is set, the confirmation handler SHALL also append a pending system row
+(`pending: true`) carrying that status text to the chat scrollback. The renderer SHALL
+animate the same braille spinner used for in-flight assistant turns next to the row, and
+`hasStreamingMessage` SHALL keep `spinnerTickCmd` firing until the action returns. The result
+handler (`sessionCompactedMsg`, `sessionClearedMsg`, `chatCronRanMsg`) SHALL call
+`replacePendingSystem` to swap the placeholder for the outcome line in place — no stale
+"Compacting session…" stuck above the result.
+
+#### Scenario: Confirmation accepted
+- **GIVEN** a `pendingConfirmation` is showing its `confirmPrompt`-tagged row
+- **WHEN** the user's next Enter input is `y` or `yes`
+- **THEN** the action closure executes, `removeConfirmPrompt()` drops the prompt row, and a brief `Confirmed.` notification is shown
+
+#### Scenario: Confirmation cancelled
+- **WHEN** the user's next Enter input is anything other than `y`/`yes`
+- **THEN** the action is not executed, `removeConfirmPrompt()` drops the prompt row, and a brief `Cancelled.` notification is shown
+
+#### Scenario: Running status spinner
+- **GIVEN** a confirmation with `runningStatus` set is accepted
+- **WHEN** the action runs
+- **THEN** a `pending: true` system row shows the braille spinner until the result handler calls `replacePendingSystem` to swap in the outcome line
+
+### Requirement: Routine-active navigation gate
+
+Slash commands that strand or replace the chat model — `/agents`, `/agent <name>`,
+`/sessions`, `/crons`, `/crons all`, `/connections`, `/routine <name>`, `/routines` — SHALL
+route through `gateNavigation()` (`internal/tui/routines_chat.go`) when a routine is active. A
+`pendingNavConfirm` SHALL be set, the prompt SHALL be rendered as a notification, and the
+Enter handler SHALL resolve it: `y` cancels any in-flight turn, ends the routine cleanly
+(closing the log file), and dispatches the navigation; `n` or Esc dismisses the prompt and
+the routine continues. The state SHALL be independent of the generic `pendingConfirmation` so
+the two flows do not compete. See the `routines` spec (slash commands and gating) for the full
+rationale.
+
+#### Scenario: Navigation gated while a routine is active
+- **GIVEN** a routine is active
+- **WHEN** the user submits a chat-replacing command such as `/agents` or `/connections`
+- **THEN** `gateNavigation()` sets a `pendingNavConfirm` and renders the prompt as a notification
+
+#### Scenario: Confirming navigation ends the routine
+- **GIVEN** a `pendingNavConfirm` is showing
+- **WHEN** the user answers `y`
+- **THEN** any in-flight turn is cancelled, the routine ends cleanly (closing the log file), and the navigation is dispatched
+
+#### Scenario: Declining navigation continues the routine
+- **GIVEN** a `pendingNavConfirm` is showing
+- **WHEN** the user answers `n` or presses Esc
+- **THEN** the prompt is dismissed and the routine continues

--- a/openspec/specs/connections/spec.md
+++ b/openspec/specs/connections/spec.md
@@ -1,0 +1,306 @@
+# Connections and Backends Specification
+
+## Purpose
+
+A connection is a saved target lucinate can connect to (URL + type + auth identity), persisted to `~/.lucinate/connections.json` and managed through the connections picker. Three backend types ship today — OpenClaw, OpenAI-compatible, and Hermes — all implementing a common `backend.Backend` interface so the chat, sessions and commands views remain backend-agnostic. This spec covers the connection types, the connections picker and form, the startup decision tree, the connection lifecycle, capability negotiation, auth-recovery modals, and secrets storage.
+
+## Requirements
+
+### Requirement: Connections picker as connection management surface
+
+The system SHALL manage the list of saved connections through the connections picker (`viewConnections`), which persists the list to `~/.lucinate/connections.json`. Each connection is a saved target (URL + type + auth identity). The picker SHALL be accessible as the entry view on first run, via `/connections` mid-session, or via the **Connections** action on the agent picker. The picker SHALL also expose a **Settings** action (key `s`) that opens the settings screen without leaving the pre-chat flow.
+
+#### Scenario: Reaching the picker mid-session
+
+- **WHEN** the user runs `/connections` during a session
+- **THEN** the connections picker opens
+- **AND** the same picker is reachable as the first-run entry view and via the **Connections** action on the agent picker
+
+#### Scenario: Opening settings from the picker
+
+- **GIVEN** the connections picker is showing
+- **WHEN** the user presses `s`
+- **THEN** the settings screen opens without leaving the pre-chat flow
+
+### Requirement: Three backend types over a common interface
+
+The system SHALL ship three backend types — OpenClaw, OpenAI-compatible, and Hermes — all implementing `backend.Backend` (`internal/backend/backend.go`) so the chat / sessions / commands views are backend-agnostic. The OpenAI and Hermes backends both speak HTTP+SSE+JSON over Bearer-token auth and SHALL share the request builder, SSE scanner, and event emitter in `internal/backend/httpcommon` — but they are sibling implementations, not a base class and a subclass. Backend-specific behaviour is documented in dedicated specs:
+
+- the `backend-openclaw` spec — full capability surface, device-token auth, server-side agents
+- the `backend-openai` spec — `/v1/chat/completions` streaming, on-disk agents (IDENTITY.md + SOUL.md), API-key auth
+- the `backend-hermes` spec — `/v1/responses` server-state chaining, one synthetic agent per connection, API-key auth
+
+The three types differ as follows:
+
+| Type      | URL shape                                                   | Auth                                   | Agent storage                                                                  |
+|-----------|-------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------|
+| OpenClaw  | `https://`/`http://`/`wss://`/`ws://` (WS endpoint derived) | Ed25519 device pairing                 | Server-side on the gateway                                                     |
+| OpenAI    | `http(s)://host/v1`                                         | Optional `Authorization: Bearer <key>` | Local under `~/.lucinate/agents/<conn-id>/<agent-id>/`                         |
+| Hermes    | `http(s)://host:8642/v1` (default loopback)                 | `Authorization: Bearer <API_SERVER_KEY>` | Server-side in the Hermes profile; only `last_response_id` + prompts log local |
+
+#### Scenario: Views stay backend-agnostic
+
+- **GIVEN** any of the three backend types is the active connection
+- **WHEN** the chat, sessions or commands views operate
+- **THEN** they call through the common `backend.Backend` interface without type-specific branching
+
+#### Scenario: OpenAI and Hermes share HTTP plumbing
+
+- **GIVEN** the OpenAI and Hermes backends both speak HTTP+SSE+JSON over Bearer-token auth
+- **THEN** they share the request builder, SSE scanner and event emitter in `internal/backend/httpcommon`
+- **AND** remain sibling implementations rather than a base class and subclass
+
+### Requirement: Adding a new backend type
+
+The `AllConnectionTypes` enum (`internal/config/connections.go`) SHALL drive the picker form's type radio. Adding a fourth backend SHALL require: implementing `backend.Backend`, extending the enum, dispatching in `DefaultBackendFactory` (`app/factory.go`), adjusting the form's type-conditional rendering, and writing a `backend_<name>.md` doc for it.
+
+`DefaultBackendFactory` has two non-TUI consumers:
+
+- `app.Send` (`lucinate send`) calls it directly to build a backend for one-shot dispatch — a new connection type that lands in the factory's switch is automatically reachable from the scripted CLI mode without further wiring (see the `one-shot` spec).
+- `app.Chat` (`lucinate chat`) defers all connect / list / create work to the TUI and just packs `Connection` / `Agent` / `Session` / `Message` overrides into `RunOptions`, so a new connection type is reachable there as soon as it works in the regular TUI (see the `chat-launch` spec).
+
+#### Scenario: Wiring a fourth backend
+
+- **WHEN** a fourth backend type is added
+- **THEN** it implements `backend.Backend`, extends `AllConnectionTypes`, dispatches in `DefaultBackendFactory`, adjusts the form's type-conditional rendering, and ships a `backend_<name>.md` doc
+
+#### Scenario: New type reachable from one-shot and chat modes
+
+- **GIVEN** a new connection type has landed in the `DefaultBackendFactory` switch
+- **THEN** `app.Send` (`lucinate send`) can build it for one-shot dispatch without further wiring
+- **AND** `app.Chat` (`lucinate chat`) can reach it as soon as it works in the regular TUI
+
+### Requirement: Startup entry-connection decision tree
+
+`config.ResolveEntryConnection()` (`internal/config/startup.go`) SHALL decide what the TUI's entry view is, in the following order:
+
+1. If `OPENCLAW_GATEWAY_URL` is set, find or auto-add a matching OpenClaw connection.
+2. Else if `LUCINATE_OPENAI_BASE_URL` is set, find or auto-add a matching OpenAI connection (with `LUCINATE_OPENAI_DEFAULT_MODEL` if provided).
+3. Else if a saved `defaultId` resolves to a known entry → use it (last-used = default).
+4. Else if exactly one connection is stored → auto-pick it.
+5. Else → open the connections picker.
+
+Auto-add (steps 1–2) SHALL mutate the in-memory store but SHALL NOT persist it until a successful connect, so a typo in the env URL doesn't accumulate ghost entries.
+
+#### Scenario: Gateway env var wins
+
+- **GIVEN** `OPENCLAW_GATEWAY_URL` is set
+- **WHEN** the TUI resolves its entry connection
+- **THEN** it finds or auto-adds a matching OpenClaw connection
+
+#### Scenario: Fall through to a single stored connection
+
+- **GIVEN** no relevant env var is set and no saved `defaultId` resolves
+- **AND** exactly one connection is stored
+- **WHEN** the entry connection is resolved
+- **THEN** that single connection is auto-picked
+
+#### Scenario: No match opens the picker
+
+- **GIVEN** no env var, no resolvable `defaultId`, and not exactly one stored connection
+- **WHEN** the entry connection is resolved
+- **THEN** the connections picker opens
+
+#### Scenario: Typo env URL leaves no ghost entry
+
+- **GIVEN** an auto-added connection from a mistyped env URL
+- **WHEN** the connect fails
+- **THEN** the in-memory auto-add is not persisted to `~/.lucinate/connections.json`
+
+### Requirement: `chat --connection` short-circuits the decision tree
+
+`lucinate chat --connection <name>` SHALL short-circuit the startup decision tree: the named connection SHALL be resolved against the store directly (ID first, then case-insensitive name), and a miss SHALL be a hard error rather than falling through to the env-var / default-id path. With `--connection` unset, `chat` SHALL run the same `ResolveEntryConnection` the bare invocation does. See the `chat-launch` spec for the override plumbing.
+
+#### Scenario: Named connection resolved directly
+
+- **GIVEN** `lucinate chat --connection <name>` is invoked
+- **WHEN** the connection is resolved
+- **THEN** it is matched against the store by ID first, then by case-insensitive name
+
+#### Scenario: Unknown named connection is a hard error
+
+- **GIVEN** `--connection <name>` names a connection that is not in the store
+- **WHEN** resolution runs
+- **THEN** it fails as a hard error rather than falling through to the env-var / default-id path
+
+#### Scenario: No override uses the normal tree
+
+- **GIVEN** `--connection` is unset
+- **WHEN** `chat` starts
+- **THEN** it runs the same `ResolveEntryConnection` as the bare invocation
+
+### Requirement: Connection lifecycle in managed mode
+
+The TUI SHALL own the connection lifecycle in managed mode (`AppOptions.Store != nil`):
+
+- A successful connect SHALL call `OnBackendChanged(backend)` so the app driver in `app/app.go` rewires the events pump and supervisor onto the new backend.
+- Picking a different connection mid-session (`/connections`, the picker action, or any other `showConnectionsMsg`) SHALL publish `nil` to the driver, which closes the active backend before binding to whatever the next pick produces.
+- The driver SHALL own Close — TUI code SHALL NOT close the backend itself once it's published.
+
+#### Scenario: Successful connect rewires the driver
+
+- **WHEN** a connect succeeds in managed mode
+- **THEN** `OnBackendChanged(backend)` is called and the app driver rewires the events pump and supervisor onto the new backend
+
+#### Scenario: Switching connection closes the old backend
+
+- **GIVEN** an active backend in managed mode
+- **WHEN** the user picks a different connection (via `/connections`, the picker action, or any `showConnectionsMsg`)
+- **THEN** `nil` is published to the driver, which closes the active backend before binding to the next pick
+
+### Requirement: Legacy mode for native-platform embedders
+
+Legacy mode (`AppOptions.Backend != nil`, no `Store`) SHALL be for native-platform embedders that manage the connection elsewhere. In legacy mode the connections picker and `/connections` SHALL be unavailable, and Close SHALL be the caller's responsibility.
+
+#### Scenario: Legacy mode hides connection management
+
+- **GIVEN** the app is started with `AppOptions.Backend != nil` and no `Store`
+- **THEN** the connections picker and `/connections` are unavailable
+- **AND** closing the backend is the caller's responsibility
+
+### Requirement: Capability negotiation via optional sub-interfaces
+
+`backend.Backend.Capabilities()` SHALL report a `Capabilities` struct (`internal/backend/backend.go`); the TUI SHALL type-assert against optional sub-interfaces (`StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `CronBackend`, `DeviceTokenAuth`, `APIKeyAuth`) at the relevant call sites. OpenClaw implements all of them. OpenAI implements `APIKeyAuth`, `CompactBackend` (the latter via a local summarisation pass — see the `backend-openai` spec), and `StatusBackend`. Hermes implements `APIKeyAuth` and `StatusBackend`. Backend-only commands the active connection doesn't support (`/think`, `/stats`, `/crons`, `!!` on OpenAI/Hermes; `/compact` on Hermes) SHALL render a "not available on this connection" system message instead of erroring.
+
+#### Scenario: Unsupported command shows a system message
+
+- **GIVEN** the active connection does not support a backend-only command (e.g. `/think` on OpenAI, `/compact` on Hermes)
+- **WHEN** the user runs it
+- **THEN** a "not available on this connection" system message is shown instead of an error
+
+#### Scenario: OpenClaw implements every sub-interface
+
+- **GIVEN** an OpenClaw connection
+- **THEN** it implements all of `StatusBackend`, `ExecBackend`, `CompactBackend`, `ThinkingBackend`, `UsageBackend`, `CronBackend`, `DeviceTokenAuth` and `APIKeyAuth`
+
+### Requirement: `/status` works on every backend
+
+`/status` SHALL work on every backend, with each one populating only the sub-blocks of `BackendStatus` that apply: OpenClaw fills the gateway-health block, OpenAI fills agent-count and `history.jsonl` stats, Hermes fills the lastResponseID thread block. See the per-backend "Status payload" sections in the `backend-openclaw`, `backend-openai`, and `backend-hermes` specs.
+
+#### Scenario: Each backend fills only its applicable status blocks
+
+- **WHEN** `/status` runs on a connection
+- **THEN** OpenClaw fills the gateway-health block, OpenAI fills agent-count and `history.jsonl` stats, and Hermes fills the lastResponseID thread block
+
+### Requirement: Agent-management capability gates picker affordances
+
+The `Capabilities.AgentManagement` flag SHALL gate both the picker's "new agent" affordance and its "delete agent" affordance. OpenClaw and OpenAI SHALL opt in (the user creates and deletes agents via the picker). Hermes SHALL leave it false because profiles are configured server-side via `hermes profile create` on the host, so both buttons SHALL be hidden on Hermes connections; `Backend.DeleteAgent` and `Backend.CreateAgent` SHALL both reject defensively if reached.
+
+#### Scenario: Hermes hides agent management
+
+- **GIVEN** a Hermes connection with `Capabilities.AgentManagement` false
+- **THEN** the picker's "new agent" and "delete agent" buttons are hidden
+- **AND** `Backend.DeleteAgent` and `Backend.CreateAgent` reject defensively if reached
+
+#### Scenario: OpenClaw and OpenAI expose agent management
+
+- **GIVEN** an OpenClaw or OpenAI connection
+- **THEN** the "new agent" and "delete agent" affordances are shown so the user creates and deletes agents via the picker
+
+### Requirement: Auth-recovery modals routed by the connecting view
+
+`Connect` errors SHALL be routed into modal sub-states by the connecting view (`internal/tui/connecting.go`):
+
+- `gateway token mismatch` → device-token modal: clear / reset identity / cancel. `ClearToken` and `ResetIdentity` come from `DeviceTokenAuth`.
+- `gateway token missing` → device-token text prompt; submission stores via `DeviceTokenAuth.StoreToken`.
+- `api key required` (HTTP 401/403 from any `/v1` request) → API-key text prompt; submission stores via `APIKeyAuth.StoreAPIKey`.
+
+The submission flow SHALL dispatch on `connectingModel.authNeed` rather than on Go interface assertion: the OpenClaw wrapper implements both `DeviceTokenAuth` and `APIKeyAuth`, so a naive type-switch would always pick the first arm. See `connecting.go` `case "enter":` for the dispatch.
+
+#### Scenario: Token mismatch opens the device-token modal
+
+- **GIVEN** `Connect` fails with `gateway token mismatch`
+- **WHEN** the connecting view routes it
+- **THEN** the device-token modal offers clear / reset identity / cancel, with `ClearToken` and `ResetIdentity` from `DeviceTokenAuth`
+
+#### Scenario: API key required prompts and stores the key
+
+- **GIVEN** a `/v1` request returns HTTP 401/403 (`api key required`)
+- **WHEN** the connecting view routes it
+- **THEN** an API-key text prompt is shown and submission stores the key via `APIKeyAuth.StoreAPIKey`
+
+#### Scenario: Dispatch avoids the ambiguous type-switch
+
+- **GIVEN** the OpenClaw wrapper implements both `DeviceTokenAuth` and `APIKeyAuth`
+- **WHEN** a modal submission is handled
+- **THEN** it dispatches on `connectingModel.authNeed` rather than a Go interface assertion, so the correct arm is chosen
+
+### Requirement: Secrets storage for API keys
+
+API keys SHALL live at `~/.lucinate/secrets/secrets.json` (mode 0600), keyed by connection ID. `config.GetAPIKey(connID)` and `config.SetAPIKey(connID, key)` SHALL be the public surface. `LUCINATE_OPENAI_API_KEY` SHALL fall back when no per-connection key is stored.
+
+The `secretAwareOpenAIBackend` and `secretAwareHermesBackend` shims in `app/factory.go` SHALL wrap their respective concrete backends so `StoreAPIKey` writes through to `~/.lucinate/secrets/secrets.json` during the auth-modal resolution path; the next launch SHALL reuse the key without re-prompting.
+
+A future enhancement is to back this with the OS keychain (Keychain on macOS, libsecret on Linux, Credential Manager on Windows) and fall back to the JSON file when no keychain is available — kept on disk for now to avoid platform-specific dependencies on first run.
+
+#### Scenario: API key written with restricted permissions
+
+- **WHEN** an API key is stored
+- **THEN** it is written to `~/.lucinate/secrets/secrets.json` (mode 0600), keyed by connection ID
+
+#### Scenario: Env fallback when no per-connection key
+
+- **GIVEN** no per-connection API key is stored
+- **WHEN** an OpenAI-compatible connection needs a key
+- **THEN** `LUCINATE_OPENAI_API_KEY` is used as a fallback
+
+#### Scenario: Stored key reused on next launch
+
+- **GIVEN** an API key stored through the `secretAwareOpenAIBackend` or `secretAwareHermesBackend` shim during auth-modal resolution
+- **WHEN** the app launches again
+- **THEN** the key is reused without re-prompting
+
+### Requirement: Connections form presets and persisted types
+
+`internal/tui/connections.go` SHALL implement the picker. The form SHALL have a fixed type radio plus type-conditional fields. It SHALL offer four presets that map to three persisted types:
+
+| Preset   | Persisted Type | Fields                                                     |
+|----------|----------------|------------------------------------------------------------|
+| OpenClaw | `openclaw`     | Type, Name, Gateway URL                                    |
+| OpenAI   | `openai`       | Type, Name, Base URL, Default model (optional)             |
+| Ollama   | `openai`       | Type, Name, Base URL, Default model (optional)             |
+| Hermes   | `hermes`       | Type, Name, Base URL, Profile name                         |
+
+Ollama SHALL be an opinionated OpenAI preset that pre-fills `Name = ollama` and `Base URL = http://localhost:11434/v1`. Hermes SHALL be its own type with a pre-filled `Base URL = http://127.0.0.1:8642/v1` and a "Profile name" model field. Switching to either preset and back SHALL clear the prefill so the user isn't stranded with the wrong localhost URL in a gateway field.
+
+#### Scenario: Ollama preset pre-fills OpenAI-typed defaults
+
+- **WHEN** the user selects the Ollama preset
+- **THEN** the form pre-fills `Name = ollama` and `Base URL = http://localhost:11434/v1` and persists type `openai`
+
+#### Scenario: Switching presets clears stale prefill
+
+- **GIVEN** a preset has pre-filled a localhost Base URL
+- **WHEN** the user switches to another preset and back
+- **THEN** the prefill is cleared so no wrong localhost URL is stranded in a gateway field
+
+### Requirement: Type radio, focus behaviour, and immutable type on edit
+
+The type radio SHALL render vertically (one preset per line) so the list reflows cleanly on narrow terminals. ↑/↓ SHALL cycle the presets when the radio is focused; Tab SHALL move between fields. Edit forms SHALL drop the radio entirely (type is immutable post-create) and SHALL start focus on the name field. Edited connections SHALL show the persisted type as a dimmed read-only label — Ollama-created connections SHALL render as "OpenAI-compatible" on edit because the Ollama preset isn't distinguishable post-save.
+
+#### Scenario: Navigating the create form
+
+- **GIVEN** the create form with the type radio focused
+- **WHEN** the user presses ↑/↓
+- **THEN** the presets cycle, and Tab moves focus between fields
+
+#### Scenario: Editing an existing connection
+
+- **GIVEN** an existing connection is edited
+- **THEN** the radio is dropped, type is immutable, focus starts on the name field, and the persisted type shows as a dimmed read-only label
+
+#### Scenario: Ollama connection labelled on edit
+
+- **GIVEN** a connection created from the Ollama preset (persisted type `openai`)
+- **WHEN** it is edited
+- **THEN** it renders as "OpenAI-compatible" because the Ollama preset isn't distinguishable post-save
+
+### Requirement: Delete confirmation as a sub-state
+
+Delete confirmation SHALL be exposed as a sub-state with confirm/cancel pairs in `Actions()`, so native-platform embedders render them as buttons rather than relying on inline `y/n` keys.
+
+#### Scenario: Delete confirmation exposed for embedders
+
+- **WHEN** the user initiates deleting a connection
+- **THEN** the confirm/cancel choices are exposed as a sub-state via `Actions()`
+- **AND** native-platform embedders render them as buttons rather than inline `y/n` keys

--- a/openspec/specs/crons/spec.md
+++ b/openspec/specs/crons/spec.md
@@ -1,0 +1,310 @@
+# Cron Jobs Specification
+
+## Purpose
+
+Provide an in-TUI browser (`internal/tui/crons.go`) that lets users list, inspect, run, edit, create, and delete the gateway's scheduled jobs without leaving lucinate. Cron is gateway-side scheduling, not a lucinate concept — only backends that implement `backend.CronBackend` expose the view. This spec covers the two entry points, the capability surface, the four substates (list, detail, form, confirm-delete), the transcript view, raw-patch edit semantics, payload field mapping, the duplicate flow, and what is deliberately out of scope.
+
+## Requirements
+
+### Requirement: Cron browser availability gated on CronBackend
+
+The cron browser SHALL only be exposed for backends that implement `backend.CronBackend`, because cron is gateway-side scheduling rather than a lucinate concept. Capability SHALL also be reported as `Capabilities.Cron` so embedders can hide the entry up-front.
+
+#### Scenario: Backend does not implement CronBackend
+
+- **GIVEN** an active backend that does not implement `backend.CronBackend`
+- **WHEN** the user attempts to open the cron browser
+- **THEN** the view is not exposed for that connection
+
+#### Scenario: Capability reported for embedders
+
+- **WHEN** an embedder inspects the backend's capabilities
+- **THEN** cron availability is reported as `Capabilities.Cron` so the entry can be hidden up-front
+
+### Requirement: Entry from chat via /crons and /crons all
+
+The system SHALL provide two chat slash commands, `/crons` and `/crons all`, both emitting `showCronsMsg{filterAgentID, filterLabel}`. The slash-command handler (`internal/tui/commands.go`) SHALL type-assert the active backend against `backend.CronBackend`. If the assertion fails, the handler SHALL show the system message `"/crons is not available on this connection"` with no view transition (the same pattern as `/compact` on Hermes). If the assertion succeeds, the message SHALL be emitted: `/crons` sets the filter to the chat's current agent, and `/crons all` clears the filter so jobs across every agent are listed. The `AppModel` SHALL record the opening view in `cronsReturn` so `esc`/Back returns to chat (mirrors `configReturn`).
+
+#### Scenario: Command on a non-cron connection
+
+- **GIVEN** the active backend does not implement `backend.CronBackend`
+- **WHEN** the user runs `/crons`
+- **THEN** the handler shows `"/crons is not available on this connection"` and does not transition views
+
+#### Scenario: /crons filters to the current agent
+
+- **GIVEN** the active backend implements `backend.CronBackend`
+- **WHEN** the user runs `/crons` from chat
+- **THEN** `showCronsMsg` is emitted with the filter set to the chat's current agent
+- **AND** `cronsReturn` records chat as the return view
+
+#### Scenario: /crons all clears the filter
+
+- **WHEN** the user runs `/crons all`
+- **THEN** `showCronsMsg` is emitted with the filter cleared so jobs across every agent are listed
+
+### Requirement: Entry from the agent picker via the k action
+
+The agent picker SHALL offer a `k: View crons` action (`internal/tui/select.go`), gated on the same `backend.CronBackend` assertion so it only appears for OpenClaw connections. Because no agent is selected on the picker, it SHALL always open unfiltered (`filterAgentID: ""`, like `/crons all`). The `k` binding SHALL be repurposed from the list's vim-style up-navigation, which is dropped in `newSelectModel`, keeping `↑`. The `AppModel` SHALL record the opening view in `cronsReturn` so `esc`/Back returns to the picker (mirrors `configReturn`).
+
+#### Scenario: Picker action opens unfiltered
+
+- **GIVEN** an OpenClaw connection implementing `backend.CronBackend`
+- **WHEN** the user selects `k: View crons` in the agent picker
+- **THEN** the cron browser opens unfiltered with `filterAgentID: ""`
+- **AND** `cronsReturn` records the picker as the return view
+
+#### Scenario: Action absent on non-cron connections
+
+- **GIVEN** a connection that does not implement `backend.CronBackend`
+- **THEN** the `k: View crons` action does not appear in the agent picker
+
+#### Scenario: k no longer navigates up
+
+- **WHEN** the picker list is built in `newSelectModel`
+- **THEN** the vim-style up-navigation on `k` is dropped and `k` is bound to View crons, with `↑` retained for up-navigation
+
+### Requirement: CronBackend capability surface wraps six gateway RPCs
+
+`backend.CronBackend` (`internal/backend/backend.go`) SHALL wrap the gateway RPCs mapped below:
+
+| Method | Wire call | Used for |
+|---|---|---|
+| `CronsList` | `cron.list` | List substate |
+| `CronRuns` | `cron.runs` | Run history in detail substate |
+| `CronAdd` | `cron.add` | Create form submit |
+| `CronUpdate` | `cron.update` (typed) | Toggle enable / disable |
+| `CronUpdateRaw` | `cron.update` (raw map) | Edit form submit — see the raw-patch edit semantics requirement |
+| `CronRemove` | `cron.remove` | Confirm-delete substate |
+| `CronRun` | `cron.run` (`mode=force`) | Manual run-now |
+
+#### Scenario: Method-to-wire-call mapping
+
+- **WHEN** a cron browser action fires
+- **THEN** it invokes the corresponding `backend.CronBackend` method, which calls the mapped gateway wire call (e.g. `CronRun` calls `cron.run` with `mode=force`)
+
+### Requirement: cronsModel single view with four substates
+
+`cronsModel` SHALL be a single view with four substates:
+
+| Substate | Purpose |
+|---|---|
+| `cronSubList` | Default — paginated, filtered job list |
+| `cronSubDetail` | Drill-down into a selected job + run history |
+| `cronSubForm` | Create or edit form |
+| `cronSubConfirmDelete` | y/n prompt before `CronRemove` fires |
+
+Each substate SHALL expose its own discoverable actions through `Actions()`, and `TriggerAction(id)` SHALL be the single dispatcher through which both keystrokes and embedder-issued `TriggerActionMsg`s flow.
+
+#### Scenario: Actions dispatched through a single path
+
+- **WHEN** either a keystroke or an embedder-issued `TriggerActionMsg` triggers an action
+- **THEN** it flows through `TriggerAction(id)` as the single dispatcher
+- **AND** the available actions come from the current substate's `Actions()`
+
+### Requirement: List substate loads and renders jobs with local filtering
+
+The list view SHALL load on `Init()` via `loadJobs()`, which calls `CronsList(Enabled: "all", SortBy: "nextRunAtMs", SortDir: "asc")`. The full slice SHALL be cached on the model so the agent-filter toggle (`a` key) can re-apply locally without a round-trip — server-side filtering is not exposed in `CronListParams`. Each row SHALL render:
+
+- **Line 1**: bold name + dim relative-time chip (`in 8h`, `due`, `—`).
+- **Line 2**: chips for session target (`main`/`isolated`), wake mode (`now`/`heartbeat`), agent ID, and a status badge (`ok`/`error`/`disabled`/`idle`).
+
+The list substate SHALL bind: `enter` opens detail; `r` refreshes; `n` opens the create form; `d` opens the create form pre-populated from the highlighted job (the duplicate flow — see the duplicate flow requirement); `esc` emits `goBackFromCronsMsg{}` to return to the view that opened the browser (chat, or the agent picker).
+
+#### Scenario: Initial load and sort
+
+- **WHEN** the list substate initialises via `Init()`
+- **THEN** `loadJobs()` calls `CronsList(Enabled: "all", SortBy: "nextRunAtMs", SortDir: "asc")` and caches the full slice on the model
+
+#### Scenario: Agent-filter toggle applies locally
+
+- **GIVEN** the full job slice is cached on the model
+- **WHEN** the user presses `a` to toggle the agent filter
+- **THEN** the filter is re-applied locally without a round-trip, because server-side filtering is not exposed in `CronListParams`
+
+#### Scenario: Row rendering
+
+- **WHEN** a job row is rendered
+- **THEN** line 1 shows the bold name plus a dim relative-time chip and line 2 shows chips for session target, wake mode, agent ID, and a status badge
+
+#### Scenario: List key bindings
+
+- **WHEN** the user presses `enter`, `r`, `n`, `d`, or `esc` in the list
+- **THEN** respectively detail opens, the list refreshes, the create form opens, the create form opens pre-populated from the highlighted job, or `goBackFromCronsMsg{}` returns to the opening view
+
+### Requirement: Detail substate shows job fields and run history
+
+Pressing `enter` on the list SHALL emit a `loadRuns(jobID)` command alongside the substate transition; `cronRunsLoadedMsg` SHALL populate the run-history table (most recent 10 entries, formatted by `formatRunLogEntry`). The detail view SHALL render:
+
+- Schedule (cron expression + timezone, or fallback for `at`/`every` kinds)
+- Description, Agent, Model (from `payload.Model`), Session target, Wake mode
+- Delivery (always shown — `none`, `announce (channel)`, or `webhook → URL`)
+- Next run, Last run (with status), Payload body
+- Run history table
+
+The detail substate SHALL provide the actions: `!` run-now, `t` toggle enable, `e` edit, `x` delete (→ confirm substate), `T` open a read-only transcript reconstructed from the run log (see the transcript view requirement), `r` refresh, `esc` back to list.
+
+#### Scenario: Entering detail loads run history
+
+- **WHEN** the user presses `enter` on a list row
+- **THEN** a `loadRuns(jobID)` command is emitted with the substate transition
+- **AND** `cronRunsLoadedMsg` populates the run-history table with the most recent 10 entries formatted by `formatRunLogEntry`
+
+#### Scenario: Detail fields rendered
+
+- **WHEN** the detail substate renders a job
+- **THEN** it shows schedule, description, agent, model, session target, wake mode, delivery (always shown), next run, last run with status, payload body, and the run history table
+
+### Requirement: Run-now bound to ! with in-flight guard
+
+Run-now SHALL be bound to `!` rather than `R` because the case-sensitive pair (`R` run vs. `r` refresh) was a misfire trap on terminals that don't preserve shift on letter keys. The detail view SHALL render a transient `Triggering run...` banner the moment `!` fires, replaced by `Run triggered.` (or `Run failed: <err>`) once `cronJobRanMsg` arrives. A `running` flag on `cronsModel` SHALL gate duplicate keystrokes while the request is in flight.
+
+#### Scenario: Triggering a manual run
+
+- **WHEN** the user presses `!` in the detail substate
+- **THEN** a transient `Triggering run...` banner appears immediately and the `running` flag gates duplicate keystrokes
+- **AND** once `cronJobRanMsg` arrives the banner becomes `Run triggered.` or `Run failed: <err>`
+
+#### Scenario: Run-now key choice
+
+- **GIVEN** terminals that don't preserve shift on letter keys
+- **WHEN** run-now is bound
+- **THEN** it uses `!` to avoid the `R` run vs. `r` refresh misfire trap
+
+### Requirement: Read-only transcript reconstructed from the run log
+
+Pressing `T` SHALL emit `cronTranscriptMsg{job, runs, agentName}`; the `AppModel` SHALL hand it to the chat view with `hideInput=true` and pre-seed `chatModel.messages` from `buildCronTranscriptMessages` (`internal/tui/history.go`). No `chat.history` round-trip SHALL be made — cron runs with `sessionTarget=isolated` don't persist a queryable session entry on the gateway (especially when the run errors before `persistSessionEntry` fires), so the run log itself is the source of truth. The run log is also the same data the detail page's run-history previews render, so transcript content matches what the previews promise.
+
+The builder SHALL walk `m.runs` (newest-first as returned by `cron.runs sortDir=desc`) in reverse and emit, per run: a separator with `RunAtMs`, a user turn with the cron's `payload.Text` / `payload.Message`, and either an assistant turn with `Summary` (Glamour-rendered when it looks like markdown) or an `errMsg` assistant turn with `Error`. Repeating the payload per run is intentional — each run is an independent invocation of the same prompt, and the structure makes per-run timing and outcome obvious.
+
+The action SHALL be gated by `hasTranscriptContent`: if no run carries a `Summary` or `Error`, the `T` entry SHALL be suppressed from `Actions()` so it doesn't dangle on jobs with nothing to show.
+
+The transcript chat view SHALL set `chatModel.transcript = true`. With no input box to consume it, `Esc` would otherwise be a no-op, so the chat key handler SHALL emit `goBackFromCronTranscriptMsg` when the flag is set; `AppModel` SHALL switch state back to `viewCrons`, where `cronsModel.subset`/`selectedID` are preserved across the transcript hop, so the user lands back on the originating detail page.
+
+#### Scenario: Transcript sourced from the run log
+
+- **WHEN** the user presses `T` in the detail substate
+- **THEN** `cronTranscriptMsg{job, runs, agentName}` is emitted and the chat view is seeded from `buildCronTranscriptMessages` with `hideInput=true`, with no `chat.history` round-trip because isolated cron runs have no queryable session entry
+
+#### Scenario: Per-run transcript structure
+
+- **WHEN** `buildCronTranscriptMessages` walks `m.runs` in reverse
+- **THEN** each run emits a separator with `RunAtMs`, a user turn with `payload.Text`/`payload.Message`, and either an assistant turn with `Summary` (Glamour-rendered when it looks like markdown) or an `errMsg` assistant turn with `Error`
+
+#### Scenario: Transcript action suppressed when empty
+
+- **GIVEN** no run carries a `Summary` or `Error`
+- **WHEN** `Actions()` is computed via `hasTranscriptContent`
+- **THEN** the `T` entry is suppressed so it doesn't dangle
+
+#### Scenario: Returning from the transcript
+
+- **GIVEN** the transcript chat view with `chatModel.transcript = true` and no input box
+- **WHEN** the user presses `Esc`
+- **THEN** the chat key handler emits `goBackFromCronTranscriptMsg`, `AppModel` switches back to `viewCrons`, and the preserved `cronsModel.subset`/`selectedID` land the user on the originating detail page
+
+### Requirement: Create and edit form constrained to cron schedules and agentTurn payloads
+
+The create and edit form SHALL share `cronForm` and the `cronFormField` enum (12 fields, tab-ordered). To avoid a TUI form modelling every union the gateway protocol exposes (`CronSchedule.Kind` ∈ `at`/`every`/`cron`; `CronPayload.Kind` ∈ `systemEvent`/`agentTurn`), the form SHALL be constrained to `cron` schedules and `agentTurn` payloads. Editing a job whose existing kind is anything else SHALL load the form in a refused state showing the banner:
+
+> Edit not supported for schedule kind "every". Use the openclaw CLI.
+
+The save path SHALL be suppressed in this state — the system surfaces the brittleness rather than silently round-tripping a truncated representation.
+
+Tab/Shift+Tab SHALL navigate fields. Space SHALL toggle the cycle/checkbox controls (`sessionTarget`, `wakeMode`, `deliveryMode`, `enabled`). Inside the payload `textarea`, Enter SHALL insert a newline; Ctrl+S (or Alt+Enter) SHALL save from anywhere; Esc SHALL cancel and return to whichever substate opened the form.
+
+#### Scenario: Editing an unmodelled kind is refused
+
+- **GIVEN** a job whose schedule kind is not `cron` or whose payload kind is not `agentTurn`
+- **WHEN** the user opens the edit form
+- **THEN** the form loads in a refused state showing `Edit not supported for schedule kind "every". Use the openclaw CLI.` and the save path is suppressed
+
+#### Scenario: Form navigation and controls
+
+- **WHEN** the user interacts with the form
+- **THEN** Tab/Shift+Tab navigate fields, Space toggles the cycle/checkbox controls (`sessionTarget`, `wakeMode`, `deliveryMode`, `enabled`), Enter inside the payload `textarea` inserts a newline, Ctrl+S or Alt+Enter saves from anywhere, and Esc cancels back to the opening substate
+
+### Requirement: Duplicate flow pre-populates a new job
+
+Pressing `d` on the list substate SHALL open the same form as `n`, but pre-populated from the highlighted job. The form SHALL stay in `mode=create` with `editingID=""`, so submission goes through `CronAdd` (not `CronUpdateRaw`) and produces a brand-new job rather than mutating the source. The name SHALL be prefixed with `Copy of ` so the duplicate is visually distinguishable in the list before the user edits it; every other field — schedule, timezone, agent, model, payload, session/wake, delivery, enabled — SHALL be copied verbatim. `populateFormFromJob` SHALL be shared with `newEditForm` so the two flows can't drift in which fields they carry over. Duplicating a job whose schedule kind is anything other than `cron` (or whose payload kind is anything other than `agentTurn`) SHALL be refused with the same banner the edit flow shows, for the same reason: the TUI form would silently truncate the unmodelled union fields.
+
+#### Scenario: Duplicating a supported job
+
+- **WHEN** the user presses `d` on a `cron`/`agentTurn` job in the list
+- **THEN** the create form opens in `mode=create` with `editingID=""`, the name prefixed `Copy of `, and every other field copied verbatim, so submission via `CronAdd` produces a new job
+
+#### Scenario: Shared populate path
+
+- **WHEN** either the duplicate flow or `newEditForm` populates the form
+- **THEN** both use `populateFormFromJob` so the fields carried over cannot drift
+
+#### Scenario: Duplicating an unmodelled kind is refused
+
+- **GIVEN** a job whose schedule kind is not `cron` or payload kind is not `agentTurn`
+- **WHEN** the user presses `d`
+- **THEN** the duplicate is refused with the same banner the edit flow shows
+
+### Requirement: Raw-patch edit semantics preserve cleared fields
+
+The toggle action (`t` on detail) and the create-form submit SHALL use the typed `protocol.CronUpdateParams`/`CronAddParams`. The edit-form submit SHALL instead go through `CronUpdateRaw(jobID, patch map[string]any)`, because every string field on `protocol.CronJobPatch` and `CronPayload` is tagged `json:",omitempty"` — once Go marshals an empty value, the field is dropped from the JSON, and the gateway can't distinguish "user cleared this field" from "user didn't touch this field" (it keeps the prior value). The map-based path SHALL emit empty strings verbatim (see `buildJobPatchMap`) so clearing model, description, or delivery actually persists. Toggle SHALL stay on the typed path because it only mutates a `*bool`, which doesn't have the omitempty problem.
+
+#### Scenario: Edit submit persists cleared fields
+
+- **GIVEN** the user clears model, description, or delivery in the edit form
+- **WHEN** the form is submitted via `CronUpdateRaw(jobID, patch map[string]any)`
+- **THEN** `buildJobPatchMap` emits the empty strings verbatim so the cleared values persist, rather than being dropped by `json:",omitempty"`
+
+#### Scenario: Toggle stays on the typed path
+
+- **WHEN** the user toggles enable/disable with `t`
+- **THEN** the typed `protocol.CronUpdateParams` path is used, because it only mutates a `*bool` and has no omitempty problem
+
+### Requirement: Payload field mapping between message and text
+
+`protocol.CronPayload` SHALL expose both `Text` and `Message` because the gateway's payload schema is a union. For `agentTurn` the prompt travels in `message` (the `agentTurn` schema declares `additionalProperties: false` and rejects `text`); for `systemEvent` it travels in `text`. Because the TUI form models `agentTurn` only, `buildAddParams` and `buildJobPatchMap` SHALL populate `message` and never emit `text`. On the read side, `populateFormFromJob` and `cronPayloadText` SHALL prefer `Message` and fall back to `Text` only for historical jobs that may still carry the prompt under the systemEvent-style field.
+
+#### Scenario: Writing an agentTurn prompt
+
+- **WHEN** `buildAddParams` or `buildJobPatchMap` writes the prompt for an `agentTurn` job
+- **THEN** it populates `message` and never emits `text`, because `agentTurn` declares `additionalProperties: false` and rejects `text`
+
+#### Scenario: Reading a prompt with fallback
+
+- **WHEN** `populateFormFromJob` or `cronPayloadText` reads the prompt
+- **THEN** it prefers `Message` and falls back to `Text` only for historical jobs that carry the prompt under the systemEvent-style field
+
+### Requirement: Confirm-delete substate
+
+Pressing `x` on detail SHALL transition to a y/n prompt. `y` SHALL call `CronRemove(jobID)` and refresh the list (returning to `cronSubList`). `n` or `esc` SHALL return to detail without action.
+
+#### Scenario: Confirming deletion
+
+- **GIVEN** the confirm-delete prompt is showing
+- **WHEN** the user presses `y`
+- **THEN** `CronRemove(jobID)` is called and the list is refreshed, returning to `cronSubList`
+
+#### Scenario: Cancelling deletion
+
+- **WHEN** the user presses `n` or `esc` at the confirm-delete prompt
+- **THEN** control returns to detail without any action
+
+### Requirement: Out-of-scope behaviours
+
+The cron browser SHALL NOT implement the following, which are deliberately out of scope:
+
+- Server-side cron filtering by agent (would need `agentId` added to `CronListParams` upstream).
+- Edit support for `at`/`every` schedules and `systemEvent` payloads.
+- Pagination of run history beyond the most recent 10 entries.
+- Live updates via cron-related gateway events — there is no streaming for cron state changes today, so the user must press `r` to refresh.
+- Replaying a cron run as a live chat session — the transcript is rebuilt from the run log, not from a queryable gateway session, so it's read-only by design.
+
+#### Scenario: No live cron updates
+
+- **GIVEN** a cron state change on the gateway
+- **WHEN** the user is viewing the cron browser
+- **THEN** the view does not update automatically and the user must press `r` to refresh, because there is no streaming for cron state changes
+
+#### Scenario: Run history is capped
+
+- **WHEN** the run-history table is populated
+- **THEN** it shows at most the most recent 10 entries, with no pagination beyond that

--- a/openspec/specs/export-and-recording/spec.md
+++ b/openspec/specs/export-and-recording/spec.md
@@ -1,0 +1,245 @@
+# Export and Recording Specification
+
+## Purpose
+
+Persist a session's conversation to disk via two slash commands: `/record` for live capture and `/export` for an after-the-fact dump. The implementation lives in `internal/tui/recorder.go` with the handlers in `internal/tui/commands.go`. Both commands draw from the same source — the canonical chat history the backend reports, never the streaming deltas — so the transcript reflects the conversation as the gateway / OpenAI-compat backend would replay it, not as the TUI rendered it. This spec covers the transcript source, on-disk file layout, the canonical-history tap, deduplication, the lifecycles of `/record` and `/export`, and the known limitations.
+
+## Requirements
+
+### Requirement: Transcript source is canonical history
+
+Both `/record` and `/export` SHALL draw from the same source: the canonical chat history the backend reports, never the streaming deltas. The transcript is meant to be the conversation as the gateway / OpenAI-compat backend would replay it, not as the TUI rendered it. The system SHALL intentionally exclude streaming placeholders, the tool-activity strip, system rows (compact/reset notices, exec output, error banners) and the inline separators inserted at session resume.
+
+#### Scenario: TUI-only rows excluded from the transcript
+
+- **GIVEN** a session whose chat view contains streaming placeholders, a tool-activity strip, system rows (compact/reset notices, exec output, error banners) and session-resume separators
+- **WHEN** the conversation is captured by `/record` or `/export`
+- **THEN** only the canonical user/assistant turns the backend reports are written
+- **AND** the TUI-only rows are excluded
+
+### Requirement: Transcript file location and permissions
+
+Transcripts SHALL be written to `<dataDir>/transcripts/` — `~/.lucinate/transcripts/` by default, or whatever `LUCINATE_DATA_DIR` / `config.SetDataDir` resolves to (see the `connections` spec for data-dir resolution). The directory SHALL be created on demand with mode `0o700`; individual files SHALL be mode `0o600`.
+
+#### Scenario: Transcript directory created on demand
+
+- **WHEN** a transcript is first written and `<dataDir>/transcripts/` does not exist
+- **THEN** the directory is created with mode `0o700`
+- **AND** the individual transcript file is written with mode `0o600`
+
+#### Scenario: Data directory override honoured
+
+- **GIVEN** `LUCINATE_DATA_DIR` or `config.SetDataDir` resolves the data directory to a non-default location
+- **WHEN** a transcript is written
+- **THEN** it is placed under `<dataDir>/transcripts/` for the resolved data directory
+
+### Requirement: Transcript filename shape
+
+Filenames SHALL follow `<kind>-<agent>-<session>-<UTCtimestamp>.md`, where `kind` is `record` or `export`. Agent and session names SHALL be passed through `sanitiseForPath`, which collapses anything outside `[A-Za-z0-9_-]` to `-` and trims separators — so `main session` becomes `main-session` and `Agent Name` becomes `Agent-Name`. The timestamp SHALL resolve to the second (`20060102T150405`); two recordings started inside the same second to the same session would collide and the second would truncate the first, which is fine in practice and avoided by `/record on` opening with `O_CREATE|O_TRUNC`.
+
+#### Scenario: Names sanitised for the filesystem
+
+- **GIVEN** an agent named `Agent Name` and a session named `main session`
+- **WHEN** the transcript filename is built
+- **THEN** `sanitiseForPath` yields `Agent-Name` and `main-session`, collapsing characters outside `[A-Za-z0-9_-]` to `-` and trimming separators
+
+#### Scenario: Kind prefix distinguishes record from export
+
+- **WHEN** a file is written by `/record`
+- **THEN** its name begins with `record-`
+- **AND** a file written by `/export` begins with `export-`
+
+### Requirement: Transcript body format
+
+The body SHALL be plain Markdown: a header listing connection / agent / model / session / timestamp, a `---` divider, then one `## User` or `## Assistant` block per turn. When a per-message `timestampMs` is reported by the backend it SHALL be appended to the heading as ` · <RFC3339>`. Assistant messages SHALL preserve any thinking content as a leading `> _thinking_` blockquote so the file is self-contained even when the chat view collapses thinking.
+
+#### Scenario: Header and per-turn blocks
+
+- **WHEN** a transcript is written
+- **THEN** it begins with a header listing connection, agent, model, session and timestamp, followed by a `---` divider
+- **AND** each turn is a `## User` or `## Assistant` block
+
+#### Scenario: Per-message timestamp appended
+
+- **GIVEN** the backend reports a `timestampMs` for a message
+- **WHEN** that message's heading is written
+- **THEN** ` · <RFC3339>` is appended to the heading
+
+#### Scenario: Thinking content preserved
+
+- **GIVEN** an assistant message with thinking content
+- **WHEN** it is written to the transcript
+- **THEN** the thinking is preserved as a leading `> _thinking_` blockquote so the file is self-contained even when the chat view collapses thinking
+
+### Requirement: Canonical-history tap
+
+The chat view SHALL receive canonical messages through two `tea.Msg` types, both produced by `fetchHistory` in `internal/tui/history.go`:
+
+- `historyLoadedMsg` — initial fetch on chat-view entry.
+- `historyRefreshMsg` — server-canonical resync issued from the chat-event `final`/`error`/`aborted` handlers in `internal/tui/events.go`. The merge boundary keeps the live tail intact (see `mergeHistoryRefresh` in `chat.go`) but the `messages` slice on the message itself is the authoritative gateway view of the conversation up to that point.
+
+Both arms SHALL call `chatModel.recordCanonical(msg.messages)` after consuming the message. When `chatModel.recorder` is `nil` (recording is off) this SHALL be a no-op; otherwise the slice SHALL be forwarded to `recorder.writeNew`, which iterates and writes any rows it hasn't seen before.
+
+#### Scenario: Initial and refresh messages both feed the recorder
+
+- **GIVEN** the chat view processes a `historyLoadedMsg` or a `historyRefreshMsg`
+- **WHEN** the message is consumed
+- **THEN** `chatModel.recordCanonical(msg.messages)` is called with the authoritative gateway view
+
+#### Scenario: Recording off is a no-op
+
+- **GIVEN** `chatModel.recorder` is `nil`
+- **WHEN** `recordCanonical` is called
+- **THEN** it is a no-op
+- **AND** when the recorder is non-nil the slice is forwarded to `recorder.writeNew`, which writes only rows it has not seen before
+
+### Requirement: Deduplication of repeated canonical rows
+
+Because each canonical refresh delivers the entire history (capped by `historyLimit`), every row arrives repeatedly, so the system SHALL deduplicate before writing. `recorder.seenSig` SHALL be a `map[string]bool` keyed by `messageSignature(role, timestampMs, sourceText)`, where `sourceText` is `chatMessage.raw` when the row was glamour-rendered and `chatMessage.content` otherwise — preferring the markdown source guarantees the dedup key matches the bytes that get written and avoids ANSI-rendered assistant turns leaking escape codes into the transcript. The hash SHALL be FNV-64a, formatted alongside role and timestamp as `role|ts|hex` so a user/assistant collision on identical content is impossible and a repeated user message at a later timestamp is recorded.
+
+The signature set SHALL live only for the lifetime of one recording. A new `/record on` SHALL start with an empty set and reseed the file from scratch (the underlying `os.OpenFile` uses `O_TRUNC`).
+
+#### Scenario: Repeated rows written once
+
+- **GIVEN** a canonical refresh redelivers rows already written in this recording
+- **WHEN** `recorder.writeNew` iterates the slice
+- **THEN** rows whose `messageSignature(role, timestampMs, sourceText)` is already in `recorder.seenSig` are skipped
+
+#### Scenario: Signature prefers markdown source
+
+- **GIVEN** a glamour-rendered assistant row
+- **WHEN** its signature is computed
+- **THEN** `sourceText` is `chatMessage.raw` (falling back to `chatMessage.content` when not rendered), so the dedup key matches the written bytes and no ANSI escape codes leak into the transcript
+
+#### Scenario: Signature distinctness across role and timestamp
+
+- **GIVEN** identical content across a user and an assistant row, or a repeated user message at a later timestamp
+- **WHEN** the FNV-64a signature is formatted as `role|ts|hex`
+- **THEN** a user/assistant collision on identical content is impossible
+- **AND** the repeated user message at the later timestamp is recorded
+
+#### Scenario: New recording reseeds the file
+
+- **WHEN** `/record on` is run again
+- **THEN** the signature set starts empty and the file is reseeded from scratch via `os.OpenFile` with `O_TRUNC`
+
+### Requirement: /record start lifecycle
+
+`/record on` SHALL open the file, write the header, attach a `*transcriptRecorder` to `chatModel`, then immediately call `recordCanonical(m.messages)` so any history already loaded into the chat view is captured before the next refresh. The chat view SHALL NOT re-fetch from the gateway at this point — the assumption is that `m.messages` reflects the most recent canonical state, since `historyLoadedMsg` and every `historyRefreshMsg` have already passed through.
+
+#### Scenario: Already-loaded history captured on start
+
+- **WHEN** `/record on` runs
+- **THEN** the file is opened, the header is written, a `*transcriptRecorder` is attached to `chatModel`, and `recordCanonical(m.messages)` is called immediately
+- **AND** the chat view does not re-fetch from the gateway, relying on `m.messages` as the most recent canonical state
+
+### Requirement: /record stop and teardown
+
+`/record off` and `chatModel.stopRecording()` SHALL close the writer and clear the field. The chat model's teardown sites in `app.go` — `sessionSelectedMsg`, `cronTranscriptMsg`, `newSessionCreatedMsg`, `sessionCreatedMsg` — SHALL call `stopRecording` before the field is reassigned, so a recording does not silently outlive its session. Recording SHALL NOT resume on the new chat; the user has to opt in again.
+
+#### Scenario: Explicit stop
+
+- **WHEN** `/record off` or `chatModel.stopRecording()` is invoked
+- **THEN** the writer is closed and the recorder field is cleared
+
+#### Scenario: Recording does not outlive its session
+
+- **GIVEN** an active recording
+- **WHEN** a `sessionSelectedMsg`, `cronTranscriptMsg`, `newSessionCreatedMsg`, or `sessionCreatedMsg` teardown fires in `app.go`
+- **THEN** `stopRecording` is called before the field is reassigned
+- **AND** recording does not resume on the new chat until the user opts in again
+
+### Requirement: /record write-failure handling
+
+A write failure on `recordCanonical` (disk full, broken permissions, file removed under us) SHALL close the recorder and surface a one-shot system error in the chat view. Subsequent canonical refreshes SHALL be no-ops because the field has been cleared — the alternative was repeated error rows on every turn, which would be more annoying than informative.
+
+#### Scenario: Write failure surfaces once
+
+- **GIVEN** an active recording
+- **WHEN** `recordCanonical` fails to write (disk full, broken permissions, file removed)
+- **THEN** the recorder is closed and a one-shot system error is shown in the chat view
+- **AND** subsequent canonical refreshes are no-ops because the field has been cleared
+
+### Requirement: /export one-shot file dump
+
+`exportTranscript` in `commands.go` SHALL be the synchronous one-shot path. It SHALL open a fresh `export-...md` file, write the same header (with `kind = "export"`), and walk the supplied `[]chatMessage` slice — typically `m.messages` — applying the same role and content filters as the recorder. Streaming rows SHALL be skipped explicitly (so an export issued mid-turn doesn't capture a half-typed assistant message); empty content SHALL be skipped; `raw` SHALL win over `content` for rendered turns. The function SHALL return the resolved path so the chat view can surface it.
+
+#### Scenario: Synchronous export with recorder filters
+
+- **WHEN** `/export` is run
+- **THEN** `exportTranscript` opens a fresh `export-...md` file, writes the header with `kind = "export"`, and walks the supplied `[]chatMessage` slice (typically `m.messages`)
+- **AND** streaming rows are skipped, empty content is skipped, and `raw` wins over `content` for rendered turns
+- **AND** the resolved path is returned so the chat view can surface it
+
+#### Scenario: Mid-turn export skips the half-typed reply
+
+- **GIVEN** an assistant reply is still streaming
+- **WHEN** `/export` is issued
+- **THEN** the streaming row is skipped so the half-typed assistant message is not captured
+
+### Requirement: /export routine prefill
+
+`/export routine` SHALL NOT write a file. `extractUserPromptsForRoutine` SHALL walk `m.messages` for non-empty user rows (preferring `raw` over `content`) and the handler SHALL dispatch `showRoutinesMsg{prefillSteps: …}`. The `showRoutinesMsg` arm in `app.go` SHALL construct the routines model, call `routinesModel.openCreateFormWithSteps(steps)` to skip the list and drop straight into the create form, and pre-populate one step per prompt. The user then fills in the name and mode and saves through the normal routines flow (see the `routines` spec). An empty session SHALL report a no-op error rather than opening an empty form.
+
+#### Scenario: User prompts prefill the routine create form
+
+- **WHEN** `/export routine` is run on a non-empty session
+- **THEN** `extractUserPromptsForRoutine` collects non-empty user rows (preferring `raw` over `content`), the handler dispatches `showRoutinesMsg{prefillSteps: …}`, and `app.go` opens the create form via `routinesModel.openCreateFormWithSteps(steps)` with one step per prompt
+- **AND** no file is written
+
+#### Scenario: Empty session is a no-op
+
+- **GIVEN** a session with no user prompts
+- **WHEN** `/export routine` is run
+- **THEN** a no-op error is reported rather than opening an empty form
+
+### Requirement: Backend-agnostic capture limited to user/assistant turns
+
+Both backends SHALL expose canonical history through the same `Backend.ChatHistory` RPC, so the recorder works against OpenClaw and OpenAI-compat alike. The OpenClaw gateway, however, does not expose tool call payloads in its history view — only the user/assistant turns survive the round-trip — so tool I/O cannot be pulled from the canonical fetch today. Tool-card capture would need a separate event-side tee.
+
+#### Scenario: Tool payloads absent from canonical history
+
+- **GIVEN** an OpenClaw session with tool activity
+- **WHEN** the transcript is captured from `Backend.ChatHistory`
+- **THEN** only the user/assistant turns are recorded because the gateway does not expose tool call payloads in its history view
+- **AND** capturing tool cards would require a separate event-side tee
+
+### Requirement: No live tail capture
+
+Streaming deltas SHALL be intentionally excluded from transcripts. A recording started mid-turn SHALL capture the assistant reply only after `final` lands and the refresh fires.
+
+#### Scenario: Mid-turn recording waits for final
+
+- **GIVEN** `/record on` is run while an assistant reply is streaming
+- **WHEN** the turn completes
+- **THEN** the assistant reply is captured only after `final` lands and the canonical refresh fires, not from the streaming deltas
+
+### Requirement: History-limit constraint
+
+`historyLimit` (a chat-view preference, see the `chat-ux` spec) SHALL cap the canonical fetch. For very long sessions, older turns may have already fallen off the window when `/record on` runs — the recorder only sees what `fetchHistory` returns. `/export` SHALL have the same constraint.
+
+#### Scenario: Older turns beyond the window are unavailable
+
+- **GIVEN** a session longer than `historyLimit`
+- **WHEN** `/record on` or `/export` runs
+- **THEN** only the turns within the capped canonical fetch returned by `fetchHistory` are captured; older turns that fell off the window are unavailable
+
+### Requirement: Filename collision within the same second
+
+Two recordings or exports started inside the same UTC second to the same session SHALL collide and the second SHALL truncate the first. This is practically impossible for `/record` and plausible only for tight scripted `/export` loops.
+
+#### Scenario: Same-second collision truncates
+
+- **GIVEN** two exports started inside the same UTC second for the same session
+- **WHEN** the second file is opened
+- **THEN** it resolves to the same filename and truncates the first
+
+### Requirement: Test coverage
+
+`internal/tui/recorder_test.go` SHALL cover the header layout, dedup across refreshes, role/streaming filters, raw-vs-rendered fidelity, the export round-trip, routine extraction, path sanitisation, filename shape, and signature distinctness. The tests SHALL use `config.SetDataDir(t.TempDir())` so they don't touch the user's real `~/.lucinate`.
+
+#### Scenario: Tests isolated from the user's data directory
+
+- **WHEN** the recorder tests run
+- **THEN** they exercise header layout, dedup across refreshes, role/streaming filters, raw-vs-rendered fidelity, the export round-trip, routine extraction, path sanitisation, filename shape, and signature distinctness
+- **AND** they use `config.SetDataDir(t.TempDir())` so the user's real `~/.lucinate` is untouched

--- a/openspec/specs/logging/spec.md
+++ b/openspec/specs/logging/spec.md
@@ -1,0 +1,193 @@
+# Logging Specification
+
+## Purpose
+
+Configure the process-wide `slog.Default` logger for lucinate from three environment
+variables and one runtime hint (`Options.TUI`). The `internal/logging` package owns this
+configuration; every other package logs through `log/slog` against the default logger and
+nothing in the codebase calls `log.Print*` directly. This spec covers the logging design,
+the destination-resolution rule, level parsing, and the TUI-safety constraints that drove
+the defaults. The user-facing summary lives in the README's environment-variables section.
+
+## Requirements
+
+### Requirement: slog-based logging through the default logger
+
+The `internal/logging` package SHALL configure the process-wide `slog.Default` logger, and
+every other package SHALL log through `log/slog` against that default logger. Nothing in the
+codebase SHALL call `log.Print*` directly. The handler SHALL be a plain
+`slog.NewTextHandler` or `slog.NewJSONHandler` — there is no custom formatter and no
+third-party logging dependency. TUI lifecycle call sites in
+`internal/tui/{events,sessions,chat,commands}.go` SHALL use `slog.Debug` directly with
+`key, value` attributes. Earlier revisions kept a `logEvent(format, args...)` shim around
+printf-style calls; that shim is gone and new code SHOULD follow the same attribute pattern.
+
+#### Scenario: Package logs via the default logger
+
+- **WHEN** any package emits a log line
+- **THEN** it calls a `log/slog` function against `slog.Default`
+- **AND** it does not call `log.Print*` directly
+
+#### Scenario: TUI call sites use structured attributes
+
+- **WHEN** a TUI lifecycle call site logs an event
+- **THEN** it calls `slog.Debug` directly with `key, value` attributes
+- **AND** does not route through a printf-style `logEvent` shim
+
+### Requirement: Side-file default protects the TUI terminal
+
+Because the TUI owns the terminal, anything written to stdout or stderr while a frame is
+being rendered will corrupt it — the cursor lands inside half-drawn ANSI sequences and the
+next repaint inherits the garbage. For TUI invocations the system SHALL default log output to
+a side file rather than the terminal. This preserves the pre-slog behaviour, which hardcoded a
+debug file (`/tmp/lucinate-events.log`) inside an `init()` hook in `internal/tui/logging.go`;
+that old file was opened on every start regardless of whether anyone wanted to read it and had
+no concept of severity. `internal/logging` keeps the side-file default for TUI invocations but
+gates everything behind a level and a configurable destination, so the same `slog.Warn` call
+can land in `<os-tempdir>/lucinate-events.log` during a TUI session (resolved via
+`os.TempDir()` so the path is sensible on every platform), stream to stderr during
+`lucinate send` so the operator sees it inline, or land in a JSON file the user pointed at for
+piping into `jq`. Calls below the configured level SHALL be dropped by the slog handler before
+they reach the writer.
+
+#### Scenario: TUI session logs to a side file, not the terminal
+
+- **GIVEN** a TUI invocation with no `LUCINATE_LOG_FILE` set
+- **WHEN** a log call at or above the configured level fires
+- **THEN** it is written to `<os.TempDir()>/lucinate-events.log`
+- **AND** nothing is written to stdout or stderr that could corrupt the rendered frame
+
+#### Scenario: Sub-level calls are dropped
+
+- **WHEN** a log call is below the configured level
+- **THEN** the slog handler drops it before it reaches the writer
+
+### Requirement: Destination resolution rule
+
+The `openDestination` function (`internal/logging/logging.go`) SHALL resolve the log
+destination from `LUCINATE_LOG_FILE` and `Options.TUI` per this rule:
+
+| `LUCINATE_LOG_FILE` set | `Options.TUI` | Destination |
+|---|---|---|
+| yes | either | the named file, opened `O_TRUNC` (current session only) |
+| no  | true   | `DefaultTUIFile()` (`<os.TempDir()>/lucinate-events.log`), opened `O_TRUNC` |
+| no  | false  | `os.Stderr` |
+
+Truncate-on-start matches the pre-slog behaviour and keeps the file scoped to the current
+session — handy when tailing it while reproducing a bug. To keep history across runs, the user
+SHALL point `LUCINATE_LOG_FILE` at a path they will archive themselves.
+
+#### Scenario: Explicit log file wins regardless of mode
+
+- **GIVEN** `LUCINATE_LOG_FILE` is set
+- **WHEN** the destination is resolved
+- **THEN** the named file is used, opened `O_TRUNC` for the current session only
+- **AND** the choice is independent of `Options.TUI`
+
+#### Scenario: TUI default file
+
+- **GIVEN** `LUCINATE_LOG_FILE` is unset AND `Options.TUI` is true
+- **WHEN** the destination is resolved
+- **THEN** it is `DefaultTUIFile()` (`<os.TempDir()>/lucinate-events.log`), opened `O_TRUNC`
+
+#### Scenario: Non-TUI defaults to stderr
+
+- **GIVEN** `LUCINATE_LOG_FILE` is unset AND `Options.TUI` is false
+- **WHEN** the destination is resolved
+- **THEN** it is `os.Stderr`
+
+### Requirement: TUI-mode detection drives the destination
+
+`Options.TUI` SHALL be set by `cli.Run` based on `isTUIInvocation(args)`: empty args (bare
+`lucinate`) and `lucinate chat` are TUI; everything else (`send`, `help`, `--version`, unknown
+subcommands) is non-TUI. This subcommand-specific routing SHALL live in `cli.Run` deliberately —
+moving it into `app.Run` would mean every embedder has to re-implement the same TUI / non-TUI
+distinction.
+
+#### Scenario: Bare invocation and chat are TUI
+
+- **WHEN** the process is launched as bare `lucinate` or `lucinate chat`
+- **THEN** `isTUIInvocation(args)` is true and `Options.TUI` is set true
+
+#### Scenario: Other subcommands are non-TUI
+
+- **WHEN** the process is launched as `send`, `help`, `--version`, or an unknown subcommand
+- **THEN** `isTUIInvocation(args)` is false and `Options.TUI` is set false
+
+### Requirement: Log level parsing and default
+
+The system SHALL support the standard `log/slog` levels `debug`, `info`, `warn`, and `error`,
+with `warn` as the default. Level parsing SHALL be case-insensitive and SHALL tolerate
+`warning` as an alias for `warn`. Anything unrecognised SHALL fall back to `warn` silently,
+because a typo in a user's shell rc must not fail the launch. The `warn` default means a bare
+`lucinate` run produces no log noise at all unless something genuinely worth flagging happens,
+preserving the previous "silent unless you opted into the debug file" behaviour while still
+giving the operator a knob to turn up.
+
+#### Scenario: Case-insensitive parsing with warning alias
+
+- **WHEN** the level is given as `WARN`, `Warning`, or `warning`
+- **THEN** it resolves to the `warn` level
+
+#### Scenario: Unrecognised level falls back silently
+
+- **GIVEN** an unrecognised level string (e.g. a typo)
+- **WHEN** the logger is initialised
+- **THEN** it falls back to `warn` without failing the launch
+
+#### Scenario: Default is silent for a bare run
+
+- **GIVEN** no level override
+- **WHEN** a bare `lucinate` runs and nothing warn-worthy happens
+- **THEN** no log output is produced
+
+### Requirement: Environment-variable configuration
+
+The system SHALL configure logging from three environment variables and the `Options.TUI`
+runtime hint:
+
+| Variable | Effect |
+|---|---|
+| `LUCINATE_LOG_FILE` | Destination path; when set, log output goes to this file, opened `O_TRUNC` for the current session, regardless of TUI mode |
+| `LUCINATE_LOG_LEVEL` | Minimum level (`debug`/`info`/`warn`/`error`, case-insensitive, `warning` accepted); unrecognised values fall back to `warn` |
+| `LUCINATE_LOG_FORMAT` | Handler selection between the text handler (`slog.NewTextHandler`) and the JSON handler (`slog.NewJSONHandler`), the latter suitable for piping into `jq` |
+
+#### Scenario: Log file variable overrides the destination
+
+- **GIVEN** `LUCINATE_LOG_FILE` points at a path
+- **WHEN** the logger initialises
+- **THEN** output goes to that file, opened `O_TRUNC`, regardless of TUI mode
+
+#### Scenario: JSON format for machine consumption
+
+- **GIVEN** `LUCINATE_LOG_FORMAT` selects JSON
+- **WHEN** the logger initialises
+- **THEN** it installs `slog.NewJSONHandler` so records can be piped into `jq`
+
+### Requirement: Idempotent re-init and test lifecycle
+
+`Init` SHALL be idempotent: a second call SHALL close the previously opened file (if any) and
+install a fresh handler. The package SHALL keep the open file handle in `currentFile` so a
+re-init does not leak a file descriptor. Tests SHALL use `closeForTest` to flush and close
+without re-init, since re-init would re-truncate the file mid-test. Outside tests nothing
+currently re-inits — `cli.Run` calls `Init` once at the top of the dispatch and the rest of the
+process inherits `slog.Default`.
+
+#### Scenario: Second Init closes the prior file
+
+- **GIVEN** `Init` has already opened a log file
+- **WHEN** `Init` is called again
+- **THEN** the previously opened file is closed and a fresh handler is installed
+- **AND** no file descriptor is leaked because the handle is tracked in `currentFile`
+
+#### Scenario: Tests close without re-truncating
+
+- **WHEN** a test needs to flush and close the log
+- **THEN** it calls `closeForTest` rather than re-initialising
+- **AND** the file is not re-truncated mid-test
+
+#### Scenario: Single init in normal operation
+
+- **WHEN** the process runs outside tests
+- **THEN** `cli.Run` calls `Init` once at the top of the dispatch
+- **AND** the rest of the process inherits `slog.Default` without re-init

--- a/openspec/specs/message-rendering/spec.md
+++ b/openspec/specs/message-rendering/spec.md
@@ -1,0 +1,181 @@
+# Message Rendering Specification
+
+## Purpose
+
+Define how chat messages are displayed in the TUI: the role each message carries and its visual treatment, the conventions that keep injected content out of restored history, conditional markdown rendering of assistant replies, the ephemeral tool-activity strip that keeps tool calls off the message list, the streaming placeholder, and the queued-message footer. Together these rules keep the transcript readable and its reading order intuitive while the agent streams a turn.
+
+## Requirements
+
+### Requirement: Message roles and their display
+
+Each chat message SHALL carry a role that determines how it is displayed in the TUI. The system SHALL support the following roles:
+
+- `user` — sent by the local user; shown right-aligned.
+- `assistant` — returned by the agent; rendered as markdown via Glamour.
+- `system` — local-only notices (errors, status, command output); shown in a muted style and never sent to the gateway.
+- `separator` — a dim divider row inserted between restored history and a new turn; labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`). The `timestampMs` field on `chatMessage` carries the unix-ms used by `formatSeparatorLabel`.
+
+Tool calls SHALL NOT be message rows. They are tracked separately and rendered in an ephemeral strip above the input — see the tool-activity strip requirement.
+
+#### Scenario: Assistant reply rendered as markdown
+
+- **WHEN** a message with role `assistant` is displayed
+- **THEN** it is rendered as markdown via Glamour
+
+#### Scenario: System notice is local-only
+
+- **GIVEN** a message with role `system`
+- **THEN** it is shown in a muted style
+- **AND** it is never sent to the gateway
+
+#### Scenario: Separator labelled with relative time
+
+- **WHEN** a `separator` row is inserted between restored history and a new turn
+- **THEN** it is labelled with the relative time of the most recent restored message (e.g. `Resumed from 2h ago`) via `formatSeparatorLabel`, using the `timestampMs` field on `chatMessage`
+
+### Requirement: Hiding injected content from restored history
+
+Some content needs to be sent to the gateway as part of a user message (so the agent sees it) but MUST NOT be shown in the local chat history when it is loaded back. The system SHALL use two complementary conventions for this, and both strippers SHALL be applied to user messages on history reload.
+
+**`System:` line prefix.** Each line of the block SHALL be prefixed with `System: ` (or `System (<qualifier>): ` for gateway-rewritten variants like `System (untrusted):`). `prefixAllLines()` in `internal/tui/skills.go` applies the prefix; `stripSystemLines()` in `internal/tui/history.go` removes matching lines on history reload, and `isSystemLine()` recognises both forms. This convention is used for the **skill catalog** prepended to the first user message of each session — see the `skills` spec and the `backend-openclaw` spec.
+
+```
+System: Available agent skills (activate with /skill-name):
+System:   - review: Perform a code review
+```
+
+**`<local-agent-skill>` envelope.** When the user invokes a skill (`/review` alone or `use /review on x`), `expandSkillReferences()` in `internal/tui/skills.go` SHALL produce a payload prefixed with `Please use the following skill(s):` followed by one or more `<local-agent-skill name="…">…</local-agent-skill>` blocks. `stripLocalAgentSkillBlocks()` in `internal/tui/history.go` SHALL elide the preamble line and every block (inclusive) on history reload. See the `skills` spec for the full payload shape and substitution rules.
+
+#### Scenario: System-prefixed lines removed on reload
+
+- **GIVEN** a user message whose lines are prefixed `System: ` or `System (<qualifier>): ` (e.g. `System (untrusted):`)
+- **WHEN** history is reloaded
+- **THEN** `stripSystemLines()` removes the matching lines, recognised by `isSystemLine()` in both forms
+
+#### Scenario: Skill envelope elided on reload
+
+- **GIVEN** a user message containing the `Please use the following skill(s):` preamble followed by one or more `<local-agent-skill name="…">…</local-agent-skill>` blocks
+- **WHEN** history is reloaded
+- **THEN** `stripLocalAgentSkillBlocks()` elides the preamble line and every block inclusive
+
+### Requirement: Conditional markdown rendering of assistant messages
+
+Assistant messages SHALL be conditionally rendered with Glamour. `looksLikeMarkdown()` in `internal/tui/history.go` SHALL check for code fences, bold markers, pipe tables, list prefixes, headings, and numbered lists; if none are found the text SHALL be shown as plain text, avoiding unwanted paragraph indentation on short replies. The Glamour renderer SHALL be created in `setSize()` with a wrap width equal to the terminal width minus 4. `wordWrap()` in `render.go` SHALL be applied after rendering and SHALL preserve lines containing box-drawing characters (table borders) so they are not split.
+
+#### Scenario: Short plain reply not rendered as markdown
+
+- **GIVEN** an assistant message with none of code fences, bold markers, pipe tables, list prefixes, headings, or numbered lists
+- **WHEN** `looksLikeMarkdown()` evaluates it
+- **THEN** it is shown as plain text, avoiding unwanted paragraph indentation
+
+#### Scenario: Table borders preserved on wrap
+
+- **WHEN** `wordWrap()` runs after rendering, with the Glamour wrap width set to the terminal width minus 4
+- **THEN** lines containing box-drawing characters (table borders) are preserved and not split
+
+### Requirement: Tool-activity strip
+
+When the agent invokes a tool, the system SHALL show it in an ephemeral **activity strip** rendered directly above the input, not inline in the scrollback. The strip SHALL be driven by `agent` events with `stream == "tool"` from the gateway — declared via the `tool-events` capability on connect (see `internal/client/client.go`).
+
+Tool calls SHALL be kept **off** the message list (`chatModel.activeTools`, a `[]toolActivity`). An earlier design appended a `role: "tool"` message per call, which froze the streaming assistant row so each subsequent tool split the reply onto a fresh row. Because the gateway streams the whole turn's text *cumulatively* (every delta carries all text so far), that split made each post-tool row re-render everything before it — the "delta accumulation / repeated content" bug. Keeping tools out of the message list leaves the streaming assistant row intact, so the whole turn lands on one row and the cumulative full-replace is correct.
+
+While a turn is in flight (or any tool is still running), the strip SHALL list each tool on its own line — a state glyph, the tool name, and a one-line argument summary:
+
+```
+✓ search (query="hello world")
+⠋ read (path="/big/file")
+```
+
+The running glyph SHALL cycle through the same braille spinner as the streaming cursor (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`), then flip to `✓` on success or `✖` on error (errors append a one-line message extracted from the tool result). When more than `maxToolStripRows` tools have run, the oldest SHALL fold into a leading `…N earlier` line so the newest stay visible.
+
+Once the turn is idle and every tool has resolved, the strip SHALL collapse to a single summary line grouping calls by name, which persists until the next turn begins:
+
+```
+✓ called search ×3, read ×2
+✖ called fetch ×2 (1 failed)
+```
+
+The mapping from event payload to strip lives in `handleAgentEvent` (`internal/tui/events.go`):
+
+- `phase: "start"` — appends a `toolActivity{state: "running"}`. The streaming assistant row is left untouched.
+- `phase: "update"` — currently a no-op. Partial result streaming is deferred (see issue for expand/collapse output).
+- `phase: "result"` — finds the matching entry by `callID` and flips its state to `"success"` or `"error"`.
+
+The strip SHALL be cleared at the start of each turn (`resetToolActivity`), and on error/aborted so a tool left mid-run cannot strand a spinning glyph. Its rendered height SHALL be subtracted from the viewport in `applyLayout` (via `toolStripHeight`), the same way the completion menu and notification rows reserve space. The `summariseArgs` helper SHALL pick a human-readable key from the args object (priority order: `command`, `path`, `file`, `filePath`, `query`, `url`, `name`, `message`, `text`) or fall back to compact JSON, truncated to 80 runes. The full output of a tool call is not currently rendered; only the header line is. An expand/collapse affordance similar to the official OpenClaw TUI's Ctrl+O is tracked separately.
+
+#### Scenario: Tool call rendered in the strip, not the scrollback
+
+- **GIVEN** the agent invokes a tool, surfaced as an `agent` event with `stream == "tool"` (enabled via the `tool-events` capability)
+- **WHEN** `handleAgentEvent` receives `phase: "start"`
+- **THEN** a `toolActivity{state: "running"}` is appended to `chatModel.activeTools` and shown in the strip above the input
+- **AND** the streaming assistant row is left untouched, keeping the whole turn on one row so the cumulative full-replace stays correct
+
+#### Scenario: Tool result flips its glyph
+
+- **WHEN** `handleAgentEvent` receives `phase: "result"`
+- **THEN** it finds the matching entry by `callID` and flips its state to `"success"` (`✓`) or `"error"` (`✖`), appending a one-line message extracted from the tool result on error
+
+#### Scenario: Oldest tools folded when the strip overflows
+
+- **WHEN** more than `maxToolStripRows` tools have run
+- **THEN** the oldest fold into a leading `…N earlier` line so the newest stay visible
+
+#### Scenario: Strip collapses to a summary when idle
+
+- **WHEN** the turn is idle and every tool has resolved
+- **THEN** the strip collapses to a single summary line grouping calls by name (e.g. `✓ called search ×3, read ×2`), which persists until the next turn begins
+
+#### Scenario: Strip cleared to avoid a stranded spinner
+
+- **WHEN** a new turn starts (`resetToolActivity`), or the turn errors or is aborted
+- **THEN** the strip is cleared so a tool left mid-run cannot strand a spinning glyph
+
+#### Scenario: Argument summary key selection
+
+- **WHEN** `summariseArgs` builds the one-line argument summary
+- **THEN** it picks the first present key in priority order `command`, `path`, `file`, `filePath`, `query`, `url`, `name`, `message`, `text`, or falls back to compact JSON, truncated to 80 runes
+
+### Requirement: Streaming placeholder and pending-row spinner
+
+When the user sends a message, the system SHALL immediately append an empty assistant message with `streaming: true` so there is always something to animate (see the `chat-ux` spec for the streaming animation). As delta events arrive, the message content SHALL be built up incrementally. If the final event arrives before any delta (e.g. an error), the placeholder message SHALL be removed from the display.
+
+The same spinner glyph SHALL also decorate *pending system rows* — `chatMessage.pending` flags a system message as in-flight, and the renderer appends the current spinner frame after the body. `/compact` and `/reset` use this to give visible feedback while their actions run; the result handler SHALL clear `pending` (or replace the row entirely) once the outcome lands.
+
+#### Scenario: Placeholder appended on send
+
+- **WHEN** the user sends a message
+- **THEN** an empty assistant message with `streaming: true` is appended immediately
+- **AND** its content is built up incrementally as delta events arrive
+
+#### Scenario: Error before any delta removes the placeholder
+
+- **GIVEN** an assistant placeholder is streaming
+- **WHEN** the final event arrives before any delta (e.g. an error)
+- **THEN** the placeholder message is removed from the display
+
+#### Scenario: Pending system row shows a spinner
+
+- **GIVEN** a system message with `chatMessage.pending` set (e.g. from `/compact` or `/reset`)
+- **WHEN** it is rendered
+- **THEN** the current spinner frame is appended after the body
+- **AND** once the outcome lands the result handler clears `pending` or replaces the row entirely
+
+### Requirement: Queued-message footer
+
+Messages the user submits while a turn is streaming SHALL be held in `chatModel.pendingMessages` and rendered by `renderPendingMessages` as dim/italic `You:` shadows in a fixed footer **below** the tool-activity strip — not in the scrollable transcript. This keeps the reading order intuitive: transcript (what happened) → tool strip (what's running) → queued shadows (what's next). Only an error notification sits lower, between the queue and the input; see the `chat-ux` spec (view region order) for the full top-to-bottom layout. The footer's height SHALL be reserved in `applyLayout` via `pendingHeight`, and `applyLayout` SHALL be re-run wherever the queue changes (enqueue, `drainQueue`, up-arrow recall, cancel) so the viewport reclaims the rows as the queue drains. Each queued message SHALL be dispatched in FIFO order by `drainQueue` once the in-flight turn finalises.
+
+#### Scenario: Queued message shown as a footer shadow
+
+- **GIVEN** a turn is streaming
+- **WHEN** the user submits another message
+- **THEN** it is held in `chatModel.pendingMessages` and rendered by `renderPendingMessages` as a dim/italic `You:` shadow in the fixed footer below the tool-activity strip, not in the scrollable transcript
+
+#### Scenario: Viewport reclaims rows as the queue drains
+
+- **WHEN** the queue changes (enqueue, `drainQueue`, up-arrow recall, or cancel)
+- **THEN** `applyLayout` re-runs, reserving the footer height via `pendingHeight` so the viewport reclaims the rows as the queue drains
+
+#### Scenario: Queued messages dispatched in FIFO order
+
+- **WHEN** the in-flight turn finalises
+- **THEN** `drainQueue` dispatches each queued message in FIFO order

--- a/openspec/specs/one-shot/spec.md
+++ b/openspec/specs/one-shot/spec.md
@@ -1,0 +1,228 @@
+# One-Shot Mode Specification
+
+## Purpose
+
+`lucinate send` is a non-TUI entry point that dispatches a single chat turn through a stored connection / agent / session and (by default) prints the assistant's first complete reply to stdout. It is the scripting surface alongside the interactive TUI, and it deliberately reuses the TUI's connection store, backend factory, and event channel so retry / auth / capability behaviour stays consistent across both modes. This spec covers the `app.Send` lifecycle, the default-session rule, detach semantics, the `ask` alias, the embedder seam, reply-text extraction, and the deliberate non-goals. The user-facing CLI shape is documented in the README's one-shot-mode section.
+
+## Requirements
+
+### Requirement: Send lifecycle pipeline
+
+`app.Send` (`app/send.go`) SHALL run an eight-step pipeline:
+
+1. **Resolve the connection.** `LoadConnections()` from `internal/config`, then `resolveSendConnection` matches the user-supplied `--connection` first by ID and then case-insensitively by `Name`. A missing connection SHALL be a clean error — the resolver MUST NOT fall through to the entry-view decision tree (`config.ResolveEntryConnection`), which is TUI-only.
+2. **Build the backend.** `DefaultBackendFactory` (`app/factory.go`) dispatches by `Connection.Type` — the same factory the TUI uses, with the same auth wiring (per-connection secrets store, env-var fallback for OpenAI, etc.).
+3. **Connect.** `backend.Backend.Connect`. A failure SHALL tear the backend back down before returning. There is no auth-recovery modal in this mode; an auth error surfaces as a normal error and the process exits non-zero.
+4. **Mark the connection as last-used.** Mirrors the TUI's "last used = default" pattern via `Connections.MarkUsed` + `config.SaveConnections` so the next launch (TUI or `send`) picks the same connection by default.
+5. **List agents and resolve the agent.** `ListAgents`, then `resolveSendAgent` matches first by ID and then by case-insensitive `Name`.
+6. **Default the session key.** `defaultSessionKey` mirrors the TUI's pick in `internal/tui/select.go`: `AgentsListResult.MainKey` when the chosen agent is the default agent (`agent.ID == list.DefaultID`), otherwise the literal string `"main"`. An explicit `--session` flag short-circuits this.
+7. **Create or resume the session.** `CreateSession` round-trips through the backend; the canonical key it returns is what `ChatSend` uses. OpenClaw asks the gateway; OpenAI-compat returns `agentID` (agent ≡ session); Hermes returns the synthetic agent ID.
+8. **Subscribe before send, then dispatch.** A `replyCollector` goroutine starts draining `backend.Events()` *before* `ChatSend` is called so the final event cannot race past the consumer. `ChatSend` returns its RPC ack containing the run ID; the collector is told the run ID after the ack lands so events from concurrent turns on the same session are filtered out.
+
+#### Scenario: Missing connection is a clean error
+- **WHEN** `--connection` names a connection that resolves against neither an ID nor a case-insensitive `Name`
+- **THEN** `resolveSendConnection` returns a clean error
+- **AND** it does NOT fall through to `config.ResolveEntryConnection`, which is TUI-only
+
+#### Scenario: Full happy-path turn
+- **GIVEN** a valid connection, agent, and message
+- **WHEN** `app.Send` runs
+- **THEN** it resolves the connection, builds the backend via `DefaultBackendFactory`, connects, marks the connection last-used via `Connections.MarkUsed` + `config.SaveConnections`, resolves the agent, defaults the session key, creates or resumes the session, and dispatches `ChatSend`
+- **AND** the `replyCollector` goroutine begins draining `backend.Events()` before `ChatSend` is called so the final event cannot race past the consumer
+
+#### Scenario: Connect failure tears down the backend
+- **WHEN** `backend.Backend.Connect` fails
+- **THEN** the backend is torn back down before returning
+- **AND** the auth error surfaces as a normal error with a non-zero process exit, with no auth-recovery modal
+
+#### Scenario: Run-ID filtering of concurrent turns
+- **GIVEN** the `replyCollector` is draining events before dispatch
+- **WHEN** `ChatSend` returns its RPC ack containing the run ID
+- **THEN** the collector is told the run ID after the ack lands
+- **AND** events from concurrent turns on the same session are filtered out
+
+### Requirement: No supervision for one-shot turns
+
+`Send` SHALL NOT run `Backend.Supervise`. A one-shot turn is short-lived enough that auto-reconnect is dead weight; a dropped socket SHALL surface as a clean failure ("backend event channel closed before reply") rather than triggering exponential backoff. The TUI's `app.Program` keeps Supervise — the lifetimes are different.
+
+#### Scenario: Dropped socket surfaces as a clean failure
+- **GIVEN** a one-shot turn is in flight
+- **WHEN** the backend socket drops
+- **THEN** `Send` returns the clean failure "backend event channel closed before reply"
+- **AND** no exponential backoff or auto-reconnect is triggered
+
+### Requirement: Default session selection
+
+The default-key rule SHALL be shared with the TUI agent picker so `lucinate send` and "select agent → main" land on the same gateway-side session:
+
+| Agent | `--session` unset → key passed to `CreateSession` |
+|-------|---------------------------------------------------|
+| Default agent (`agent.ID == list.DefaultID`) | `list.MainKey` |
+| Any other agent                              | `"main"` (literal)                                |
+
+If the same key already exists on the gateway, `CreateSession` SHALL resume it; if not, the gateway SHALL provision one. From the script's point of view, `lucinate send --connection X --agent Y "hello"` repeats into the same conversation forever unless `--session` is supplied.
+
+The literal-`"main"` fallback for non-default agents matches what the TUI passes when the user picks a non-default agent and accepts the picker's "main" session. Backends that don't keep server-side session state (OpenAI, Hermes) SHALL ignore the key shape and route by `agentID` regardless.
+
+#### Scenario: Default agent uses the main-session key
+- **GIVEN** the chosen agent is the default agent (`agent.ID == list.DefaultID`) and `--session` is unset
+- **WHEN** the session key is defaulted
+- **THEN** `list.MainKey` is passed to `CreateSession`
+
+#### Scenario: Non-default agent falls back to literal "main"
+- **GIVEN** the chosen agent is not the default agent and `--session` is unset
+- **WHEN** the session key is defaulted
+- **THEN** the literal string `"main"` is passed to `CreateSession`, matching what the TUI passes when the user accepts the picker's "main" session
+
+#### Scenario: Repeated sends land in the same conversation
+- **GIVEN** `--session` is not supplied
+- **WHEN** `lucinate send --connection X --agent Y "hello"` is run repeatedly
+- **THEN** `CreateSession` resumes the existing key if present or the gateway provisions one, so the turns repeat into the same conversation
+
+#### Scenario: Stateless backends route by agent
+- **GIVEN** an OpenAI or Hermes backend that keeps no server-side session state
+- **WHEN** a session key is passed
+- **THEN** the backend ignores the key shape and routes by `agentID`
+
+### Requirement: Detach mode
+
+`Send` in detach mode (`--detach`) SHALL skip step 8's wait: after `ChatSend` returns, `Send` SHALL return nil regardless of subsequent events. `--detach` returns as soon as `ChatSend` resolves its RPC ack.
+
+This guarantees:
+
+- Validation errors surface synchronously: missing flag, no such agent, no such connection, wire-level rejection (auth, idempotency conflict, malformed input).
+- The gateway has accepted the turn and assigned a run ID.
+
+It does **not** guarantee:
+
+- That the assistant will reply.
+- That a reply, if it arrives, ever reaches stdout — the run continues server-side, and the streaming events are consumed nowhere in detach mode. The reply is rendered the next time the user opens the TUI on that session, just as if a previous TUI window had been closed mid-turn.
+
+Detach is intended for cron-style automation ("nudge the agent at 09:00 to draft the morning digest, render the result on my next browse") and for fire-and-forget shell-pipeline steps that don't care about the response text.
+
+#### Scenario: Detach returns on the ack
+- **GIVEN** `--detach` is set
+- **WHEN** `ChatSend` resolves its RPC ack
+- **THEN** `Send` returns nil immediately, skipping the reply wait, regardless of subsequent events
+
+#### Scenario: Validation errors surface synchronously in detach
+- **GIVEN** `--detach` is set
+- **WHEN** there is a missing flag, no such agent, no such connection, or a wire-level rejection (auth, idempotency conflict, malformed input)
+- **THEN** the error surfaces synchronously
+
+#### Scenario: Detach does not guarantee a reply reaches stdout
+- **GIVEN** `--detach` is set and the gateway has accepted the turn with a run ID
+- **WHEN** the assistant later replies
+- **THEN** the reply is not written to stdout — the run continues server-side and streaming events are consumed nowhere
+- **AND** the reply is rendered the next time the user opens the TUI on that session
+
+### Requirement: The `ask` alias
+
+`lucinate ask` (`internal/cli/ask.go`) SHALL be a thin wrapper over the same `app.Send` pipeline — there is no second code path. The only difference from `send` is where the flags' default values come from:
+
+- `runAsk` loads `config.LoadPreferences().Ask` (a `config.AskDefaults` block in `config.json`) and seeds the `ask` flag set's defaults with it. An omitted `-c`/`-a`/`-s`/`-d` SHALL fall back to the saved value; an explicit flag SHALL still override it, because `flag` parsing runs after the defaults are set.
+- After parsing, `runAsk` SHALL guard on a blank connection or agent and return an `ask:`-prefixed error pointing the user at `/settings ▸ Ask command defaults`, rather than letting `app.Send`'s `send:`-prefixed "required" error surface for what is, in `ask`'s world, a configuration gap.
+- Everything else — message join, `--`/dash handling, the `app.Send` dispatch — SHALL be identical to `runSend`.
+
+`config.AskDefaults` has one field per `send` flag (`Connection`, `Agent`, `Session`, `Detach`). The three files carry mutual `KEEP IN SYNC` comments (`internal/cli/send.go`, `internal/cli/ask.go`, `internal/config/preferences.go`): a new field added to `send` should gain an `AskDefaults` field and a row in the TUI sub-screen so `ask` stays a complete alias. The defaults are edited in the TUI under `/settings ▸ Ask command defaults` (`internal/tui/askconfigview.go`); see the `commands` spec for `/settings` dispatch.
+
+#### Scenario: Omitted flag falls back to saved default
+- **GIVEN** a `config.AskDefaults` block in `config.json`
+- **WHEN** `-c`/`-a`/`-s`/`-d` is omitted from an `ask` invocation
+- **THEN** the value falls back to the saved default, because `runAsk` seeds the flag set's defaults before `flag` parsing
+
+#### Scenario: Explicit flag overrides the saved default
+- **GIVEN** a saved `AskDefaults` value for a flag
+- **WHEN** the flag is passed explicitly
+- **THEN** the explicit value overrides the saved default, because `flag` parsing runs after the defaults are set
+
+#### Scenario: Blank connection or agent yields an ask-prefixed error
+- **GIVEN** an `ask` invocation whose resolved connection or agent is blank
+- **WHEN** `runAsk` guards after parsing
+- **THEN** it returns an `ask:`-prefixed error pointing at `/settings ▸ Ask command defaults`, rather than `app.Send`'s `send:`-prefixed "required" error
+
+#### Scenario: Everything else matches runSend
+- **WHEN** an `ask` turn is dispatched
+- **THEN** message join, `--`/dash handling, and the `app.Send` dispatch are identical to `runSend`
+
+### Requirement: Embedding `app.Send` from Go
+
+`SendOptions` SHALL be the embedder's seam set:
+
+```go
+err := app.Send(ctx, app.SendOptions{
+    Connection:       "my-con",
+    Agent:            "main",
+    Session:          "",       // empty → main-session default
+    Message:          "hello",
+    Detach:           false,
+    Out:              os.Stdout,
+    BackendFactory:   nil,      // nil → DefaultBackendFactory
+    ConnectionsStore: nil,      // nil → LoadConnections()
+})
+```
+
+- `Out` is where the reply is written when not detached.
+- `BackendFactory` lets tests substitute a fake backend (see `app/send_test.go` for the pattern) without going through `DefaultBackendFactory`'s auth / secrets wiring.
+- `ConnectionsStore`, when non-nil, SHALL suppress the implicit `SaveConnections` after `MarkUsed` so test runs don't leave a dirty `connections.json` on disk; production callers leave it nil.
+
+The function is single-shot — there is no streaming surface and no incremental callback. Embedders that need to observe deltas, tool events, or thinking blocks SHALL drive `app.Program` directly.
+
+#### Scenario: Nil options resolve to defaults
+- **GIVEN** `SendOptions` with `BackendFactory: nil` and `ConnectionsStore: nil`
+- **WHEN** `app.Send` runs
+- **THEN** `BackendFactory` resolves to `DefaultBackendFactory` and `ConnectionsStore` resolves to `LoadConnections()`
+
+#### Scenario: Non-nil ConnectionsStore suppresses the disk write
+- **GIVEN** a non-nil `ConnectionsStore`
+- **WHEN** the connection is marked used
+- **THEN** the implicit `SaveConnections` after `MarkUsed` is suppressed so no dirty `connections.json` is left on disk
+
+#### Scenario: Fake backend for tests
+- **GIVEN** a `BackendFactory` supplied by a test
+- **WHEN** `app.Send` builds the backend
+- **THEN** the fake backend is used without going through `DefaultBackendFactory`'s auth / secrets wiring
+
+#### Scenario: Streaming observers must drive the program
+- **GIVEN** an embedder that needs to observe deltas, tool events, or thinking blocks
+- **WHEN** it wants incremental output
+- **THEN** it drives `app.Program` directly, because `app.Send` is single-shot with no streaming surface or incremental callback
+
+### Requirement: Reply text extraction
+
+The shared wire-format parser SHALL live at `internal/backend/chatevent.go` as the single seam for reply-text extraction:
+
+- `backend.ExtractChatText(raw)` SHALL handle the two shapes a chat event's `Message` can take — a plain JSON string (delta) or a `{ content: [{type, text}, ...] }` object (final). It is used by the TUI's chat view (`internal/tui/events.go`) and by `app/send.go`'s `replyCollector` so both paths agree on what the visible body is.
+- `backend.ExtractChatThinking(raw)` SHALL return the concatenated `type:"thinking"` blocks from a final event. Currently only the TUI consumes this; `Send` ignores thinking blocks because the contract for `--connection X --agent Y "msg"` is "the assistant's reply on stdout", not the deliberation that led to it.
+
+If a backend ever changes the wire shape, both consumers update together — the parser is the single seam.
+
+#### Scenario: Extract handles delta and final shapes
+- **WHEN** `backend.ExtractChatText(raw)` receives a plain JSON string (delta) or a `{ content: [{type, text}, ...] }` object (final)
+- **THEN** it returns the visible body for both shapes, so the TUI chat view and `send`'s `replyCollector` agree
+
+#### Scenario: Send ignores thinking blocks
+- **GIVEN** a final event containing `type:"thinking"` blocks
+- **WHEN** `Send` extracts the reply
+- **THEN** it ignores the thinking blocks, because the contract is the assistant's reply on stdout, not the deliberation
+- **AND** only the TUI consumes `backend.ExtractChatThinking(raw)`
+
+### Requirement: One-shot non-goals
+
+`Send` SHALL deliberately omit the following TUI-only behaviours:
+
+- **Slash-command parsing.** A message body of `/help` SHALL be sent verbatim to the agent; the TUI's command dispatcher is intentionally not on this path. Scripts that want a command's effect should call the corresponding RPC directly rather than typing it as chat input.
+- **Skill catalog injection.** The TUI sends `Skills` in `ChatSendParams` so the gateway can advertise local skills to the model; `Send` SHALL omit it. Skills are a TUI-discovery concept (slash-command activation, mid-message expansion); revisit if scripted workflows ever want `lucinate send … "/review the diff"` to expand the same way.
+- **Auth recovery modals.** The TUI routes `token-mismatch` / `401` into modal flows; `Send` SHALL let them bubble. Scripts that need to bootstrap auth should run `lucinate` once interactively and let the TUI's auth flow seed the secrets store.
+
+#### Scenario: Slash command sent verbatim
+- **WHEN** a message body of `/help` is sent through `Send`
+- **THEN** it is delivered verbatim to the agent, with no command dispatch
+
+#### Scenario: Skills omitted from ChatSendParams
+- **WHEN** `Send` builds `ChatSendParams`
+- **THEN** it omits `Skills`, unlike the TUI
+
+#### Scenario: Auth errors bubble instead of opening a modal
+- **WHEN** a `token-mismatch` or `401` auth error occurs during `Send`
+- **THEN** it bubbles up as a normal error rather than opening an auth-recovery modal

--- a/openspec/specs/openclaw-go-fork/spec.md
+++ b/openspec/specs/openclaw-go-fork/spec.md
@@ -1,0 +1,155 @@
+# openclaw-go Fork Specification
+
+## Purpose
+
+Lucinate's gateway client depends on **our fork** of `openclaw-go`
+([`outofcoffee/openclaw-go`](https://github.com/outofcoffee/openclaw-go)), not the
+upstream module directly. This is deliberate and expected to last: upstream
+(`a3tai/openclaw-go`) tracks the openclaw gateway via a release-sync process that lags
+the gateway itself by weeks, so fixes we need (e.g. gateway protocol v4 support) are not
+yet available upstream. The fork lets us ship without waiting on an upstream merge. This
+spec covers how the dependency is wired, the fork's patch-queue model, how it is bumped
+and re-synced, and the conditions under which the fork is retired.
+
+## Requirements
+
+### Requirement: Fork dependency and rationale
+
+The build SHALL consume our fork of `openclaw-go`
+([`outofcoffee/openclaw-go`](https://github.com/outofcoffee/openclaw-go)) as the gateway
+client dependency rather than the upstream module (`a3tai/openclaw-go`) directly. This
+divergence is deliberate and expected to persist: upstream tracks the openclaw gateway
+via a release-sync process that lags the gateway itself by weeks, so fixes we need (e.g.
+gateway protocol v4 support) are not yet available upstream. The fork exists so we can
+ship without waiting on an upstream merge.
+
+#### Scenario: Client depends on the fork, not upstream
+
+- **GIVEN** upstream `a3tai/openclaw-go` lags the gateway release by weeks and lacks fixes we need
+- **WHEN** the gateway client is built
+- **THEN** it consumes `outofcoffee/openclaw-go` (our fork)
+- **AND** does not depend on the upstream module directly
+
+### Requirement: go.mod require plus replace wiring
+
+`go.mod` SHALL keep the upstream module path `github.com/a3tai/openclaw-go` in `require`
+and redirect it to a **tag on our fork** with a `replace` directive:
+
+```
+require github.com/a3tai/openclaw-go v1.20260325.1-...   // upstream pseudo-version
+replace github.com/a3tai/openclaw-go => github.com/outofcoffee/openclaw-go v1.20260430.0-lucinate.2
+```
+
+The module path SHALL stay `github.com/a3tai/openclaw-go` (the fork does not rename its
+module), so upstream and fork stay drop-in compatible and the day upstream ships what we
+need we delete the `replace` line and bump the `require`.
+
+#### Scenario: Upstream path redirected to the fork tag
+
+- **GIVEN** `go.mod` requires `github.com/a3tai/openclaw-go` at an upstream pseudo-version
+- **WHEN** the module is resolved
+- **THEN** a `replace` directive redirects it to `github.com/outofcoffee/openclaw-go` at a fork tag such as `v1.20260430.0-lucinate.2`
+- **AND** the module path remains `github.com/a3tai/openclaw-go` because the fork does not rename its module, keeping upstream and fork drop-in compatible
+
+### Requirement: Pin a tag, never a branch or SHA
+
+The `replace` SHALL pin a **tag**, never a branch HEAD or a one-off feature SHA, so a
+build is always reproducible and dependency bumps are deliberate.
+
+#### Scenario: Reproducible pin
+
+- **WHEN** the fork dependency is pinned in `go.mod`
+- **THEN** it references a released tag
+- **AND** never a branch HEAD or a one-off feature SHA, so builds are reproducible and bumps are deliberate
+
+### Requirement: Fork patch-queue model
+
+The fork SHALL carry our not-yet-upstreamed patches as a queue on top of upstream, with
+**one feature per branch**, each cut from `upstream/main` and opened as its own upstream
+PR (so it *can* merge when upstream catches up). The current feature branches are:
+
+- `feat/protocol-v4-range` — advertise a v3–v4 protocol range.
+- `feat/bootstrap-token-connect` — setup-code bootstrap token + node→operator handoff.
+
+The **`lucinate` integration branch** SHALL equal `upstream/main` + every patch above,
+cherry-picked. This is the only thing lucinate depends on. It SHALL be tagged
+`v1.20260430.<base>-lucinate.<n>`, where the date is the upstream base and `<n>`
+increments per patch-set revision.
+
+#### Scenario: One feature per branch, each an upstream PR
+
+- **GIVEN** patches not yet accepted upstream
+- **WHEN** they are carried in the fork
+- **THEN** each is a single feature on its own branch cut from `upstream/main` (e.g. `feat/protocol-v4-range`, `feat/bootstrap-token-connect`) and opened as its own upstream PR so it can merge when upstream catches up
+
+#### Scenario: Integration branch is the only lucinate dependency
+
+- **GIVEN** the `lucinate` integration branch equals `upstream/main` plus every feature patch cherry-picked
+- **WHEN** lucinate pins the fork
+- **THEN** it depends only on that integration branch, tagged `v1.20260430.<base>-lucinate.<n>` where the date is the upstream base and `<n>` increments per patch-set revision
+
+### Requirement: Bumping and re-syncing when upstream moves
+
+When upstream cuts a new release-sync we want, or merges one of our patches, the fork
+SHALL be rebuilt on the new upstream base by resetting the integration branch to
+`upstream/main` and cherry-picking only the patches upstream has NOT merged yet, then
+cutting the next tag. In the fork repository:
+
+```sh
+cd ~/projects/openclaw-go
+git fetch upstream --tags
+
+# rebuild the integration branch on the new upstream base
+git checkout lucinate
+git reset --hard upstream/main
+# cherry-pick only the patches upstream has NOT merged yet
+git cherry-pick <feat/bootstrap-token-connect HEAD> <feat/protocol-v4-range HEAD>
+go test ./... -race
+
+# cut the next tag (new upstream date and/or next patch-set number)
+git tag -a v<NEW>-lucinate.<n+1> -m "..."
+git push --force-with-lease origin lucinate
+git push origin v<NEW>-lucinate.<n+1>
+```
+
+Then in lucinate, the `replace` SHALL be repointed at the new tag and the module
+re-tidied and rebuilt:
+
+```sh
+go mod edit -replace github.com/a3tai/openclaw-go=github.com/outofcoffee/openclaw-go@v<NEW>-lucinate.<n+1>
+go mod tidy && go build ./... && go test ./...
+```
+
+If a patch has landed upstream, it SHALL be dropped from the cherry-pick list (and its
+PR closed); the rest of the queue carries forward unchanged.
+
+#### Scenario: Rebuild the integration branch on a new upstream base
+
+- **GIVEN** upstream cuts a new release-sync we want, or merges one of our patches
+- **WHEN** the fork is re-synced
+- **THEN** the `lucinate` branch is reset hard to `upstream/main`, only the still-unmerged patches are cherry-picked, `go test ./... -race` is run, and the next tag `v<NEW>-lucinate.<n+1>` is cut and pushed with `--force-with-lease`
+
+#### Scenario: Repoint lucinate at the new fork tag
+
+- **GIVEN** a new fork tag `v<NEW>-lucinate.<n+1>` has been pushed
+- **WHEN** lucinate is updated
+- **THEN** `go mod edit -replace` repoints the `replace` at the new tag, followed by `go mod tidy && go build ./... && go test ./...`
+
+#### Scenario: A patch has landed upstream
+
+- **GIVEN** one of our patches has been merged upstream
+- **WHEN** the fork is re-synced
+- **THEN** that patch is dropped from the cherry-pick list and its PR closed
+- **AND** the rest of the queue carries forward unchanged
+
+### Requirement: Retire the fork on upstream parity
+
+When upstream `openclaw-go` ships gateway protocol v4 and the setup-code bootstrap
+support, the fork SHALL be retired: remove the `replace`, bump the `require` to that
+release, delete the merged fork branches, and delete this document.
+
+#### Scenario: Upstream reaches parity
+
+- **GIVEN** upstream `openclaw-go` ships gateway protocol v4 and the setup-code bootstrap support
+- **WHEN** the fork is retired
+- **THEN** the `replace` is removed, the `require` is bumped to that upstream release, the merged fork branches are deleted, and this document is deleted

--- a/openspec/specs/routines/spec.md
+++ b/openspec/specs/routines/spec.md
@@ -1,0 +1,601 @@
+# Routines Specification
+
+## Purpose
+
+Routines are ordered prompt sequences stored on disk and replayed against the active session via `/routine <name>`. Each step is a complete user message; the controller dispatches them one at a time, optionally auto-advancing after each assistant reply. Routines are a chat-only concept — there is no gateway counterpart, and every backend works with them. The user-facing surface is `/routine <name>` (activate) and `/routines` (manage). This spec covers the STEPS.md file format, disk storage, the routine controller lifecycle, the auto-advance hook, stale-event filtering, assistant directives, logging, the manager view, slash-command gating, notifications, the status row, and key bindings.
+
+## Requirements
+
+### Requirement: STEPS.md file format
+
+Each routine SHALL be stored as a single `STEPS.md` file in plain markdown. Optional YAML frontmatter delimited by `---` lines carries routine metadata; the body is split into steps on lines containing exactly `---`. The recognised frontmatter fields are `name` (informational), `mode` (`auto` | `manual`; default `manual`), and `log` (absolute or relative-to-cwd path; omit to disable logging). A representative file:
+
+```markdown
+---
+name: demo
+mode: auto              # auto | manual; default = manual
+log: ./demo.log         # absolute or relative-to-cwd; omit to disable logging
+---
+
+generate two integers between 1 and 10
+
+---
+
+if the sum is greater than 10 say /routine:stop, otherwise /routine:continue
+
+---
+
+say "the sum is less than or equal to 10"
+```
+
+The parser (`internal/routines/parse.go`) SHALL apply these rules:
+
+- If the first non-blank line is `---`, consume YAML frontmatter until the next `---` line. Anything else is treated as body with no frontmatter.
+- The body is split on lines whose `strings.TrimRight(line, " \t\r")` equals `---`.
+- Each chunk is `strings.TrimSpace`'d. Empty chunks are dropped, so consecutive `---` lines collapse harmlessly.
+- The on-disk directory name is the routine's identity (`Routine.Name`); `frontmatter.name` is informational.
+
+`Format(r Routine)` is the round-trip: frontmatter is emitted only when at least one field is non-empty, and steps are joined with `\n---\n\n`. `TestFormatRoundTrip` pins the parse→format→parse invariant.
+
+#### Scenario: File with frontmatter and multiple steps parses to steps
+
+- **GIVEN** a `STEPS.md` whose first non-blank line is `---`
+- **WHEN** the parser reads it
+- **THEN** it consumes YAML frontmatter until the next `---`, then splits the remaining body into steps on lines equal to `---` after trailing whitespace is trimmed
+- **AND** trims each chunk and drops empty chunks so consecutive `---` lines collapse harmlessly
+
+#### Scenario: File with no frontmatter
+
+- **GIVEN** a `STEPS.md` whose first non-blank line is not `---`
+- **WHEN** the parser reads it
+- **THEN** the whole content is treated as body with no frontmatter
+
+#### Scenario: Default mode
+
+- **GIVEN** a routine whose frontmatter omits `mode`
+- **WHEN** it is parsed
+- **THEN** the mode defaults to `manual`
+
+#### Scenario: Round-trip is stable
+
+- **WHEN** a routine is formatted with `Format(r Routine)` and re-parsed
+- **THEN** the parse→format→parse invariant holds (pinned by `TestFormatRoundTrip`)
+- **AND** frontmatter is emitted only when at least one field is non-empty and steps are joined with `\n---\n\n`
+
+### Requirement: Disk layout and storage operations
+
+Routines SHALL be stored on disk under the data directory resolved through `config.DataDir()`, one directory per routine named by the routine's identity, each containing a single `STEPS.md`:
+
+```
+~/.lucinate/routines/
+  <name>/
+    STEPS.md
+```
+
+`internal/routines/store.go` SHALL expose these operations:
+
+| Function | Behaviour |
+|---|---|
+| `Dir()` | `<data-dir>/routines` (not auto-created) |
+| `List()` | Scan + parse every subdirectory; entries that fail to parse are silently skipped so one bad file doesn't sink the listing |
+| `Load(name)` | Returns `Routine{}` + `ErrNotFound` if the directory is missing |
+| `Save(r)` | `MkdirAll(0o700)` + atomic `WriteFile`/`Rename` of `STEPS.md` |
+| `Delete(name)` | `os.RemoveAll(<dir>/<name>)` |
+
+#### Scenario: Listing tolerates a bad file
+
+- **WHEN** `List()` scans the routines directory and one subdirectory fails to parse
+- **THEN** that entry is silently skipped and the remaining routines are still listed
+
+#### Scenario: Load of a missing routine
+
+- **GIVEN** no directory exists for the requested name
+- **WHEN** `Load(name)` is called
+- **THEN** it returns `Routine{}` and `ErrNotFound`
+
+#### Scenario: Save writes atomically
+
+- **WHEN** `Save(r)` is called
+- **THEN** it creates the directory with `MkdirAll(0o700)` and writes `STEPS.md` atomically via `WriteFile`/`Rename`
+
+### Requirement: Name validation predicates
+
+Two name predicates SHALL live in `internal/routines/`:
+
+- `validName` (path safety) rejects empty, `.`, `..`, leading-dot, and any name containing `/`, `\`, or NUL. `Load` and `Delete` use this predicate so existing on-disk directories — including any non-kebab names left over from earlier versions — keep working.
+- `IsValidKebab` (form rule) tightens to lowercase ASCII letters, digits, and hyphens; no leading or trailing hyphen, no consecutive hyphens. `Save` enforces it, so any new save or rename lands on disk with a typeable, lowercase identifier. The companion `ToKebab(s string) string` produces a best-effort kebab version of arbitrary input — used by the form's submit error to suggest a fix when the user typed `My Routine!` or similar.
+
+#### Scenario: Path-unsafe names rejected on load and delete
+
+- **GIVEN** a name that is empty, `.`, `..`, leading-dot, or contains `/`, `\`, or NUL
+- **WHEN** `Load` or `Delete` is called with it
+- **THEN** `validName` rejects it
+
+#### Scenario: Save enforces kebab identifiers
+
+- **WHEN** `Save` is called
+- **THEN** `IsValidKebab` requires lowercase ASCII letters, digits, and hyphens with no leading or trailing hyphen and no consecutive hyphens
+- **AND** existing non-kebab on-disk directories still load and delete because those paths use `validName`, not `IsValidKebab`
+
+#### Scenario: Kebab suggestion for invalid form input
+
+- **GIVEN** the user typed a name such as `My Routine!`
+- **WHEN** the form submit error is raised
+- **THEN** `ToKebab` produces a best-effort kebab suggestion to fix it
+
+### Requirement: Routine controller state and lifecycle
+
+The active routine SHALL live on `chatModel.activeRoutine` (`internal/tui/routines_chat.go`), holding the routine, its mode, the count of dispatched steps, the paused flag, and an optional logger:
+
+```go
+type activeRoutine struct {
+    routine routines.Routine
+    mode    routines.Mode
+    sent    int                 // count of steps already dispatched
+    paused  bool
+    logger  *routines.Logger    // nil if no `log:` configured
+}
+```
+
+The lifecycle entry points on `*chatModel` SHALL be:
+
+| Method | Purpose |
+|---|---|
+| `startRoutine(name)` | Load + parse from disk, open the log if configured, append the "Routine started" notification, return the `tea.Cmd` for step 0's send |
+| `sendNextRoutineStep()` | Read `Steps[ar.sent]`, increment `ar.sent`, append the user message + assistant placeholder to `m.messages`, set `m.sending=true`, log the user line, return `sendMessage(...)` |
+| `maybeAdvanceRoutine()` | Called from the chat `final` event handler. Completion fires first: when the answered step was the last, calls `endRoutine("completed")` regardless of mode and returns nil so the user always gets the same notification + cleared `activeRoutine`. Otherwise returns `sendNextRoutineStep` only when mode is auto and not paused; in manual or paused mid-routine it returns nil and the user drives the next step. |
+| `applyDirectives(reply)` | Scans the assistant reply for `/routine:` directives and applies them in order |
+| `endRoutine(reason)` | Closes the logger, clears `activeRoutine`, posts a "Routine X <reason>" notification |
+| `cycleRoutineMode()` | Bound to `Shift+Tab` (mirrors Claude Code's mode-cycle gesture) — flips between auto and manual; entering auto unsets `paused`. Yields to slash-menu cycling when the completion menu is active. |
+
+Step indexing SHALL be strictly monotonic: only `sendNextRoutineStep` increments `ar.sent`, and it does so once per call. Auto-advance SHALL be gated solely on `ar.sent < len(Steps)` and the directive/pause flags — there is no path that decrements or skips.
+
+#### Scenario: Starting a routine dispatches step 0
+
+- **WHEN** `startRoutine(name)` runs
+- **THEN** it loads and parses the routine from disk, opens the log if configured, appends the "Routine started" notification, and returns the `tea.Cmd` for step 0's send
+
+#### Scenario: Manual routine completes on its final reply
+
+- **GIVEN** a routine in manual mode whose last step has just been answered
+- **WHEN** `maybeAdvanceRoutine()` runs from the `final` handler
+- **THEN** completion fires first: `endRoutine("completed")` is called regardless of mode, the notification is posted, `activeRoutine` is cleared, and it returns nil
+
+#### Scenario: Auto routine advances mid-routine
+
+- **GIVEN** a routine in auto mode, not paused, with steps remaining
+- **WHEN** `maybeAdvanceRoutine()` runs
+- **THEN** it returns `sendNextRoutineStep` to dispatch the next step
+
+#### Scenario: Manual or paused routine stays quiet between steps
+
+- **GIVEN** a routine in manual mode, or auto with `paused` set, with steps remaining
+- **WHEN** `maybeAdvanceRoutine()` runs mid-routine
+- **THEN** it returns nil and the user drives the next step
+
+#### Scenario: Step index only ever advances
+
+- **WHEN** any step is dispatched
+- **THEN** only `sendNextRoutineStep` increments `ar.sent`, once per call, with no path that decrements or skips
+
+### Requirement: Auto-advance hook ordering in the final event
+
+Auto-advance SHALL live in the `final` case of `handleEvent` (`internal/tui/events.go`) and SHALL run in this order:
+
+1. Mark the streaming assistant message as finalised (existing behaviour).
+2. Capture the merge boundary via `bumpGen()` — the just-finalised turn is now on the history-side of any refresh issued from here on; subsequent appends get the new gen and survive the merge.
+3. If `m.activeRoutine != nil`: log the assistant content (when a logger is configured) and call `applyDirectives` so a `/routine:stop` or `/routine:pause` is honoured before any auto-advance fires.
+4. Always queue `refreshHistoryAt(boundary)` and `loadStats()`. The merge in the `historyRefreshMsg` handler is non-destructive — the live tail of the next routine step (placeholder, system rows) survives because those rows carry a higher gen than the boundary.
+5. Drain `m.pendingMessages` via `drainQueueSkipRefresh` — user-typed queue jumps ahead of the routine. The `SkipRefresh` variant is used because we already queued the resync above; `drainQueue`'s built-in empty-queue refresh would otherwise duplicate it.
+6. If the queue was empty and `m.sending` is now false, call `maybeAdvanceRoutine()`. If it returns a cmd, append it to the batch (sending the next step).
+
+The unconditional refresh SHALL be the heart of the resync architecture. Pre-Layer-3, the refresh was deferred to "queue empty AND no routine to advance", which meant a 10-step auto-mode routine accumulated drift across all 10 steps before the first server-canonical reconciliation; with drift large enough, stale-event filtering became the only line of defence against spurious step submission. Now every `final` reconciles, every step.
+
+The `error` and `aborted` cases SHALL also `bumpGen()` so the boundary stays monotonic, and SHALL set `paused = true` instead of advancing — so a transient gateway error doesn't loop the next step. The user MAY press Enter (empty input) to retry the next step or Esc to end the routine. These cases do not currently issue their own refresh; the next successful turn's refresh covers the canonical reconciliation.
+
+#### Scenario: Directives are honoured before auto-advance
+
+- **GIVEN** `m.activeRoutine != nil` and the assistant reply contains `/routine:stop` or `/routine:pause`
+- **WHEN** the `final` case runs
+- **THEN** the assistant content is logged (when a logger is configured) and `applyDirectives` is applied before any auto-advance fires
+
+#### Scenario: Every final reconciles with the server
+
+- **WHEN** any successful `final` is handled during a routine
+- **THEN** `refreshHistoryAt(boundary)` and `loadStats()` are queued unconditionally, and the merge preserves the live tail because those rows carry a higher gen than the boundary
+
+#### Scenario: Queued user messages jump ahead of the routine
+
+- **GIVEN** pending user-typed messages when a `final` arrives
+- **WHEN** the queue is drained via `drainQueueSkipRefresh`
+- **THEN** the queued messages are sent before any routine auto-advance, and the built-in empty-queue refresh is skipped because the resync was already queued
+
+#### Scenario: Transient error pauses rather than advancing
+
+- **GIVEN** an `error` or `aborted` event during a routine
+- **WHEN** it is handled
+- **THEN** `bumpGen()` keeps the boundary monotonic, `paused` is set to true, and the next step is not looped
+- **AND** the user can press Enter to retry the next step or Esc to end the routine
+
+### Requirement: Stale-event filtering by finalised run
+
+The OpenClaw gateway has been observed emitting a duplicate `delta` event with the full content right after the matching `final`, on the same `runID`. Without filtering, that delta lands on the next routine step's freshly-appended placeholder, flipping `awaitingDelta` and letting a subsequent empty-content `final` falsely finalise an empty turn — which spuriously auto-advances the routine.
+
+The system SHALL keep `chatModel.finalisedRuns`, a bounded LRU set (cap `finalisedRunsCap = 32`) of run IDs already finalised. The top of the chat-event branch in `handleEvent` SHALL drop any event whose `RunID` is a member:
+
+```go
+if m.finalisedRuns.contains(chatEv.RunID) {
+    slog.Debug("stale event ignored for finalised run", "run_id", chatEv.RunID)
+    return nil
+}
+```
+
+The set SHALL be added to inside the `final`, `error`, and `aborted` paths, but only when the corresponding state mutation actually happened (gated on the same `finalised` flag). FIFO eviction SHALL keep a long-lived chat from growing the filter unboundedly.
+
+The set's depth matters: a single-deep filter is enough for the immediate duplicate-after-final case, but back-to-back routine steps open a wider window. A stale event for run N-2 can arrive while run N is streaming; with only the most-recent run remembered, that earlier id slips past and corrupts the live placeholder. `TestHandleEvent_StaleDeltaAfterFinalIgnored` pins the duplicate case; `TestHandleEvent_StaleDeltaFromOlderRunIgnored` pins the back-to-back race; `TestFinalisedRunSet_EvictsOldestPastCap` pins the FIFO bound.
+
+#### Scenario: Duplicate delta after final is dropped
+
+- **GIVEN** a `delta` event arrives on a `runID` already in `finalisedRuns`
+- **WHEN** the chat-event branch of `handleEvent` runs
+- **THEN** the event is dropped (a debug line is logged) so it cannot flip `awaitingDelta` on the next step's placeholder
+
+#### Scenario: Stale event from an older run is dropped
+
+- **GIVEN** a stale event for run N-2 arrives while run N is streaming
+- **WHEN** the filter checks it against `finalisedRuns` (cap 32)
+- **THEN** the older run id is still remembered and the event is dropped, not left to corrupt the live placeholder
+
+#### Scenario: Filter is bounded
+
+- **WHEN** more than `finalisedRunsCap = 32` runs have been finalised
+- **THEN** FIFO eviction drops the oldest ids so the set never grows unboundedly
+
+### Requirement: Assistant directives
+
+The assistant SHALL be able to steer the routine by emitting one of these directives on its own line (leading whitespace allowed):
+
+| Directive | Effect |
+|---|---|
+| `/routine:stop` | End the active routine immediately |
+| `/routine:pause` | Pause without ending — Enter sends the next step, Esc ends |
+| `/routine:continue` | Explicit no-op; also unsets `paused` so it can resume an auto-mode routine |
+| `/routine:mode auto` | Switch to auto mode; unsets `paused` |
+| `/routine:mode manual` | Switch to manual mode |
+
+Matching (`internal/routines/directives.go`) SHALL use the anchored, per-line pattern:
+
+```go
+^\s*/routine:(stop|pause|continue|mode\s+(auto|manual))\s*$
+```
+
+Because it is anchored with `^...$` and applied per line, inline mentions (`as in /routine:stop`, backtick-wrapped tokens) SHALL deliberately not match. Directives SHALL be kept verbatim in the rendered transcript — `applyDirectives` does not rewrite the assistant message. User-typed `/routine:*` lines in the chat input SHALL NOT be parsed; only assistant replies are scanned.
+
+#### Scenario: Own-line directive is applied
+
+- **GIVEN** an assistant reply with `/routine:stop` on its own line (leading whitespace allowed)
+- **WHEN** `applyDirectives` scans it
+- **THEN** the directive matches the anchored per-line pattern and the routine ends immediately
+
+#### Scenario: Inline mention does not match
+
+- **GIVEN** an assistant reply mentioning `/routine:stop` inline or inside backticks
+- **WHEN** `applyDirectives` scans it
+- **THEN** it deliberately does not match, and the directive text stays verbatim in the transcript
+
+#### Scenario: User-typed directives are ignored
+
+- **GIVEN** a user types a `/routine:*` line in the chat input
+- **WHEN** the input is processed
+- **THEN** it is not parsed as a directive; only assistant replies are scanned
+
+#### Scenario: Continue unsets paused
+
+- **GIVEN** a paused auto-mode routine
+- **WHEN** the assistant emits `/routine:continue`
+- **THEN** it acts as a no-op that also unsets `paused`, allowing the routine to resume
+
+### Requirement: Routine logging
+
+When the frontmatter sets `log: <path>`, `routines.Logger` SHALL open the file (`O_APPEND | O_CREATE | O_WRONLY`, mode `0o600`) at routine start and close it on `endRoutine`. Relative paths SHALL resolve against the lucinate working directory at start time, captured via `os.Getwd()`. The log format SHALL be:
+
+```
+--- routine: demo started 2026-05-09T22:30:00Z ---
+[2026-05-09T22:30:00Z] user: <step 1 text>
+[2026-05-09T22:30:05Z] assistant: <reply line 1>
+<reply line 2 — no per-line prefix>
+```
+
+Only the first line of a multi-line message SHALL get the `[ts] role:` prefix; subsequent lines are written verbatim so log diffs read like the chat. The logger SHALL be best-effort — write errors are silently swallowed so a logging hiccup never breaks the running routine. `Open` SHALL return `nil, nil` for an empty path so callers can invoke it unconditionally.
+
+#### Scenario: Log opened at start and closed at end
+
+- **GIVEN** frontmatter with `log: ./demo.log`
+- **WHEN** the routine starts and later ends
+- **THEN** the file is opened at start with `O_APPEND | O_CREATE | O_WRONLY` mode `0o600`, a run header is written, and the file is closed on `endRoutine`
+- **AND** a relative path resolves against the working directory captured via `os.Getwd()` at start time
+
+#### Scenario: Only the first line of a message is prefixed
+
+- **WHEN** a multi-line user or assistant message is logged
+- **THEN** only the first line gets the `[ts] role:` prefix and subsequent lines are written verbatim
+
+#### Scenario: Logging never breaks the routine
+
+- **WHEN** a log write fails
+- **THEN** the error is silently swallowed and the routine continues
+
+#### Scenario: Empty log path is a no-op
+
+- **GIVEN** no `log:` path is configured
+- **WHEN** `Open` is called
+- **THEN** it returns `nil, nil` so callers can invoke it unconditionally
+
+### Requirement: Manager view substates
+
+`/routines` SHALL open `routinesModel` (`internal/tui/routines.go`), modelled on the cron browser, with four substates:
+
+| Substate | Purpose |
+|---|---|
+| `routinesSubList` | List of routines (name + step count + mode chips) |
+| `routinesSubDetail` | Read-only view of a single routine — frontmatter, file path, every step rendered in order |
+| `routinesSubForm` | Create / edit / duplicate form |
+| `routinesSubConfirmDelete` | y/n prompt before `routines.Delete` fires |
+
+Key bindings SHALL follow the project-wide conventions (captured in project config). The list view SHALL expose `n` (new) and `d` (duplicate, gated on a non-empty list); the detail view SHALL expose `e` (edit) and `x` (delete) — `x` rather than `d` so duplicate and delete stay distinct in the user's vocabulary, matching the cron browser.
+
+#### Scenario: Manager opens on the list
+
+- **WHEN** the user runs `/routines`
+- **THEN** `routinesModel` opens on `routinesSubList` showing each routine's name, step count, and mode chips
+
+#### Scenario: List and detail key bindings distinguish duplicate from delete
+
+- **GIVEN** the manager view
+- **WHEN** the user is on the list with a non-empty list
+- **THEN** `n` creates a new routine and `d` duplicates the highlighted one
+- **AND** on the detail view `e` edits and `x` (not `d`) deletes, keeping duplicate and delete distinct
+
+### Requirement: Form editing and step manipulation
+
+The form SHALL have three textinputs (name, mode, log) plus a slice of `textarea.Model` for the steps — one per step. The focus index SHALL be a single int: `0..2` are the header fields, `3+i` is step `i`. Key bindings inside the form SHALL be:
+
+| Key | Action |
+|---|---|
+| Tab / Shift+Tab | Cycle focus |
+| Ctrl+S (or Alt+S) | Save — Ctrl+S is the surfaced binding; Alt+S is kept as a fallback for terminals that intercept Ctrl+S as XOFF |
+| Alt+Up | Insert blank step above the focused step |
+| Alt+Down | Insert blank step below the focused step |
+| Alt+Delete (or Alt+Backspace) | Remove the focused step (y/n confirm) |
+| Esc | Cancel without saving |
+| Alt+Enter | Newline within a step textarea |
+
+`insertStep(idx, value)` SHALL use an overlap-safe `copy` (`memmove`) so shift-right insertion never duplicates content. `deleteStep(idx)` SHALL re-insert a blank textarea when the slice would otherwise empty out, so the form always has at least one step to type into.
+
+#### Scenario: Save has a fallback binding
+
+- **WHEN** the user saves the form
+- **THEN** Ctrl+S saves, and Alt+S is accepted as a fallback for terminals that intercept Ctrl+S as XOFF
+
+#### Scenario: Insert and delete steps
+
+- **WHEN** the user presses Alt+Up or Alt+Down on a focused step
+- **THEN** a blank step is inserted above or below it via `insertStep`, using an overlap-safe copy so no content is duplicated
+
+#### Scenario: Form always keeps at least one step
+
+- **WHEN** the user removes the only remaining step (after y/n confirm)
+- **THEN** `deleteStep` re-inserts a blank textarea so the form always has at least one step to type into
+
+### Requirement: Duplicate routine flow
+
+Pressing `d` on the list view SHALL open the form pre-populated from the highlighted routine, in create mode — `editingID` stays empty so submission goes through the plain `routines.Save` path with no rename, no overwrite, no delete-of-original. The cloned name SHALL be built by `duplicateRoutineName(name, existing)`:
+
+- `"" → ""` (passes through so the form-level "name is required" check fires).
+- Otherwise: `"Copy of " + name`, walking `(2)`, `(3)`, … to find the first slot that doesn't collide with an existing routine. Routines are name-keyed (the directory under `~/.lucinate/routines/<name>/` is the identity), so collision avoidance is required — unlike cron jobs which have a separate ID.
+
+`Frontmatter.Name` SHALL be set to the duplicated name so the `STEPS.md` metadata stays in sync with the directory identity. `Frontmatter.Log` SHALL be copied verbatim — if it's a relative path the user can change it in the form before saving so the duplicate doesn't share the original's log file.
+
+#### Scenario: Duplicate opens in create mode
+
+- **GIVEN** a highlighted routine on the list view
+- **WHEN** the user presses `d`
+- **THEN** the form opens pre-populated in create mode with `editingID` empty, so submission uses plain `routines.Save` with no rename, overwrite, or delete-of-original
+
+#### Scenario: Clone name avoids collisions
+
+- **GIVEN** an existing routine named `demo`
+- **WHEN** `duplicateRoutineName` builds the clone name
+- **THEN** it yields `Copy of demo`, walking `(2)`, `(3)`, … to find the first non-colliding slot, because routines are name-keyed by directory
+
+#### Scenario: Frontmatter stays in sync
+
+- **WHEN** a routine is duplicated
+- **THEN** `Frontmatter.Name` is set to the duplicated name and `Frontmatter.Log` is copied verbatim so the user can edit a relative log path before saving to avoid sharing the original's log file
+
+### Requirement: Form scrolling and step sizing
+
+The form's middle section (header inputs + step textareas) SHALL render inside a scrollable `viewport.Model`; the title and the footer (error line + help line) SHALL stay pinned. `viewForm` SHALL record the line index where each focusable field starts as it builds the body content (`fieldLineStarts`), and `ensureFocusVisible` SHALL adjust the viewport's `YOffset` so the focused field is fully on-screen — scrolling down when the user tabs past the bottom of the visible window, scrolling up when they shift-tab back. Without this, a routine with many steps used to push the help line off the terminal entirely.
+
+Step textareas SHALL be sized at a fixed 4 lines each rather than auto-fitting the available height: the previous "divide remaining space across all steps" heuristic squeezed every textarea down to a 1-line stub once step count grew, and the user couldn't see the content of any step. The viewport handles overflow now, so a fixed per-step size is friendlier to type into.
+
+#### Scenario: Focused field stays visible while scrolling
+
+- **GIVEN** a routine with many steps in the form
+- **WHEN** the user tabs past the bottom or shift-tabs back above the visible window
+- **THEN** `ensureFocusVisible` adjusts the viewport's `YOffset` so the focused field is fully on-screen while the title and footer stay pinned
+
+#### Scenario: Fixed step height
+
+- **WHEN** the form renders step textareas
+- **THEN** each is a fixed 4 lines with viewport overflow, rather than divided down to 1-line stubs as step count grows
+
+### Requirement: Form submission and change notification
+
+Submission SHALL iterate `form.steps` in order, dropping blank ones, and go through `routines.Save`. Editing with a renamed `name` SHALL write the new directory and `Delete` the old one. After save (or delete), the model SHALL emit `routinesChangedMsg` so the chat view refreshes its `m.routineNames` cache for `/routine <TAB>` completion.
+
+#### Scenario: Blank steps dropped on save
+
+- **WHEN** the form is submitted
+- **THEN** it iterates `form.steps` in order, drops blank steps, and saves through `routines.Save`
+
+#### Scenario: Rename writes new and deletes old
+
+- **GIVEN** an edit that changes the `name`
+- **WHEN** it is saved
+- **THEN** the new directory is written and the old one is deleted
+
+#### Scenario: Completion cache refreshes after CRUD
+
+- **WHEN** a save or delete completes
+- **THEN** the model emits `routinesChangedMsg` and the chat view refreshes its `m.routineNames` cache for `/routine <TAB>` completion
+
+### Requirement: Slash commands and navigation gating
+
+The system SHALL register two entries in `slashCommands`:
+
+| Command | Behaviour |
+|---|---|
+| `/routine <name>` | Activate the named routine. Bare `/routine` is an error pointing at `/routines`. Tab completion uses `m.routineNames` populated by `loadRoutineNames()` at chat init and after any manager-view CRUD. |
+| `/routines` | Open the manager via `showRoutinesMsg{}` |
+
+Only one routine SHALL run at a time per session. Both commands SHALL route through `gateNavigation()` (`routines_chat.go`) when a routine is already active, showing:
+
+```
+Routine "demo" is active. Starting routine "other" will cancel it. Continue? (y/n)
+```
+
+The same gate SHALL cover the navigations that strand or replace the chat model — `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections` — for the same reason: the active routine controller can't survive a chat-view reset, and silently dropping it would leak the open log file. On `y`, the gate SHALL cancel any in-flight turn (`cancelTurn`) and end the routine (`endRoutine`) before dispatching the navigation. On `n` or Esc the prompt SHALL clear and the routine SHALL continue. `startRoutine` itself still has a defensive `if m.activeRoutine != nil` guard, but in normal flow the gate runs first.
+
+#### Scenario: Bare /routine is an error
+
+- **WHEN** the user submits `/routine` with no name
+- **THEN** it is an error pointing at `/routines`
+
+#### Scenario: Starting a second routine prompts to cancel the first
+
+- **GIVEN** routine `demo` is active
+- **WHEN** the user runs `/routine other` (or a stranding navigation such as `/agents`, `/agent <name>`, `/sessions`, `/crons`, `/crons all`, `/connections`)
+- **THEN** `gateNavigation()` shows the "Continue? (y/n)" prompt
+- **AND** on `y` it cancels the in-flight turn via `cancelTurn` and ends the routine via `endRoutine` before dispatching the navigation
+- **AND** on `n` or Esc the prompt clears and the routine continues
+
+#### Scenario: Tab completion of routine names
+
+- **WHEN** the user types `/routine ` and presses Tab
+- **THEN** completion draws from `m.routineNames`, populated by `loadRoutineNames()` at chat init and after any manager-view CRUD
+
+### Requirement: Routine notifications
+
+Routine state changes (started, paused, ended) and routine errors SHALL be surfaced as ephemeral notifications, not chat rows (see the `chat-ux` spec, Notifications). They SHALL live outside `m.messages` so a `historyRefreshMsg` doesn't wipe them, and SHALL clear when the user submits any non-empty input. The routine controller SHALL call `m.notify` / `m.notifyError` directly; the legacy `appendSystemError` helper still exists but routes to `notifyError` under the hood for older callers.
+
+#### Scenario: Notifications survive a history refresh
+
+- **GIVEN** a routine notification is showing
+- **WHEN** a `historyRefreshMsg` is handled
+- **THEN** the notification survives because it lives outside `m.messages`
+
+#### Scenario: Notification clears on next input
+
+- **GIVEN** a routine notification is showing
+- **WHEN** the user submits any non-empty input
+- **THEN** the notification clears
+
+### Requirement: Routine status row
+
+When `m.activeRoutine != nil`, the chat View SHALL render a single styled row immediately above the input box. While auto-advancing or mid-turn the trailing segment SHALL be a passive preview:
+
+```
+routine: demo — AUTO — sent: 5/10 — next: <preview>
+```
+
+When the routine is awaiting user input — manual mode, or auto with `paused` set, with no turn in flight and steps remaining — the trailing segment SHALL switch to a call-to-action so the user sees both what the next message is and that the routine is parked on them:
+
+```
+routine: demo — MANUAL — sent: 5/10 — ▶ Press Enter to send: <preview>
+```
+
+`AUTO`/`MANUAL` SHALL reflect the mode; `(paused)` SHALL be appended when `paused` is set. The row SHALL be coloured by mode — amber (`execClr`) for auto, cyan (`userClr`) for manual — so the driver is legible at a glance without the row competing with the purple chat header. The renderer is `routineStatusLine` + `routineStatusStyle` in `routines_chat.go`; the preview length is computed from `m.width` so it grows with the terminal (floor 20 chars, fallback 40 when width is not yet known). `applyLayout()` (`completion.go`) SHALL subtract one row from the viewport height when a routine is active so the status row doesn't push the input off-screen.
+
+#### Scenario: Preview while advancing
+
+- **GIVEN** an active routine that is auto-advancing or mid-turn
+- **WHEN** the chat View renders
+- **THEN** the status row shows `routine: <name> — AUTO — sent: N/M — next: <preview>` above the input box
+
+#### Scenario: Call-to-action when parked on the user
+
+- **GIVEN** an active routine awaiting user input (manual, or auto with `paused`, no turn in flight, steps remaining)
+- **WHEN** the chat View renders
+- **THEN** the trailing segment reads `▶ Press Enter to send: <preview>`
+- **AND** `(paused)` is appended when `paused` is set
+
+#### Scenario: Row is coloured by mode and preserves input space
+
+- **WHEN** the status row renders
+- **THEN** it is amber (`execClr`) for auto and cyan (`userClr`) for manual, and `applyLayout()` subtracts one viewport row so the status row doesn't push the input off-screen
+
+### Requirement: Routine key bindings
+
+The chat view SHALL bind these keys while relevant to routines:
+
+| Key | Behaviour |
+|---|---|
+| Shift+Tab | Cycle mode (auto ↔ manual). No-op when no routine is active. Mirrors Claude Code's mode-cycle gesture. Yields to slash-menu cycling when the completion menu is active. |
+| Esc | When a routine is active: end the routine and (if streaming) cancel the in-flight turn. Otherwise behaves as before (`/cancel`-equivalent or transcript back). |
+| Enter (empty input) | When a routine is active and idle (manual or paused): send the next step. Otherwise no-op. |
+
+#### Scenario: Shift+Tab cycles mode
+
+- **GIVEN** a routine is active and the completion menu is not showing
+- **WHEN** the user presses Shift+Tab
+- **THEN** the mode cycles auto ↔ manual; with no routine active it is a no-op, and it yields to slash-menu cycling when the completion menu is active
+
+#### Scenario: Esc ends an active routine
+
+- **GIVEN** a routine is active
+- **WHEN** the user presses Esc
+- **THEN** the routine ends and, if streaming, the in-flight turn is cancelled; with no routine active Esc behaves as before
+
+#### Scenario: Enter sends the next step when idle
+
+- **GIVEN** a routine is active and idle (manual or paused)
+- **WHEN** the user presses Enter on an empty input
+- **THEN** the next step is sent; otherwise it is a no-op
+
+### Requirement: Verification coverage
+
+The routines feature SHALL be pinned by unit tests and a manual smoke procedure. The unit tests SHALL include:
+
+- `internal/routines/parse_test.go` — frontmatter parsing, default mode, blank-line preservation, format round-trip.
+- `internal/routines/directives_test.go` — own-line matching, inline-mention rejection, all five directive kinds.
+- `internal/routines/store_test.go` — disk round-trip, invalid-name rejection.
+- `internal/routines/log_test.go` — header + per-message timestamp shape, multi-line bodies, append across reopens, nil-receiver safety.
+- `internal/tui/events_test.go::TestHandleEvent_StaleDeltaAfterFinalIgnored` / `TestHandleEvent_StaleDeltaFromOlderRunIgnored` / `TestFinalisedRunSet_*` — pin the bounded stale-run filter.
+- `internal/tui/events_test.go::TestHandleEvent_FinalRefreshesEvenWithQueuedMessages` / `TestHandleEvent_FinalRefreshesDuringRoutineAutoAdvance` — pin that the resync fires on every successful `final`, not just at queue/routine end.
+- `internal/tui/events_test.go::TestHandleEvent_FinalBumpsGen` / `TestHandleEvent_FinalEmptyAckDoesNotBumpGen` — pin the gen-bump semantics that anchor the merge boundary.
+- `internal/tui/events_test.go::TestMergeHistoryRefresh_PreservesLiveTail` / `TestMergeHistoryRefresh_NoLiveTail` — pin the merge contract the unconditional refresh depends on.
+- `internal/tui/notifications_test.go` — notify/clear and history-refresh persistence.
+- `internal/tui/routines_test.go::TestRoutinesDuplicate_*` / `TestDuplicateRoutineName_*` / `TestRoutinesDetailKey_X_TriggersDelete` / `TestRoutinesDetailKey_D_NoLongerDeletes` — pin the duplicate flow, the collision-suffix algorithm, and the `d` → `x` delete remap.
+- `internal/tui/routines_chat_test.go::TestMaybeAdvanceRoutine_ManualCompletion` / `TestMaybeAdvanceRoutine_ManualMidStepIsNoOp` — pin that manual routines complete on their final reply and stay quiet between steps.
+
+The manual smoke procedure SHALL be:
+
+1. Drop a routine at `~/.lucinate/routines/demo/STEPS.md` with `mode: manual`. `/routine demo` dispatches step 0; status row reads `MANUAL — sent: 1/N — ▶ Press Enter to send: …`.
+2. Press Enter on an empty input — step 1 dispatches.
+3. Step through to the end. After the final step's reply, a `Routine "demo" completed.` notification appears, the status row disappears, and the input returns to plain chat.
+4. Shift+Tab flips status to `AUTO`. Subsequent step finals auto-advance.
+5. Have step N's reply emit `/routine:stop` on its own line — routine ends; "Routine 'demo' stopped by assistant." notification appears above the input and survives the post-turn `refreshHistory`.
+6. Repeat with `log: ./routine.log` set — verify a run header and ISO-timestamped `user:` / `assistant:` lines.
+7. Activate a routine, run `/agents` — confirm the gate prompt; `n` keeps the routine running, `y` ends it cleanly and returns to the picker.
+
+#### Scenario: Unit tests pin the behaviour
+
+- **WHEN** the routines unit-test suite runs
+- **THEN** parsing, directives, storage, logging, the stale-run filter, the per-final resync, gen-bump semantics, the merge contract, notifications, the duplicate flow, and manual completion are all covered
+
+#### Scenario: Manual smoke exercises the end-to-end flow
+
+- **GIVEN** a `demo` routine on disk
+- **WHEN** an operator follows the smoke procedure
+- **THEN** manual stepping, completion notification, auto-advance, an assistant `/routine:stop`, logging output, and the navigation gate all behave as described

--- a/openspec/specs/sessions/spec.md
+++ b/openspec/specs/sessions/spec.md
@@ -1,0 +1,176 @@
+# Sessions Specification
+
+## Purpose
+
+A session is the unit of conversation between lucinate and an agent: it is created when a user picks an agent, restored deterministically on restart, browsed and managed from within the TUI, and fed by a queue that keeps fast typing from dropping messages. This spec covers the session lifecycle, the session browser, the compact and reset commands, and message queueing — including deterministic session keys, one-shot and launch-time overrides, and the async history and stats loads.
+
+## Requirements
+
+### Requirement: Session creation and deterministic keys
+
+The system SHALL create a session when the user selects an agent in the agent picker (see the `agents` spec). It SHALL call `client.CreateSession(agentID, key)` and pass the returned `sessionKey` to `newChatModel()`. The session key SHALL be deterministic for non-default agents (based on agent ID) so the same session is restored on restart.
+
+The same default-key rule SHALL be reused by the one-shot CLI mode: `app.Send` (`lucinate send`) calls `CreateSession` with `MainKey` for the default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the same conversation as "open the picker, pick the agent, hit enter". See the `one-shot` spec for the full lifecycle.
+
+#### Scenario: Picking an agent creates a session
+
+- **WHEN** the user selects an agent in the agent picker
+- **THEN** `client.CreateSession(agentID, key)` is called and the returned `sessionKey` is passed to `newChatModel()`
+
+#### Scenario: Deterministic restore on restart
+
+- **GIVEN** a non-default agent
+- **WHEN** its session is created
+- **THEN** the session key is derived from the agent ID
+- **AND** the same session is restored on restart
+
+#### Scenario: One-shot dispatch lands on the same conversation
+
+- **WHEN** `app.Send` (`lucinate send`) creates a session
+- **THEN** it uses `MainKey` for the default agent and the literal `"main"` for any other agent
+- **AND** the dispatch lands on the same conversation as picking the agent interactively
+
+### Requirement: Session key override from the chat launcher
+
+`lucinate chat --session <key>` SHALL override the default key at the picker's `CreateSession` site: `AppModel.initialSession` is consumed in the `viewSelect` block of `update`, beating both the literal `"main"` and `MainKey`. The override SHALL be one-shot — cleared once consumed so a follow-up agent pick on the same picker does not keep landing on the original key. See the `chat-launch` spec.
+
+#### Scenario: Explicit session key beats the defaults
+
+- **GIVEN** `lucinate chat --session <key>`
+- **WHEN** the `viewSelect` block of `update` consumes `AppModel.initialSession`
+- **THEN** the supplied key is used instead of the literal `"main"` or `MainKey`
+
+#### Scenario: Override is cleared after use
+
+- **GIVEN** a session-key override has been consumed
+- **WHEN** the user picks another agent on the same picker
+- **THEN** the override is no longer applied and the pick does not keep landing on the original key
+
+### Requirement: Async history and stats load on chat init
+
+On `chatModel.Init()`, the system SHALL run two async commands in parallel:
+
+- `loadHistory()` — fetches the last N messages from the gateway (`client.SessionHistory()`), strips `System:` lines (see the `message-rendering` spec, history cleanup), and populates the viewport.
+- `loadStats()` — fetches token usage and cost via `client.SessionUsage()` for the header bar.
+
+History depth (N) SHALL be configurable; see the `chat-ux` spec (history depth).
+
+#### Scenario: History and stats load in parallel
+
+- **WHEN** `chatModel.Init()` runs
+- **THEN** `loadHistory()` and `loadStats()` are dispatched in parallel
+
+#### Scenario: History is fetched, cleaned, and rendered
+
+- **WHEN** `loadHistory()` runs
+- **THEN** it fetches the last N messages via `client.SessionHistory()`, strips `System:` lines, and populates the viewport
+
+#### Scenario: Stats load the header bar
+
+- **WHEN** `loadStats()` runs
+- **THEN** it fetches token usage and cost via `client.SessionUsage()` for the header bar
+
+### Requirement: Session browser
+
+`/sessions` SHALL emit `showSessionsMsg{}`, which navigates to the sessions view (`sessionsModel` in `internal/tui/sessions.go`). The model SHALL call `client.SessionsList(agentID)` and parse the response into `sessionItem` values grouped into two lists:
+
+- **Conversations** — regular sessions.
+- **Scheduled** — sessions whose key contains `:cron:`, used by scheduled/automated agents.
+
+Both lists SHALL be sorted by `updatedAt` descending. Selecting a session SHALL return `sessionSelectedMsg` and a new `chatModel` SHALL be constructed with the chosen key, loading its history.
+
+#### Scenario: Opening the session browser
+
+- **WHEN** the user runs `/sessions`
+- **THEN** `showSessionsMsg{}` navigates to the sessions view (`sessionsModel`), which calls `client.SessionsList(agentID)` and parses the response into `sessionItem` values
+
+#### Scenario: Sessions grouped and sorted
+
+- **WHEN** the sessions list is built
+- **THEN** regular sessions appear under Conversations and sessions whose key contains `:cron:` appear under Scheduled
+- **AND** both lists are sorted by `updatedAt` descending
+
+#### Scenario: Selecting a session opens its chat
+
+- **WHEN** the user selects a session
+- **THEN** `sessionSelectedMsg` is returned and a new `chatModel` is constructed with the chosen key, loading its history
+
+### Requirement: Compact command
+
+`/compact` SHALL use the confirmation pattern (see the `commands` spec, confirmation pattern) before taking action. It SHALL call `backend.SessionCompact()`, which summarises older messages in the session context to reduce token usage. On OpenClaw the gateway SHALL run the pass server-side; on the OpenAI-compatible backend the pass SHALL run locally (a streaming `POST /v1/chat/completions` against the agent's configured model — see the `backend-openai` spec, compaction). While the pass is in flight the confirmation handler SHALL show a pending `Compacting session…` system row with the streaming spinner attached. On success the placeholder SHALL be replaced in place with `Session compacted.`; the smaller context SHALL be picked up on the next chat send.
+
+#### Scenario: Compact confirmed and run server-side
+
+- **GIVEN** an OpenClaw backend
+- **WHEN** the user confirms `/compact`
+- **THEN** `backend.SessionCompact()` runs the pass server-side while a pending `Compacting session…` row with the streaming spinner is shown
+
+#### Scenario: Compact run locally on the OpenAI-compatible backend
+
+- **GIVEN** the OpenAI-compatible backend
+- **WHEN** `/compact` runs
+- **THEN** the pass runs locally as a streaming `POST /v1/chat/completions` against the agent's configured model
+
+#### Scenario: Compact succeeds
+
+- **WHEN** the compaction pass completes successfully
+- **THEN** the placeholder is replaced in place with `Session compacted.`
+- **AND** the smaller context is picked up on the next chat send
+
+### Requirement: Reset command
+
+`/reset` SHALL use the confirmation pattern (see the `commands` spec, confirmation pattern) before taking action. It SHALL call `backend.SessionDelete()` to permanently remove the session, then immediately create a replacement via `backend.CreateSession()`. While the round-trip is in flight the chat view SHALL show a pending `Clearing session…` system row with the spinner attached. On success the new session key SHALL be returned as `sessionClearedMsg{newSessionKey}` and the chat model SHALL reinitialise with an empty history; on error the placeholder SHALL be replaced in place with the error.
+
+#### Scenario: Reset deletes and replaces the session
+
+- **WHEN** the user confirms `/reset`
+- **THEN** `backend.SessionDelete()` permanently removes the session and `backend.CreateSession()` immediately creates a replacement while a pending `Clearing session…` row with the spinner is shown
+
+#### Scenario: Reset succeeds
+
+- **WHEN** the reset round-trip completes successfully
+- **THEN** `sessionClearedMsg{newSessionKey}` is returned and the chat model reinitialises with an empty history
+
+#### Scenario: Reset fails
+
+- **WHEN** the reset round-trip errors
+- **THEN** the placeholder is replaced in place with the error
+
+### Requirement: Message queueing while a response is in flight
+
+While `m.sending == true` (a response is in flight), new user input SHALL be appended to `m.pendingMessages []string` rather than sent immediately. This prevents messages from being dropped when the user types quickly.
+
+After each response, `drainQueue()` (in `chat.go`) SHALL:
+
+1. If there are pending messages, dequeue the first one and send it as if the user typed it fresh (including command detection, skill prepend, etc.).
+2. Refresh history once the queue is fully drained.
+
+Local (`!`) and remote (`!!`) exec results SHALL also trigger queue draining. See the `shell-execution` spec for the exec flow.
+
+#### Scenario: Input queued during a response
+
+- **GIVEN** `m.sending == true`
+- **WHEN** the user submits new input
+- **THEN** it is appended to `m.pendingMessages` rather than sent immediately
+
+#### Scenario: Queue drained after a response
+
+- **WHEN** a response completes and `drainQueue()` runs
+- **THEN** the first pending message is dequeued and sent as if freshly typed (including command detection, skill prepend, etc.)
+- **AND** history is refreshed once the queue is fully drained
+
+#### Scenario: Exec results trigger draining
+
+- **WHEN** a local (`!`) or remote (`!!`) exec result arrives
+- **THEN** it triggers queue draining
+
+### Requirement: Pre-seeded queue from the chat launcher
+
+`lucinate chat <message>` SHALL pre-seed the same queue: `newChatModel` appends the supplied text to `pendingMessages` at construction time, and the `historyLoadedMsg` handler SHALL return `m.drainQueue()` once the scrollback has rendered — so the user turn appears after the loaded history, matching what a human typing the same message would see. See the `chat-launch` spec.
+
+#### Scenario: Launch message appears after loaded history
+
+- **GIVEN** `lucinate chat <message>`
+- **WHEN** `newChatModel` is constructed
+- **THEN** the supplied text is appended to `pendingMessages`
+- **AND** the `historyLoadedMsg` handler returns `m.drainQueue()` once the scrollback has rendered, so the user turn appears after the loaded history

--- a/openspec/specs/shell-execution/spec.md
+++ b/openspec/specs/shell-execution/spec.md
@@ -1,0 +1,104 @@
+# Shell Execution Specification
+
+## Purpose
+
+Lucinate supports running shell commands directly from the chat input using a prefix
+convention: `!<command>` runs on the local machine (the user's shell), while `!!<command>`
+runs on the gateway host (remote). Both prefixes are handled in `chat.go`'s `Update()` before
+messages are sent to the gateway. This spec covers local execution, remote two-phase-approval
+execution, and how command execution overlaps with in-flight chat messages.
+
+## Requirements
+
+### Requirement: Shell command prefix convention
+
+The system SHALL let users run shell commands from the chat input using a prefix convention,
+distinguishing local from remote execution by the prefix:
+
+| Prefix | Where it runs |
+|---|---|
+| `!<command>` | Local machine (user's shell) |
+| `!!<command>` | Gateway host (remote) |
+
+Both prefixes SHALL be handled in `chat.go`'s `Update()` before messages are sent to the
+gateway.
+
+#### Scenario: Single-bang input runs locally
+
+- **WHEN** the chat input starts with `!` but not `!!`
+- **THEN** the command runs on the local machine in the user's shell
+
+#### Scenario: Double-bang input runs remotely
+
+- **WHEN** the chat input starts with `!!`
+- **THEN** the command runs on the gateway host
+
+### Requirement: Local execution (`!`)
+
+Local execution SHALL be detected when the input starts with `!` but not `!!`.
+`localExecCommand()` in `commands.go` SHALL spawn `exec.Command("sh", "-c", command)` and
+capture combined stdout and stderr. The result SHALL be returned as
+`localExecFinishedMsg{output, exitCode, err}` and displayed as a system message. Local
+execution SHALL have no gateway involvement and SHALL require no approval.
+
+#### Scenario: Local command runs in the user's shell
+
+- **GIVEN** input that starts with `!` but not `!!`
+- **WHEN** the command is executed
+- **THEN** `localExecCommand()` spawns `exec.Command("sh", "-c", command)`, captures combined stdout and stderr, and returns `localExecFinishedMsg{output, exitCode, err}`
+- **AND** the result is displayed as a system message
+- **AND** there is no gateway involvement and no approval is required
+
+### Requirement: Remote execution (`!!`) with two-phase approval
+
+Remote execution SHALL be detected when the input starts with `!!`. The stripped command SHALL
+be passed to `execCommand()` in `commands.go`, which implements a two-phase approval flow:
+
+1. **Submit** — `client.ExecRequest(ctx, command, sessionKey)` is called. The gateway returns
+   immediately with an `ExecApprovalRequestResult` containing `{ID, Status, Decision}`.
+2. **Approve** — If `Decision` is empty (not yet resolved by gateway policy), the client
+   auto-approves via `client.ExecResolve(ctx, id, "allow-once")`. If the approval was already
+   resolved (the gateway's own exec policy accepted it), the `"unknown or expired"` error is
+   silently ignored.
+3. **Result** — Output arrives asynchronously via an `exec.finished` gateway event, processed
+   in `handleEvent()` in `events.go`. The system message "running on gateway..." is replaced
+   with the output or an error.
+
+If the gateway denies the request (`Decision == "deny"`), an error SHALL be shown immediately
+without waiting for the event.
+
+#### Scenario: Submit and auto-approve an unresolved request
+
+- **GIVEN** input that starts with `!!`
+- **WHEN** the stripped command is passed to `execCommand()` and `client.ExecRequest(ctx, command, sessionKey)` returns an `ExecApprovalRequestResult` with an empty `Decision`
+- **THEN** the client auto-approves via `client.ExecResolve(ctx, id, "allow-once")`
+
+#### Scenario: Approval already resolved by gateway policy
+
+- **GIVEN** the gateway's own exec policy has already resolved the approval
+- **WHEN** the client attempts to auto-approve
+- **THEN** the `"unknown or expired"` error is silently ignored
+
+#### Scenario: Result arrives asynchronously
+
+- **WHEN** the `exec.finished` gateway event arrives and is processed in `handleEvent()` in `events.go`
+- **THEN** the system message "running on gateway..." is replaced with the output or an error
+
+#### Scenario: Gateway denies the request
+
+- **GIVEN** the gateway returns `Decision == "deny"`
+- **WHEN** the request is handled
+- **THEN** an error is shown immediately without waiting for the `exec.finished` event
+
+### Requirement: Message queueing during execution
+
+Both local and remote execution MAY overlap with in-flight chat messages. New user input while
+`m.sending == true` SHALL be held in `m.pendingMessages` and drained after the current exchange
+completes. See the `sessions` spec (message queueing) for details.
+
+#### Scenario: Input held while a send is in flight
+
+- **GIVEN** `m.sending == true`
+- **WHEN** new user input arrives
+- **THEN** it is held in `m.pendingMessages`
+- **AND** drained after the current exchange completes

--- a/openspec/specs/skills/spec.md
+++ b/openspec/specs/skills/spec.md
@@ -1,0 +1,216 @@
+# Agent Skills Specification
+
+## Purpose
+
+Agent skills are locally-stored prompt templates that users can inject into a chat session via slash commands (e.g. `/review`). They allow users to define reusable instructions without modifying gateway configuration. A skill can be invoked on its own (`/review`) or referenced mid-message (`use /review on the diff`). This spec covers the skill file format, startup discovery, catalog injection into the session, activation and reference expansion, tab completion, UI commands, and how new skills are added.
+
+## Requirements
+
+### Requirement: Skill file format
+
+Each skill SHALL live in its own directory and MUST contain a `SKILL.md` file with YAML frontmatter. The frontmatter MUST provide both a `name` and a `description` — both are required. The body is arbitrary markdown and SHALL be sent verbatim to the agent when the skill is activated.
+
+```
+---
+name: review
+description: Perform a code review
+---
+
+Please review the following code for correctness, style, and potential bugs. Be concise.
+```
+
+#### Scenario: Well-formed skill file
+
+- **GIVEN** a directory containing a `SKILL.md` with `name` and `description` in its frontmatter and a markdown body
+- **WHEN** the skill is activated
+- **THEN** the body is sent verbatim to the agent
+
+#### Scenario: Missing required frontmatter
+
+- **GIVEN** a `SKILL.md` missing either `name` or `description`
+- **WHEN** skills are discovered
+- **THEN** the file is not a valid skill because both `name` and `description` are required
+
+### Requirement: Startup skill discovery
+
+Skills SHALL be discovered at startup by `discoverSkills()` in `internal/tui/skills.go`, which scans these directories in order:
+
+1. `<cwd>/.agents/skills/*/SKILL.md`
+2. `<cwd>/.agent/skills/*/SKILL.md`
+3. `~/.agents/skills/*/SKILL.md`
+4. `~/.agent/skills/*/SKILL.md`
+
+CWD directories SHALL be scanned first — if two skills share the same `name`, the first one found wins. Symlinked skill directories SHALL be resolved via `os.Stat`. Discovery SHALL run as a Bubble Tea command in `chatModel.Init()` and return a `skillsDiscoveredMsg` which stores the skill list in `chatModel.skills`. Skills are discovered once at startup, so a restart is required to pick up new files.
+
+#### Scenario: Scan order and duplicate name resolution
+
+- **GIVEN** two skills with the same `name`, one under a CWD directory and one under a home directory
+- **WHEN** `discoverSkills()` scans the four directories in order
+- **THEN** the CWD skill is found first and wins
+
+#### Scenario: Symlinked skill directory
+
+- **GIVEN** a skill directory reached via a symlink
+- **WHEN** discovery runs
+- **THEN** it is resolved via `os.Stat` and included
+
+#### Scenario: Discovery result stored in the model
+
+- **WHEN** discovery completes
+- **THEN** a `skillsDiscoveredMsg` is returned and the skill list is stored in `chatModel.skills`
+
+### Requirement: Skill catalog injection into the session
+
+The agent SHALL NOT receive skill information unless it is explicitly included in a message. The chat layer SHALL pass the discovered skills through `ChatSendParams.Skills`, and the OpenClaw backend's `takePendingCatalog()` (`internal/backend/openclaw/openclaw.go`) SHALL prepend a skill listing to the **first user message** of each session:
+
+```
+System: Available agent skills (activate with /skill-name):
+System:   - review: Perform a code review
+```
+
+Lines SHALL be prefixed with `System: ` using the convention described in the `message-rendering` spec. The catalog SHALL be sent only once per session — a per-session flag, mutex-guarded against concurrent sends, prevents re-emission. See the `backend-openclaw` spec for the backend-side detail.
+
+#### Scenario: Catalog prepended to the first message
+
+- **GIVEN** discovered skills passed through `ChatSendParams.Skills`
+- **WHEN** the first user message of a session is sent
+- **THEN** `takePendingCatalog()` prepends the `System: Available agent skills` listing with one `System:   - name: description` line per skill
+
+#### Scenario: Catalog sent once per session
+
+- **GIVEN** the catalog has already been emitted for a session
+- **WHEN** further messages are sent, including concurrently
+- **THEN** the per-session flag, mutex-guarded, prevents re-emission
+
+### Requirement: Skill activation and reference expansion
+
+A `/skill-name` token SHALL be recognised when it sits at the start of a message *or* mid-prose preceded by whitespace, with token characters `[A-Za-z0-9_-]`. Matching SHALL be case-insensitive.
+
+`handleSlashCommand()` (`commands.go`) SHALL return `(false, nil)` for any `/`-prefixed input whose first token names a known skill, deferring to the regular Enter-handler send path. Unknown slashes that aren't built-ins SHALL still produce an error system message there.
+
+The send path SHALL run `expandSkillReferences(text, skills)` (`skills.go`) before dispatching. When at least one matched skill is found it SHALL produce a payload of the form:
+
+```
+Please use the following skill:
+
+<local-agent-skill name="review">
+<skill body>
+</local-agent-skill>
+
+run the "review" skill above on the diff
+```
+
+`expandSkillReferences` SHALL apply these rules:
+
+- Each unique matched skill produces one `<local-agent-skill name="...">…</local-agent-skill>` block. Order follows first-occurrence in the prose.
+- Each `/skill-name` token in the prose is replaced with `the "<canonical-name>" skill above`. The canonical name comes from the skill's frontmatter, regardless of how the user typed it.
+- Multiple distinct skills produce a plural preamble (`Please use the following skills:`) and one envelope per skill.
+- A "bare" message — the entire trimmed input is a single `/skill-name` — collapses the prose to `use the "<name>" skill above immediately`.
+
+The visible chat row SHALL show the user-typed text. On history reload the rendered text reflects the post-substitution payload (the gateway has no record of the original prose) — this is a known cosmetic divergence.
+
+`stripLocalAgentSkillBlocks` (`history.go`) SHALL elide the preamble line and every `<local-agent-skill>...</local-agent-skill>` block when restoring user messages from history, alongside the `System:` line strip used for the catalog.
+
+#### Scenario: Slash command deferred to the send path
+
+- **GIVEN** input whose first `/`-prefixed token names a known skill
+- **WHEN** `handleSlashCommand()` processes it
+- **THEN** it returns `(false, nil)` and defers to the regular Enter-handler send path
+
+#### Scenario: Unknown slash command
+
+- **GIVEN** a `/`-prefixed token that is neither a built-in nor a known skill
+- **WHEN** `handleSlashCommand()` processes it
+- **THEN** an error system message is produced
+
+#### Scenario: Mid-prose reference expanded
+
+- **GIVEN** the message `run /review on the diff`
+- **WHEN** `expandSkillReferences` runs before dispatch
+- **THEN** a `<local-agent-skill name="review">` block wraps the skill body
+- **AND** the `/review` token is replaced with `the "review" skill above`
+
+#### Scenario: Multiple distinct skills
+
+- **GIVEN** prose referencing two distinct known skills
+- **WHEN** the references are expanded
+- **THEN** the plural preamble `Please use the following skills:` is used and one envelope is emitted per skill, ordered by first occurrence
+
+#### Scenario: Bare skill message
+
+- **GIVEN** input whose entire trimmed text is a single `/skill-name`
+- **WHEN** the reference is expanded
+- **THEN** the prose collapses to `use the "<name>" skill above immediately`
+
+#### Scenario: History reload strips skill envelopes
+
+- **WHEN** user messages are restored from history
+- **THEN** `stripLocalAgentSkillBlocks` elides the preamble line, every `<local-agent-skill>...</local-agent-skill>` block, and the `System:` catalog lines
+
+### Requirement: Skill name tab completion
+
+Skill names SHALL participate in the same completion menu as built-in slash commands. `matchingSlashCommands(prefix)` (`completion.go`) SHALL return every match for the current prefix — built-ins in curated order, then skills — and the menu rendered between the viewport and input lists them all. Tab SHALL extend the input to the longest common prefix; if multiple skills share a prefix, repeated Tab cycles them and Shift+Tab cycles back. Mid-message completion SHALL still work: `use /rev<TAB>` resolves the slash token under the cursor regardless of position. See the `commands` spec (Tab completion) for the cycle/LCP machinery.
+
+Completion SHALL only fire when the cursor sits at the end of the slash token (next character is whitespace or end-of-buffer); inserting mid-token would clobber the trailing characters and `findSlashTokenAt` returns ok=false.
+
+#### Scenario: Completion menu lists built-ins then skills
+
+- **GIVEN** a slash-token prefix
+- **WHEN** `matchingSlashCommands(prefix)` runs
+- **THEN** it returns built-in matches in curated order followed by skill matches
+
+#### Scenario: Cycling shared prefixes with Tab
+
+- **GIVEN** multiple skills sharing a prefix
+- **WHEN** the user presses Tab repeatedly
+- **THEN** the input extends to the longest common prefix and repeated Tab cycles the skills (Shift+Tab cycles back)
+
+#### Scenario: Mid-message completion under the cursor
+
+- **GIVEN** the input `use /rev` with the cursor at the end of the slash token
+- **WHEN** the user presses Tab
+- **THEN** the slash token under the cursor is resolved regardless of position
+
+#### Scenario: No completion mid-token
+
+- **GIVEN** the cursor sitting inside a slash token rather than at its end
+- **WHEN** completion is attempted
+- **THEN** `findSlashTokenAt` returns ok=false and completion does not fire
+
+### Requirement: Skill UI commands
+
+The system SHALL provide the following commands and reporting behaviour:
+
+| Command | Behaviour |
+|---|---|
+| `/skills` | Lists all discovered skills with their descriptions |
+| `/<name>` | Activates the named skill (alone or with prose) |
+| `/help` | Mentions how many skills are loaded |
+
+The count of loaded skills SHALL also appear in the `/stats` table.
+
+#### Scenario: Listing skills
+
+- **WHEN** the user runs `/skills`
+- **THEN** all discovered skills are listed with their descriptions
+
+#### Scenario: Loaded-skill count reported
+
+- **WHEN** the user runs `/help` or `/stats`
+- **THEN** `/help` mentions how many skills are loaded and the count also appears in the `/stats` table
+
+### Requirement: Adding a new skill
+
+To add a skill, the user SHALL create a directory under one of the scanned paths containing a `SKILL.md`, for example:
+
+```
+~/.agents/skills/my-skill/SKILL.md
+```
+
+Because skills are discovered once at startup, a restart SHALL be required to pick up new files.
+
+#### Scenario: New skill picked up after restart
+
+- **GIVEN** a new `SKILL.md` created under a scanned path such as `~/.agents/skills/my-skill/SKILL.md`
+- **WHEN** the application is restarted
+- **THEN** the new skill is discovered


### PR DESCRIPTION
Adopt OpenSpec so each subsystem has a machine-checkable behavioural contract, with the developer docs kept as the rationale behind that behaviour.

## Summary

- Convert the 19 subsystem docs into OpenSpec behavioural specs under `openspec/specs/<domain>/spec.md` (requirements + scenarios), validated with `openspec validate --specs --strict`.
- Reduce each `docs/<domain>.md` to the lessons, pitfalls, and design rationale behind that subsystem — the "why it works this odd way" a spec doesn't capture — each pointing at its sibling spec.
- Move project-wide conventions (tech stack, the keyboard-key vocabulary, the native-platform naming rule) into `openspec/config.yaml`'s `context`, the canonical home injected into every OpenSpec proposal.
- Rework `AGENTS.md` to document the OpenSpec change workflow and mark where behaviour, rationale, and conventions each live, so specs stay the source of truth for behaviour.
- Commit the generated `.claude/` OpenSpec tooling (the `/opsx:*` commands and `openspec-*` skills) so contributors share the workflow.

## Implementation details

The split follows OpenSpec's own model: a spec captures observable behaviour, while the *why* has no first-class home in a spec. Learned knowledge is preserved three ways — as a requirement when the pitfall became a rule the system must honour, as rationale prose inside the docs, or as cross-cutting conventions in `config.yaml`. The conversion is faithful, not a summary: paths, function names, tables, and war-stories are all retained, just relocated to whichever of the two files fits.

OpenSpec is brownfield-first, so from here specs grow through reviewed changes (`openspec/changes/`) rather than bulk edits.