### PR TITLE
feat: open the agent's messaging conversation by default

### DIFF
--- a/app/send.go
+++ b/app/send.go
@@ -166,7 +166,14 @@ func Send(ctx context.Context, opts SendOptions) error {
 
 	createKey := opts.Session
 	if createKey == "" {
-		createKey = defaultSessionKey(agentList, agent)
+		// Prefer the messaging conversation (e.g. a Telegram DM) the
+		// user talks to this agent on, mirroring the TUI. Fall back to
+		// the "main session" pick when there is none.
+		if msgKey := backend.PickMessagingSessionKey(ctx, b, agent.ID); msgKey != "" {
+			createKey = msgKey
+		} else {
+			createKey = defaultSessionKey(agentList, agent)
+		}
 	}
 	sessionKey, err := b.CreateSession(ctx, agent.ID, createKey)
 	if err != nil {

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -9,17 +9,44 @@ requirements don't dwell on.
 
 ## Why session keys are deterministic
 
-The session key is deterministic for non-default agents (based on agent ID) so the same session
-is restored on restart rather than spawning a fresh conversation each launch. The same
-default-key rule is reused by the one-shot CLI mode (`lucinate send`): it uses `MainKey` for the
-default agent and the literal `"main"` for any other agent, so a scripted dispatch lands on the
-same conversation as "open the picker, pick the agent, hit enter". Keeping both entry points on
-the same key rule is the whole point — otherwise a scripted send and an interactive pick would
-drift onto different conversations.
+When an agent has no messaging conversation (see the next section), the fallback session key is
+deterministic for non-default agents (based on agent ID) so the same session is restored on
+restart rather than spawning a fresh conversation each launch. That fallback rule is reused by
+the one-shot CLI mode (`lucinate send`): it uses `MainKey` for the default agent and the literal
+`"main"` for any other agent, so a scripted dispatch lands on the same conversation as "open the
+picker, pick the agent, hit enter". Keeping both entry points on the same key rule is the whole
+point — otherwise a scripted send and an interactive pick would drift onto different
+conversations.
 
 The `lucinate chat --session <key>` override is deliberately **one-shot** — cleared once
 consumed in the `viewSelect` block so a follow-up agent pick on the same picker doesn't keep
-landing on the original key.
+landing on the original key. It beats the messaging-conversation preference too.
+
+## Why opening an agent prefers its messaging conversation
+
+When you reach an agent through an external messaging channel, the real conversation lives in a
+channel-tied session the gateway minted — a key like `agent:main:telegram:direct:123456789`.
+Opening the agent onto a blank `main` bucket would hide the history and context you came to see,
+so `backend.PickMessagingSessionKey` looks up the agent's sessions and prefers that conversation
+before falling back to the `main`/`MainKey` rule above.
+
+Two things are deliberate about how it finds that session:
+
+- **It reads structured fields, never the key.** The `channel`, `kind`, and
+  `origin`/`deliveryContext` fields on each `sessions.list` row already carry the channel, the
+  direct-vs-group kind, and the peer identity. Those are the signals we match on. The five-part
+  key format is the gateway's to own — parsing it here would couple us to a shape we don't
+  control, and the structured fields carry the same information without that coupling.
+- **Most-recently-updated wins when there is more than one.** Nothing the client can see says
+  which human is "you", so if an agent has several messaging DMs we take the most recent one. It
+  is a heuristic, and we accept it: the alternative (asking the gateway which channel account is
+  connected via `channels.status`) turned out not to carry the sender identity either, so it
+  cannot pin down the conversation any better.
+
+The lookup fails safe. A `sessions.list` error, an unexpected response, or simply no messaging
+session all collapse to "" and fall back to the old default — opening an agent is never blocked
+on this extra call. Backends with no messaging sessions (OpenAI-compatible, Hermes) always fall
+back, so their behaviour is unchanged.
 
 ## Why history and stats load in parallel
 

--- a/internal/backend/session_pick.go
+++ b/internal/backend/session_pick.go
@@ -1,0 +1,124 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// PickMessagingSessionKey returns the key of the external-messaging
+// conversation — e.g. a Telegram DM — that the user actually talks to
+// the given agent on, or "" when the agent has no such session.
+//
+// When an agent is reached through a messaging channel, the useful
+// session to open is that conversation, not a blank "main" bucket. The
+// gateway mints those session keys itself (they look like
+// agent:main:telegram:direct:123456789) and they are opaque to us, so
+// we do not parse them. Instead we read the structured channel/kind/
+// origin fields the gateway returns from sessions.list — the same
+// fields its own conversation views key off. When several messaging
+// conversations exist for one agent we cannot tell which human is "the
+// user", so the most-recently-updated one wins.
+//
+// Any error — a transport failure, a backend that has no messaging
+// sessions, an unexpected shape — yields "" so the caller falls back to
+// its existing default. Opening an agent must never be blocked by this
+// lookup.
+func PickMessagingSessionKey(ctx context.Context, b Backend, agentID string) string {
+	raw, err := b.SessionsList(ctx, agentID)
+	if err != nil {
+		slog.Debug("messaging session pick: sessions.list failed", "agent", agentID, "err", err)
+		return ""
+	}
+	return pickMessagingKeyFromRaw(raw)
+}
+
+// pickMessagingKeyFromRaw is the pure selection over a sessions.list
+// response, split out so it can be tested without a live backend.
+func pickMessagingKeyFromRaw(raw []byte) string {
+	var resp messagingSessionsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		slog.Debug("messaging session pick: parse failed", "err", err)
+		return ""
+	}
+	best := ""
+	var bestUpdated int64 = -1
+	for _, row := range resp.Sessions {
+		if !row.isMessagingConversation() {
+			continue
+		}
+		if row.UpdatedAt > bestUpdated {
+			bestUpdated = row.UpdatedAt
+			best = row.Key
+		}
+	}
+	return best
+}
+
+// messagingSessionsResponse is the sessions.list envelope. The gateway
+// returns many more fields per session than we read here.
+type messagingSessionsResponse struct {
+	Sessions []messagingSessionRow `json:"sessions"`
+}
+
+// messagingSessionRow mirrors the subset of a gateway session row that
+// identifies a messaging conversation without decoding the opaque
+// session key. The channel, peer, and direct/group signals each appear
+// in a few places depending on how the gateway recorded the session;
+// the accessor methods below apply the same precedence the gateway uses
+// (deliveryContext, then the last-* fields, then origin).
+type messagingSessionRow struct {
+	Key         string `json:"key"`
+	Kind        string `json:"kind"`
+	Channel     string `json:"channel"`
+	LastChannel string `json:"lastChannel"`
+	LastTo      string `json:"lastTo"`
+	UpdatedAt   int64  `json:"updatedAt"`
+	Origin      struct {
+		Provider           string `json:"provider"`
+		ChatType           string `json:"chatType"`
+		From               string `json:"from"`
+		NativeDirectUserID string `json:"nativeDirectUserId"`
+	} `json:"origin"`
+	DeliveryContext struct {
+		Channel string `json:"channel"`
+		To      string `json:"to"`
+	} `json:"deliveryContext"`
+}
+
+// channelName is the messaging channel the session belongs to (e.g.
+// "telegram"), or "" for a local/main session that never arrived over a
+// channel.
+func (r messagingSessionRow) channelName() string {
+	return firstNonEmpty(r.DeliveryContext.Channel, r.LastChannel, r.Channel, r.Origin.Provider)
+}
+
+// peer is the channel-local identity on the other end of the
+// conversation (e.g. the Telegram user id). A local/main session has no
+// peer.
+func (r messagingSessionRow) peer() string {
+	return firstNonEmpty(r.DeliveryContext.To, r.LastTo, r.Origin.From, r.Origin.NativeDirectUserID)
+}
+
+// isDirect reports whether the session is a one-to-one conversation
+// rather than a group or the agent's global bucket.
+func (r messagingSessionRow) isDirect() bool {
+	return r.Kind == "direct" || r.Origin.ChatType == "direct"
+}
+
+// isMessagingConversation reports whether this row is a direct
+// conversation the user holds with the agent over a messaging channel.
+// It requires all three signals so a plain "main" session (no channel,
+// no peer) and group chats are excluded.
+func (r messagingSessionRow) isMessagingConversation() bool {
+	return r.isDirect() && r.channelName() != "" && r.peer() != ""
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/backend/session_pick_test.go
+++ b/internal/backend/session_pick_test.go
@@ -1,0 +1,128 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestPickMessagingKeyFromRaw(t *testing.T) {
+	const telegramDM = `{
+		"key": "agent:main:telegram:direct:123456789",
+		"kind": "direct",
+		"channel": "telegram",
+		"lastChannel": "telegram",
+		"lastTo": "123456789",
+		"updatedAt": 1000,
+		"origin": {"provider":"telegram","chatType":"direct","from":"123456789","nativeDirectUserId":"123456789"},
+		"deliveryContext": {"channel":"telegram","to":"123456789"}
+	}`
+	// A plain main session: no channel, no peer. Newer than the DM so
+	// "most recent wins" alone would pick it — it must still be skipped.
+	const plainMain = `{"key":"agent:main:main","kind":"global","updatedAt":9000}`
+	const cron = `{"key":"agent:main:cron:daily","kind":"unknown","updatedAt":500}`
+	// A group chat over telegram: has a channel and a peer but is not a
+	// one-to-one conversation. Newest of all — must still be excluded.
+	const telegramGroup = `{
+		"key":"agent:main:telegram:group:-100123",
+		"kind":"group","channel":"telegram","lastTo":"-100123","updatedAt":99999,
+		"origin":{"provider":"telegram","chatType":"group"}
+	}`
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "telegram DM chosen over a newer plain main session",
+			raw:  `{"sessions":[` + plainMain + `,` + telegramDM + `]}`,
+			want: "agent:main:telegram:direct:123456789",
+		},
+		{
+			name: "most recently updated messaging conversation wins",
+			raw: `{"sessions":[
+				{"key":"old","kind":"direct","channel":"telegram","lastTo":"1","updatedAt":100},
+				{"key":"new","kind":"direct","channel":"telegram","lastTo":"2","updatedAt":200}
+			]}`,
+			want: "new",
+		},
+		{
+			name: "group and cron and main only yields no messaging session",
+			raw:  `{"sessions":[` + plainMain + `,` + cron + `,` + telegramGroup + `]}`,
+			want: "",
+		},
+		{
+			name: "direct signalled only via origin.chatType and origin fields",
+			raw: `{"sessions":[{
+				"key":"origin-only","updatedAt":10,
+				"origin":{"provider":"telegram","chatType":"direct","from":"42"}
+			}]}`,
+			want: "origin-only",
+		},
+		{
+			name: "direct signalled only via deliveryContext",
+			raw: `{"sessions":[{
+				"key":"delivery-only","kind":"direct","updatedAt":10,
+				"deliveryContext":{"channel":"whatsapp","to":"+15551234"}
+			}]}`,
+			want: "delivery-only",
+		},
+		{
+			name: "channel present but no peer is not a conversation",
+			raw:  `{"sessions":[{"key":"no-peer","kind":"direct","channel":"telegram","updatedAt":10}]}`,
+			want: "",
+		},
+		{
+			name: "empty session list",
+			raw:  `{"sessions":[]}`,
+			want: "",
+		},
+		{
+			name: "malformed json",
+			raw:  `not json`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickMessagingKeyFromRaw([]byte(tt.raw))
+			if got != tt.want {
+				t.Errorf("pickMessagingKeyFromRaw() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// stubBackend embeds the Backend interface (nil) so only the one method
+// we exercise needs a body; any other call would panic, which is what we
+// want if the helper ever reaches for more than sessions.list.
+type stubBackend struct {
+	Backend
+	raw []byte
+	err error
+}
+
+func (s stubBackend) SessionsList(context.Context, string) (json.RawMessage, error) {
+	return s.raw, s.err
+}
+
+func TestPickMessagingSessionKey_SessionsListError(t *testing.T) {
+	got := PickMessagingSessionKey(context.Background(), stubBackend{err: errors.New("boom")}, "main")
+	if got != "" {
+		t.Errorf("on sessions.list error want %q, got %q", "", got)
+	}
+}
+
+func TestPickMessagingSessionKey_HappyPath(t *testing.T) {
+	raw := []byte(`{"sessions":[{
+		"key":"agent:main:telegram:direct:123456789","kind":"direct",
+		"deliveryContext":{"channel":"telegram","to":"123456789"},"updatedAt":5
+	}]}`)
+	got := PickMessagingSessionKey(context.Background(), stubBackend{raw: raw}, "main")
+	if got != "agent:main:telegram:direct:123456789" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -996,24 +997,45 @@ func (m AppModel) update(msg tea.Msg) (AppModel, tea.Cmd) {
 				// the resolved session key for event filtering.
 				b := m.backend
 				agentID := item.agent.ID
-				createKey := "main"
+				// Fallback when the agent has no messaging
+				// conversation: the connection's default-agent
+				// MainKey, otherwise the literal "main".
+				fallbackKey := "main"
 				if item.sessionKey == m.selectModel.mainKey {
-					createKey = item.sessionKey
+					fallbackKey = item.sessionKey
 				}
 				// Honour an explicit `lucinate chat --session <key>`
-				// override; this beats both the literal "main" and
-				// the connection's default-agent MainKey. One-shot:
-				// cleared so a later selection on the same picker
-				// doesn't keep landing on the original key.
+				// override; this beats both the messaging session and
+				// the fallback. One-shot: cleared so a later selection
+				// on the same picker doesn't keep landing on the
+				// original key.
+				overrideKey := ""
 				if m.initialSession != "" {
-					createKey = m.initialSession
+					overrideKey = m.initialSession
 					m.initialSession = ""
 				}
 				timeout := m.requestTimeoutFromPrefs()
 				return m, func() tea.Msg {
 					ctx, cancel := context.WithTimeout(context.Background(), timeout)
 					defer cancel()
+					createKey := overrideKey
+					source := "override"
+					if createKey == "" {
+						// Prefer the messaging conversation (e.g. a
+						// Telegram DM) the user talks to this agent
+						// on; fall back when there is none.
+						if msgKey := backend.PickMessagingSessionKey(ctx, b, agentID); msgKey != "" {
+							createKey = msgKey
+							source = "messaging"
+						} else {
+							createKey = fallbackKey
+							source = "fallback"
+						}
+					}
 					key, err := b.CreateSession(ctx, agentID, createKey)
+					slog.Debug("open agent: chose session",
+						"agent", agentID, "source", source,
+						"requestedKey", createKey, "resolvedKey", key, "err", err)
 					return sessionCreatedMsg{
 						sessionKey: key,
 						agentID:    agentID,

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -516,7 +516,14 @@ func (m *chatModel) handleAgentCommand(text string) (bool, tea.Cmd) {
 		if match.Model != nil {
 			modelID = match.Model.Primary
 		}
-		key, err := b.CreateSession(ctx, match.ID, "main")
+		// Land on the messaging conversation (e.g. a Telegram DM) the
+		// user talks to this agent on; fall back to "main" when there
+		// is none.
+		createKey := "main"
+		if msgKey := backend.PickMessagingSessionKey(ctx, b, match.ID); msgKey != "" {
+			createKey = msgKey
+		}
+		key, err := b.CreateSession(ctx, match.ID, createKey)
 		return sessionCreatedMsg{
 			sessionKey: key,
 			agentID:    match.ID,

--- a/internal/tui/messaging_session_test.go
+++ b/internal/tui/messaging_session_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+	"github.com/a3tai/openclaw-go/protocol"
+
+	"github.com/lucinate-ai/lucinate/internal/config"
+)
+
+// TestAppModel_OpenAgent_PrefersMessagingSession: opening an agent that
+// has a Telegram DM must resume that conversation, not a blank "main"
+// session. This drives the picker selection path end to end so it also
+// covers the sessions.list lookup wired into the create command.
+func TestAppModel_OpenAgent_PrefersMessagingSession(t *testing.T) {
+	fake := newFakeBackend()
+	fake.sessionsListHook = func(ctx context.Context, agentID string) (json.RawMessage, error) {
+		return json.RawMessage(`{"sessions":[
+			{"key":"agent:main:main","kind":"global","updatedAt":9000},
+			{"key":"agent:main:telegram:direct:123456789","kind":"direct",
+			 "deliveryContext":{"channel":"telegram","to":"123456789"},"updatedAt":1000}
+		]}`), nil
+	}
+	// Default CreateSession echoes the key back, so the resolved session
+	// key in the message is exactly what the open path chose.
+
+	m := AppModel{
+		state:   viewSelect,
+		backend: fake,
+		prefs:   config.Preferences{ConnectTimeoutSeconds: 1},
+	}
+	m.selectModel = newSelectModel(fake, true, false, nil, false, "")
+	m.selectModel.list.SetItems([]list.Item{
+		agentItem{agent: protocol.AgentSummary{ID: "main", Name: "main"}, sessionKey: "main"},
+	})
+	m.selectModel.loading = false
+	m.selectModel.selected = true
+
+	_, cmd := m.update(agentsLoadedMsg{result: &protocol.AgentsListResult{
+		Agents: []protocol.AgentSummary{{ID: "main", Name: "main"}},
+	}})
+	if cmd == nil {
+		t.Fatal("expected a session-create command after agent selection")
+	}
+
+	msg, ok := cmd().(sessionCreatedMsg)
+	if !ok {
+		t.Fatalf("expected sessionCreatedMsg, got %T", cmd())
+	}
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+	if want := "agent:main:telegram:direct:123456789"; msg.sessionKey != want {
+		t.Errorf("opened session %q, want the Telegram DM %q", msg.sessionKey, want)
+	}
+}

--- a/openspec/changes/default-to-messaging-session/.openspec.yaml
+++ b/openspec/changes/default-to-messaging-session/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/default-to-messaging-session/design.md
+++ b/openspec/changes/default-to-messaging-session/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Opening an agent creates or resumes a session at three sites — the TUI agent picker (`viewSelect` in `internal/tui/app.go`), the in-chat `/agent` switch (`internal/tui/commands.go`), and one-shot `lucinate send` (`app/send.go`). All three default the session key to `MainKey` for the connection's default agent, or the literal `"main"` otherwise.
+
+When the user actually converses with the agent over an external messaging channel, the conversation lives in a channel-tied session the gateway minted, e.g. `agent:main:telegram:direct:123456789`. That key is opaque to lucinate. The goal is to open that conversation by default rather than a blank `main` bucket. The constraint: do it without new gateway/SDK surface and without brittle string-parsing of a gateway-owned key format.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Default to the messaging conversation the user talks to an agent on, at all three open-agent sites.
+- Reuse existing RPCs (`sessions.list`, `CreateSession`) — no protocol changes.
+- Recognise the messaging session from structured data, not by decoding the opaque key.
+- Fail safe: any error or "no messaging session" falls back to today's behaviour; never block opening an agent.
+
+**Non-Goals:**
+- Knowing definitively *which* human is "the user" — the client has no such signal, so a heuristic (most-recent) is accepted.
+- Filtering by live channel connectivity (`channels.status`) — see Decisions.
+- Changing session keys, the session browser, or how history loads.
+
+## Decisions
+
+**Anchor the lookup on `sessions.list` structured fields, not `channels.status` or `sessions.resolve`.** Each `sessions.list` row already carries `channel`, `kind` (`direct`/`group`/`global`), and an `origin`/`deliveryContext` block with the provider (`telegram`), the peer id (`from` / `nativeDirectUserId` / `to`), and the account. A row qualifies as a messaging conversation when it is `direct` and has both a channel and a peer; among qualifiers the most-recently-updated `key` is used verbatim. This mirrors the gateway's own conversation-extraction precedence.
+
+- *Alternative — `channels.status`:* rejected. It is a global snapshot with no agent linkage and no sender identity, so it cannot yield the `123456789` needed to identify the conversation. It can only report that *a* channel account is connected. (It was the initially-preferred option until investigation showed it lacks the key data.)
+- *Alternative — `sessions.resolve`:* rejected. It only normalises a key/sessionId/label you already hold into a canonical key; it cannot take channel + sender and return a key.
+- *Alternative — parse the opaque key (`:telegram:`, `:direct:`):* rejected as brittle; the format is gateway-owned and undocumented on the client side. The structured fields carry the same information without that coupling.
+
+**Perform the lookup inside the existing async create command.** The picker's create step is already a `tea.Cmd` closure, so the extra `sessions.list` round-trip runs there before `CreateSession`, under the same request timeout. `CreateSession` already "creates or resumes", so passing the existing messaging key simply resumes that conversation — no new open-existing path needed.
+
+**One shared helper.** `backend.PickMessagingSessionKey(ctx, b, agentID)` lives in `internal/backend` (imported by both `internal/tui` and `app`, no import cycle) with the pure selection split into `pickMessagingKeyFromRaw` for table-driven tests.
+
+## Risks / Trade-offs
+
+- [Wrong DM chosen when an agent has several messaging conversations] → most-recently-updated wins; acceptable because the client cannot identify the operator's own peer id, and the user accepted this trade-off.
+- [Opens a session on a channel that is no longer connected] → accepted; the conversation and its history still exist and are useful. Live-connectivity filtering via `channels.status` was explicitly deferred.
+- [Extra `sessions.list` round-trip on every open] → one fast call the session browser already makes; runs under the existing timeout and falls back to the old default on error, so latency and failure are bounded.
+- [Gateway changes the `origin`/`deliveryContext` field shape] → the helper degrades to "no messaging session" (fields absent → no qualifier) and falls back, rather than misbehaving.
+
+## Open Questions
+
+None outstanding. The messaging-vs-main disambiguation (most-recent) and the decision to skip `channels.status` connectivity filtering were both settled during proposal review.

--- a/openspec/changes/default-to-messaging-session/proposal.md
+++ b/openspec/changes/default-to-messaging-session/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When an agent is reached through an external messaging channel (e.g. Telegram), the real conversation lives in a channel-tied session whose key the gateway mints itself — for example `agent:main:telegram:direct:123456789`. Opening that agent in lucinate today lands the user on a blank `main`/`MainKey` session instead of the conversation they actually hold with the agent, so the history and context they came to see are not there.
+
+## What Changes
+
+- When opening an agent, lucinate SHALL default to the external-messaging conversation the user talks to that agent on, instead of the literal `"main"`/`MainKey`. This applies at all three "open this agent" sites: the TUI agent picker, the in-chat `/agent <name>` switch, and the one-shot `lucinate send`.
+- The messaging session SHALL be found by reading the structured `channel` / `kind` / `origin` / `deliveryContext` fields the gateway already returns from `sessions.list` — never by parsing the opaque session key. A session qualifies when it is a one-to-one (`direct`) conversation that carries both a messaging channel and a peer identity.
+- When several messaging conversations exist for one agent, the most-recently-updated one SHALL win (nothing tells the client which human is "the user").
+- When the agent has no messaging conversation, behaviour SHALL fall back to today's rule: `MainKey` for the connection's default agent, the literal `"main"` otherwise. A `sessions.list` error SHALL be treated as "no messaging session" so opening an agent is never blocked.
+- An explicit `--session <key>` override SHALL continue to beat every default, now including the messaging-session default.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none: this refines existing session-selection behaviour -->
+
+### Modified Capabilities
+
+- `sessions`: the session-creation default-key rule gains a messaging-conversation preference ahead of the `main`/`MainKey` fallback; the chat-launcher `--session` override now also beats that preference. (The `chat-launch` spec's override plumbing is unchanged — the override still wins, and that spec cross-references `sessions` for the rule.)
+- `one-shot`: `lucinate send` defaults to the same messaging conversation before falling back to `defaultSessionKey`.
+
+## Impact
+
+- New helper `backend.PickMessagingSessionKey` in `internal/backend/session_pick.go` (reads `sessions.list` structured fields; pure selection split out for testing).
+- Wired into `internal/tui/app.go` (`viewSelect` open path, now performing the `sessions.list` lookup inside the async create command), `internal/tui/commands.go` (`/agent` switch), and `app/send.go` (one-shot default).
+- No SDK, protocol, or gateway changes: uses the existing `SessionsList` / `CreateSession` surface. Backends without messaging sessions (OpenAI-compatible, Hermes) return no qualifying session and keep their current behaviour.

--- a/openspec/changes/default-to-messaging-session/specs/one-shot/spec.md
+++ b/openspec/changes/default-to-messaging-session/specs/one-shot/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Default session selection
+
+The default-key rule SHALL be shared with the TUI agent picker so `lucinate send` and "select agent → open" land on the same gateway-side session. When `--session` is unset, `app.Send` SHALL first prefer the external-messaging conversation the user holds with the agent (via `backend.PickMessagingSessionKey`; see the `sessions` spec, `Messaging-conversation default session`), and only when there is none SHALL it fall back to the shared default:
+
+| Agent | `--session` unset, no messaging conversation → key passed to `CreateSession` |
+|-------|---------------------------------------------------|
+| Default agent (`agent.ID == list.DefaultID`) | `list.MainKey` |
+| Any other agent                              | `"main"` (literal)                                |
+
+If the same key already exists on the gateway, `CreateSession` SHALL resume it; if not, the gateway SHALL provision one. From the script's point of view, `lucinate send --connection X --agent Y "hello"` repeats into the same conversation forever unless `--session` is supplied.
+
+The literal-`"main"` fallback for non-default agents matches what the TUI passes when the user opens a non-default agent that has no messaging conversation. Backends that don't keep server-side session state (OpenAI, Hermes) SHALL ignore the key shape and route by `agentID` regardless, and expose no messaging conversation so the fallback always applies.
+
+#### Scenario: Messaging conversation preferred when present
+- **GIVEN** the chosen agent has an external-messaging direct conversation and `--session` is unset
+- **WHEN** the session key is defaulted
+- **THEN** the messaging conversation's key is passed to `CreateSession`
+
+#### Scenario: Default agent uses the main-session key
+- **GIVEN** the chosen agent is the default agent (`agent.ID == list.DefaultID`), has no messaging conversation, and `--session` is unset
+- **WHEN** the session key is defaulted
+- **THEN** `list.MainKey` is passed to `CreateSession`
+
+#### Scenario: Non-default agent falls back to literal "main"
+- **GIVEN** the chosen agent is not the default agent, has no messaging conversation, and `--session` is unset
+- **WHEN** the session key is defaulted
+- **THEN** the literal string `"main"` is passed to `CreateSession`, matching what the TUI passes when the user opens a non-default agent with no messaging conversation
+
+#### Scenario: Repeated sends land in the same conversation
+- **GIVEN** `--session` is not supplied
+- **WHEN** `lucinate send --connection X --agent Y "hello"` is run repeatedly
+- **THEN** `CreateSession` resumes the existing key if present or the gateway provisions one, so the turns repeat into the same conversation

--- a/openspec/changes/default-to-messaging-session/specs/sessions/spec.md
+++ b/openspec/changes/default-to-messaging-session/specs/sessions/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Messaging-conversation default session
+
+When opening an agent, the system SHALL prefer the external-messaging conversation the user holds with that agent (e.g. a Telegram DM) over the literal `"main"`/`MainKey` default. The conversation SHALL be identified by `backend.PickMessagingSessionKey`, which reads the structured `channel`, `kind`, `origin`, and `deliveryContext` fields returned by `sessions.list` — it SHALL NOT parse the opaque session key. A session qualifies when it is a one-to-one (`direct`) conversation that carries both a messaging channel and a peer identity. When several qualify, the most-recently-updated one SHALL be chosen. This rule SHALL apply at every open-agent site: the agent picker, the in-chat `/agent` switch, and one-shot `lucinate send`.
+
+The lookup SHALL fail safe: on any error, or when no session qualifies, the system SHALL fall back to the existing `MainKey`/`"main"` default and SHALL NOT block opening the agent.
+
+#### Scenario: Telegram DM preferred over a blank main session
+- **GIVEN** an agent whose activity is a Telegram direct conversation
+- **WHEN** the user opens the agent
+- **THEN** `CreateSession` is called with the messaging conversation's key and that conversation is resumed
+
+#### Scenario: Structured fields, not the opaque key
+- **WHEN** a candidate session is evaluated for the messaging default
+- **THEN** its channel, direct/group kind, and peer identity are read from the `channel`/`kind`/`origin`/`deliveryContext` fields
+- **AND** the opaque session key is not parsed
+
+#### Scenario: Most recent messaging conversation wins
+- **GIVEN** an agent with more than one messaging direct conversation
+- **WHEN** the default session is chosen
+- **THEN** the most-recently-updated conversation is used
+
+#### Scenario: Fall back when there is no messaging conversation
+- **GIVEN** an agent with no qualifying messaging conversation, or a failing `sessions.list`
+- **WHEN** the default session is chosen
+- **THEN** the system falls back to `MainKey` for the default agent or the literal `"main"` otherwise
+- **AND** opening the agent is not blocked
+
+## MODIFIED Requirements
+
+### Requirement: Session creation and deterministic keys
+
+The system SHALL create a session when the user selects an agent in the agent picker (see the `agents` spec). It SHALL call `client.CreateSession(agentID, key)` and pass the returned `sessionKey` to `newChatModel()`.
+
+When choosing the key, the system SHALL first prefer the agent's external-messaging conversation (see the `Messaging-conversation default session` requirement). When the agent has no such conversation, the key SHALL fall back to the deterministic default: `MainKey` for the connection's default agent, and the literal `"main"` (deterministic for non-default agents, based on agent ID) otherwise — so the same fallback session is restored on restart.
+
+The same default-key rule (messaging preference, then the `MainKey`/`"main"` fallback) SHALL be reused by the one-shot CLI mode: `app.Send` (`lucinate send`), so a scripted dispatch lands on the same conversation as "open the picker, pick the agent, hit enter". See the `one-shot` spec for the full lifecycle.
+
+#### Scenario: Picking an agent creates a session
+- **WHEN** the user selects an agent in the agent picker
+- **THEN** `client.CreateSession(agentID, key)` is called and the returned `sessionKey` is passed to `newChatModel()`
+
+#### Scenario: Opening an agent prefers its messaging conversation
+- **GIVEN** an agent with an external-messaging direct conversation
+- **WHEN** the user opens the agent from the picker or the in-chat `/agent` switch
+- **THEN** the session key is the messaging conversation's key, so the conversation and its history are resumed
+
+#### Scenario: Deterministic restore when there is no messaging conversation
+- **GIVEN** an agent with no external-messaging conversation
+- **WHEN** its session is created
+- **THEN** the key falls back to `MainKey` for the default agent, or the literal `"main"` (derived from the agent ID) otherwise
+- **AND** the same session is restored on restart
+
+#### Scenario: One-shot dispatch lands on the same conversation
+- **WHEN** `app.Send` (`lucinate send`) creates a session
+- **THEN** it prefers the same messaging conversation, otherwise uses `MainKey` for the default agent and the literal `"main"` for any other agent
+- **AND** the dispatch lands on the same conversation as picking the agent interactively
+
+### Requirement: Session key override from the chat launcher
+
+`lucinate chat --session <key>` SHALL override the default key at the picker's `CreateSession` site: `AppModel.initialSession` is consumed in the `viewSelect` block of `update`, beating the messaging-conversation default as well as the literal `"main"` and `MainKey`. When the override is present the messaging-conversation lookup SHALL be skipped entirely. The override SHALL be one-shot — cleared once consumed so a follow-up agent pick on the same picker does not keep landing on the original key. See the `chat-launch` spec.
+
+#### Scenario: Explicit session key beats the defaults
+- **GIVEN** `lucinate chat --session <key>`
+- **WHEN** the `viewSelect` block of `update` consumes `AppModel.initialSession`
+- **THEN** the supplied key is used instead of the messaging-conversation default, the literal `"main"`, or `MainKey`
+
+#### Scenario: Override is cleared after use
+- **GIVEN** a session-key override has been consumed
+- **WHEN** the user picks another agent on the same picker
+- **THEN** the override is not reused and the normal default (messaging conversation, else `"main"`/`MainKey`) applies

--- a/openspec/changes/default-to-messaging-session/tasks.md
+++ b/openspec/changes/default-to-messaging-session/tasks.md
@@ -1,0 +1,25 @@
+## 1. Messaging-session helper
+
+- [x] 1.1 Add `backend.PickMessagingSessionKey` in `internal/backend/session_pick.go`, reading `sessions.list` structured fields (`channel`/`kind`/`origin`/`deliveryContext`) rather than the opaque key
+- [x] 1.2 Qualify a row as a messaging conversation (`direct` with both a channel and a peer); pick the most-recently-updated
+- [x] 1.3 Fail safe: return `""` on any error or no match so callers fall back
+- [x] 1.4 Split the pure selection into `pickMessagingKeyFromRaw` for unit testing
+
+## 2. Wire the open-agent sites
+
+- [x] 2.1 TUI picker (`internal/tui/app.go`, `viewSelect`): run the lookup in the async create command; prefer the messaging key, else `MainKey`/`"main"`, keeping the `--session` override winning
+- [x] 2.2 In-chat `/agent` switch (`internal/tui/commands.go`): prefer the messaging key, else `"main"`
+- [x] 2.3 One-shot `lucinate send` (`app/send.go`): prefer the messaging key, else `defaultSessionKey`
+
+## 3. Tests
+
+- [x] 3.1 Table-driven unit tests for `pickMessagingKeyFromRaw` (selection, field precedence, group/cron/main exclusion, malformed input)
+- [x] 3.2 Cover `PickMessagingSessionKey` error and happy paths
+- [x] 3.3 TUI open-path test that resumes the messaging conversation over a newer `main`
+- [x] 3.4 Run `go build`, `go vet`, `go test` — all green
+
+## 4. Spec & docs
+
+- [x] 4.1 Add the `sessions` and `one-shot` delta specs for the messaging-conversation default
+- [x] 4.2 Update `docs/sessions.md` rationale (structured-field matching, most-recent heuristic, fail-safe fallback)
+- [x] 4.3 `openspec validate default-to-messaging-session --strict` passes


### PR DESCRIPTION
Open an agent onto the external-messaging conversation the user actually talks to it on (e.g. a Telegram DM) instead of a blank `main` session.

## Summary
- When opening an agent, prefer the messaging conversation the user holds with that agent over the literal `"main"`/`MainKey` default. Applies at all three open-agent sites: the TUI agent picker, the in-chat `/agent <name>` switch, and one-shot `lucinate send`.
- The conversation is found via a new `backend.PickMessagingSessionKey` helper that reads the structured `channel`/`kind`/`origin`/`deliveryContext` fields the gateway already returns from `sessions.list` — it never parses the opaque session key.
- When several messaging conversations exist for one agent, the most-recently-updated one wins. When there is none (or `sessions.list` errors), behaviour falls back to today's `MainKey`/`"main"` rule; opening an agent is never blocked on the extra lookup.
- An explicit `--session` override still beats every default.
- Adds an OpenSpec change (`default-to-messaging-session`) capturing the behaviour delta to the `sessions` and `one-shot` specs, plus the rationale in `docs/sessions.md`.

## Implementation details
The messaging session is identified from structured row fields rather than by decoding the gateway-minted key (`agent:main:telegram:direct:...`), so lucinate stays decoupled from a key format it does not own. `channels.status` and `sessions.resolve` were both considered as the anchor and rejected — neither carries the sender identity needed to pin down the conversation — so `sessions.list` is the source of truth and "most recent" is the accepted disambiguator when more than one DM exists. See `design.md` in the change for the full reasoning.

Backends without messaging sessions (OpenAI-compatible, Hermes) surface no qualifying session and keep their current behaviour. No SDK, protocol, or gateway changes.
