### PR TITLE
ci: add integration-gate aggregate check for branch protection

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,3 +104,24 @@ jobs:
       - name: Teardown
         if: always()
         run: ./test/integration/teardown-hermes.sh
+
+  # Fixed-name aggregate gate so branch protection can require one stable check
+  # instead of the version-specific matrix job names, which change whenever the
+  # gateway/hermes pins are bumped. Requiring those directly would leave a stale
+  # context pending forever after a bump and block every PR.
+  integration-gate:
+    name: integration-gate
+    needs: [openclaw-smoke, hermes-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify backend smoke jobs passed
+        run: |
+          if [ "${{ needs.openclaw-smoke.result }}" != "success" ] \
+            || [ "${{ needs.hermes-smoke.result }}" != "success" ]; then
+            echo "One or more backend smoke jobs did not succeed:"
+            echo "  openclaw-smoke: ${{ needs.openclaw-smoke.result }}"
+            echo "  hermes-smoke:   ${{ needs.hermes-smoke.result }}"
+            exit 1
+          fi
+          echo "All backend smoke jobs succeeded."


### PR DESCRIPTION
## Summary

Adds a fixed-name `integration-gate` job to the backend integration workflow so branch protection can require a single stable check instead of the version-specific matrix job names (`openclaw <ver>`, `hermes <ver>`), which change every time the gateway/Hermes pins are bumped.

## Key changes

- New `integration-gate` job that `needs` both `openclaw-smoke` and `hermes-smoke`, runs with `if: always()`, and fails unless both matrix jobs succeed.

## Why

Requiring the matrix job names directly would leave a stale required context pending forever after a version bump, permanently blocking every PR. A stable aggregate gate avoids that while still gating merges on the full backend matrix. Once this lands on `main`, the `protect default` ruleset will require `build` + `integration-gate`.